### PR TITLE
Fix union types in connect

### DIFF
--- a/packages/types/__tests__/connect.tests.ts
+++ b/packages/types/__tests__/connect.tests.ts
@@ -1,0 +1,86 @@
+import Connect from "../connect";
+import Action from "../action";
+import Package from "../package";
+import Derived from "../derived";
+import Namespaces from "../namespaces";
+
+interface Package1 extends Package {
+  name: "package-1";
+  namespaces: Namespaces<"namespace1" | "namespace2">;
+  state: {
+    namespace1: {
+      prop1: string;
+      prop2: number;
+      prop3: Derived<Package1, string>;
+      prop4: Derived<Package1, string, number>;
+      array1: string[];
+      nested1: {
+        prop5: Derived<Package1, string, number>;
+        array2: number[];
+        nested2: {
+          prop6: Derived<Package1, string>;
+        };
+      };
+    };
+  };
+  actions: {
+    namespace1: {
+      action1: Action<Package1>;
+      action2: Action<Package1>;
+    };
+    namespace2: {
+      action3: Action<Package1, string>;
+      action4: Action<Package1, number>;
+    };
+  };
+  libraries: {
+    namespace3: {
+      library1: () => void;
+    };
+  };
+}
+
+interface OwnProps {
+  ownProp1: string;
+}
+
+const props: Connect<Package1, OwnProps> = {
+  state: {
+    namespace1: {
+      prop1: "prop1",
+      prop2: 2,
+      prop3: "prop3",
+      prop4: str => str.length,
+      array1: ["array1"],
+      nested1: {
+        prop5: str => str.length,
+        array2: [2],
+        nested2: {
+          prop6: "prop6"
+        }
+      }
+    }
+  },
+  actions: {
+    namespace1: {
+      action1: () => {},
+      action2: () => {}
+    },
+    namespace2: {
+      action3: str => {
+        const str2: string = str;
+      },
+      action4: num => {
+        const num2: number = num;
+      }
+    }
+  },
+  libraries: {
+    namespace3: {
+      library1: () => {}
+    }
+  },
+  ownProp1: "ownProp1"
+};
+
+test("Types are fine!", () => {});

--- a/packages/types/connect.ts
+++ b/packages/types/connect.ts
@@ -1,18 +1,21 @@
 import Package from "./package";
-import { ResolveState } from "./utils";
+import { ResolveState, Omit } from "./utils";
 
 // Resolves the actions for things like Action and Derived.
 export type ResolveActions<Actions extends Package["state"]> = {
   [P in keyof Actions]: Actions[P] extends (
     ...a: any
-  ) => (a: infer Args) => void // Turns "state => args => {}" into "args => {}"
-    ? (a: Args) => void // Turns "state => {}" into "() => {}"
+  ) => (arg: infer Arg) => void // Turns "state => args => {}" into "args => {}"
+    ? (arg: Arg) => void // Turns "state => {}" into "() => {}"
     : Actions[P] extends (state: Package["state"]) => any
     ? () => void
     : ResolveActions<Actions[P]>
 };
 
-export type Connect<S extends Package, Props extends object = {}> = S & {
+export type Connect<S extends Package, Props extends object = {}> = Omit<
+  S,
+  "state" | "actions" | "name" | "namespaces"
+> & {
   state: ResolveState<S["state"]>;
   actions: ResolveActions<S["actions"]>;
 } & Props;

--- a/packages/types/utils.ts
+++ b/packages/types/utils.ts
@@ -15,3 +15,6 @@ export type DeepPartial<T> = T extends Array<infer U>
   : T extends object
   ? DeepPartialObject<T>
   : T;
+
+// Omits any property found in the passed object.
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
This a quick fix for a union problem in the Connect type. Now it omits the original `state` and `actions` from the package and includes only the properly processed ones.

I've also added tests for Connect.