### PR TITLE
Show Nav's scrollbar only when its content overflows

### DIFF
--- a/packages/mars-theme/src/html/components/nav.js
+++ b/packages/mars-theme/src/html/components/nav.js
@@ -22,7 +22,7 @@ const Container = styled.ul`
   box-sizing: border-box;
   padding: 0 24px;
   margin: 0;
-  overflow-x: scroll;
+  overflow-x: auto;
 `;
 
 const Item = styled.li`


### PR DESCRIPTION
Just set `overflow-x` to `auto in` Nav component.