### PR TITLE
Integrate provider with core

### DIFF
--- a/examples/typescript-basic/frontity.settings.ts
+++ b/examples/typescript-basic/frontity.settings.ts
@@ -11,7 +11,7 @@ const settings: Settings<ExtensionExample1 | ExtensionExample2> = [
     packages: [
       {
         name: "@frontity/extension-example-1",
-        exclude: ["extension1"],
+        exclude: [],
         settings: {
           extension1: {
             setting1: "1"

--- a/packages/connect/src/index.d.ts
+++ b/packages/connect/src/index.d.ts
@@ -1,9 +1,11 @@
 declare module "@frontity/connect" {
   import { ComponentType } from "react";
 
-  function observable<Observable extends object>(obj?: Observable): Observable;
-  function isObservable(obj: object): boolean;
-  function raw<Observable extends object>(obj: Observable): Observable;
+  export function observable<Observable extends object>(
+    obj?: Observable
+  ): Observable;
+  export function isObservable(obj: object): boolean;
+  export function raw<Observable extends object>(obj: Observable): Observable;
 
   interface Scheduler {
     add: Function;
@@ -16,11 +18,11 @@ declare module "@frontity/connect" {
     lazy?: boolean;
   }
 
-  function observe<Reaction extends Function>(
+  export function observe<Reaction extends Function>(
     func: Reaction,
     options?: ObserveOptions
   ): Reaction;
-  function unobserve(func: Function): void;
+  export function unobserve(func: Function): void;
 
   // Resolves the derived state for things like Action and Derived.
   type ResolveState<State> = {
@@ -29,7 +31,7 @@ declare module "@frontity/connect" {
       : ResolveState<State[P]>
   };
 
-  function createStore<S extends object, A extends object>({
+  export function createStore<S extends object, A extends object>({
     state,
     actions
   }: {
@@ -37,9 +39,11 @@ declare module "@frontity/connect" {
     actions: A;
   }): { state: S; actions: A; getSnapshot: () => S };
 
+  export const Provider: React.ProviderExoticComponent<
+    React.ProviderProps<any>
+  >;
+
   function connect<Comp extends ComponentType<any>>(comp: Comp): Comp;
 
-  const Provider: React.ProviderExoticComponent<React.ProviderProps<any>>;
-
-  export = connect;
+  export default connect;
 }

--- a/packages/core/src/app/index.tsx
+++ b/packages/core/src/app/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cache } from "emotion";
-import { CacheProvider } from "@emotion/core";
+import { CacheProvider as EmotionProvider } from "@emotion/core";
+import { Provider as ConnectProvider } from "@frontity/connect";
 import { MergedPackages } from "../types";
 
 type Props = {
@@ -9,14 +10,16 @@ type Props = {
 
 const App: React.FunctionComponent<Props> = ({ store }) => {
   return (
-    <CacheProvider value={cache}>
-      {store.roots.map(({ Root, name }) => (
-        <Root key={name} />
-      ))}
-      {store.fills.map(({ Fill, name }) => (
-        <Fill key={name} />
-      ))}
-    </CacheProvider>
+    <EmotionProvider value={cache}>
+      <ConnectProvider value={store}>
+        {store.roots.map(({ Root, name }) => (
+          <Root key={name} />
+        ))}
+        {store.fills.map(({ Fill, name }) => (
+          <Fill key={name} />
+        ))}
+      </ConnectProvider>
+    </EmotionProvider>
   );
 };
 

--- a/packages/core/src/utils/__tests__/__snapshots__/packages.tests.tsx.snap
+++ b/packages/core/src/utils/__tests__/__snapshots__/packages.tests.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mergePackages should a list of packages with its excludes 1`] = `
+exports[`mergePackages should output a list of packages with its excludes 1`] = `
 Object {
   "actions": Object {},
   "fills": Array [],
@@ -16,10 +16,10 @@ Object {
   ],
   "state": Object {
     "namespace2": Object {
-      "prop2": 2,
+      "prop2": "This should be included",
     },
     "namespace3": Object {
-      "prop3": 3,
+      "prop3": "This should be included",
     },
     "settings": Object {
       "frontity": Object {
@@ -38,12 +38,18 @@ Object {
           },
         ],
       },
+      "namespace2": Object {
+        "settings2": "This should be included",
+      },
+      "namespace3": Object {
+        "settings3": "This should be included",
+      },
     },
   },
 }
 `;
 
-exports[`packageList should a list of packages with its excludes 1`] = `
+exports[`packageList should output a list of packages with its excludes 1`] = `
 Array [
   Object {
     "exclude": Array [

--- a/packages/core/src/utils/__tests__/packages.tests.tsx
+++ b/packages/core/src/utils/__tests__/packages.tests.tsx
@@ -3,7 +3,7 @@ import { getVariable, packageList, mergePackages } from "../packages";
 import { NormalizedSettings } from "@frontity/file-settings/src";
 
 describe("getVariable", () => {
-  test("should generate different variable names for different packages", () => {
+  it("should generate different variable names for different packages", () => {
     expect(getVariable("@org/package", "mode")).not.toBe(
       getVariable("org-package", "mode")
     );
@@ -42,7 +42,7 @@ describe("packageList", () => {
       }
     ]
   };
-  test("should a list of packages with its excludes", () => {
+  it("should output a list of packages with its excludes", () => {
     expect(packageList({ settings })).toMatchSnapshot();
   });
 });
@@ -73,11 +73,19 @@ describe("mergePackages", () => {
         namespace2: () => <div>"namespace2"</div>
       },
       state: {
+        settings: {
+          namespace1: {
+            setting1: "This should NOT be included"
+          },
+          namespace2: {
+            settings2: "This should be included"
+          }
+        },
         namespace1: {
-          prop1: 1
+          prop1: "This should NOT be included"
         },
         namespace2: {
-          prop2: 2
+          prop2: "This should be included"
         }
       }
     },
@@ -86,13 +94,19 @@ describe("mergePackages", () => {
         namespace3: () => <div>"namespace3"</div>
       },
       state: {
+        settings: {
+          namespace3: {
+            settings3: "This should be included"
+          }
+        },
         namespace3: {
-          prop3: 3
+          prop3: "This should be included"
         }
       }
     }
   };
-  test("should a list of packages with its excludes", () => {
+
+  it("should output a list of packages with its excludes", () => {
     expect(mergePackages({ packages, state })).toMatchSnapshot();
   });
 });

--- a/packages/core/src/utils/packages.ts
+++ b/packages/core/src/utils/packages.ts
@@ -43,7 +43,9 @@ export const mergePackages = ({
   const config: MergedPackages = {
     roots: [],
     fills: [],
-    state: {},
+    state: {
+      settings: {}
+    },
     actions: {}
   };
   const packageExcludes = state.settings.frontity.packages;
@@ -82,7 +84,19 @@ export const mergePackages = ({
     if (packages[pkg.variable].state) {
       Object.entries(packages[pkg.variable].state).forEach(
         ([namespace, state]) => {
-          if (pkg.exclude.indexOf(namespace) === -1) {
+          if (namespace === "settings") {
+            Object.entries(state).forEach(
+              ([settingsNamespace, settingsState]) => {
+                if (pkg.exclude.indexOf(settingsNamespace) === -1) {
+                  config.state.settings = deepmerge(
+                    config.state.settings,
+                    { [settingsNamespace]: settingsState },
+                    { clone: false }
+                  );
+                }
+              }
+            );
+          } else if (pkg.exclude.indexOf(namespace) === -1) {
             config.state = deepmerge(
               config.state,
               { [namespace]: state },

--- a/packages/extension-example-1/package.json
+++ b/packages/extension-example-1/package.json
@@ -19,6 +19,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "frontity": "^0.1.0"
+    "frontity": "^0.1.0",
+    "@frontity/connect": "^0.1.0"
   }
 }

--- a/packages/extension-example-1/src/html/index.tsx
+++ b/packages/extension-example-1/src/html/index.tsx
@@ -1,5 +1,19 @@
 import React from "react";
 import Package from "../../type";
+import connect from "@frontity/connect";
+import Connect from "@frontity/types/connect";
+
+type Props = Connect<Package, { prop: string }>;
+
+const Extension1: React.FC<Props> = ({ state, actions, prop, roots }) => (
+  <>
+    <div>
+      I am the root of extension example 1! State is: {state.extension1.prop1}
+    </div>
+    <button onClick={() => actions.extension1.action1()}>2</button>
+    <button onClick={() => actions.extension1.action2(3)}>3</button>
+  </>
+);
 
 const ExtensionExample1: Package = {
   name: "@frontity/extension-example-1",
@@ -18,8 +32,18 @@ const ExtensionExample1: Package = {
       prop3: state => state.comments.prop2 + 1
     }
   },
+  actions: {
+    extension1: {
+      action1: state => {
+        state.extension1.prop1 = 2;
+      },
+      action2: state => num => {
+        state.extension1.prop1 = num;
+      }
+    }
+  },
   roots: {
-    extension1: () => <div>I am the root of extension example 1!</div>
+    extension1: connect(Extension1)
   },
   fills: {
     extension1: () => <div>I am a fill of extension example 1</div>

--- a/packages/extension-example-1/type.ts
+++ b/packages/extension-example-1/type.ts
@@ -1,4 +1,4 @@
-import { Package, Namespaces, Derived } from "@frontity/types";
+import { Package, Namespaces, Derived, Action } from "@frontity/types";
 
 interface ExtensionExample1 extends Package {
   name: "@frontity/extension-example-1";
@@ -15,6 +15,12 @@ interface ExtensionExample1 extends Package {
     comments: {
       prop2: number;
       prop3: Derived<ExtensionExample1, number>;
+    };
+  };
+  actions: {
+    extension1: {
+      action1: Action<ExtensionExample1>;
+      action2: Action<ExtensionExample1, number>;
     };
   };
   roots: {

--- a/packages/types/connect.ts
+++ b/packages/types/connect.ts
@@ -1,0 +1,20 @@
+import Package from "./package";
+import { ResolveState } from "./utils";
+
+// Resolves the actions for things like Action and Derived.
+export type ResolveActions<Actions extends Package["state"]> = {
+  [P in keyof Actions]: Actions[P] extends (
+    ...a: any
+  ) => (a: infer Args) => void // Turns "state => args => {}" into "args => {}"
+    ? (a: Args) => void // Turns "state => {}" into "() => {}"
+    : Actions[P] extends (state: Package["state"]) => any
+    ? () => void
+    : ResolveActions<Actions[P]>
+};
+
+export type Connect<S extends Package, Props extends object = {}> = S & {
+  state: ResolveState<S["state"]>;
+  actions: ResolveActions<S["actions"]>;
+} & Props;
+
+export default Connect;

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -3,3 +3,4 @@ export { default as Package } from "./package";
 export { default as Action } from "./action";
 export { default as Derived } from "./derived";
 export { default as Namespaces } from "./namespaces";
+export { default as Connect } from "./connect";


### PR DESCRIPTION
This adds the connect `Provider` to the core, connected with the store. It also adds a connected component in `typescript-basic`.