### PR TITLE
Some "new project" package improvements

### DIFF
--- a/examples/mars-theme-example/frontity.settings.js
+++ b/examples/mars-theme-example/frontity.settings.js
@@ -1,4 +1,4 @@
-const settings = {
+export default {
   name: "mars-theme-example",
   state: {
     frontity: {
@@ -38,5 +38,3 @@ const settings = {
     }
   ]
 };
-
-module.exports = settings;

--- a/packages/frontity/src/functions/create/__tests__/__snapshots__/steps.tests.ts.snap
+++ b/packages/frontity/src/functions/create/__tests__/__snapshots__/steps.tests.ts.snap
@@ -215,6 +215,7 @@ Array [
     "{
   \\"name\\": \\"random-name\\",
   \\"version\\": \\"1.0.0\\",
+  \\"private\\": true,
   \\"description\\": \\"Frontity project\\",
   \\"keywords\\": [
     \\"frontity\\"
@@ -261,6 +262,7 @@ Array [
     "{
   \\"name\\": \\"random-name\\",
   \\"version\\": \\"1.0.0\\",
+  \\"private\\": true,
   \\"description\\": \\"Frontity project\\",
   \\"keywords\\": [
     \\"frontity\\"

--- a/packages/frontity/src/functions/create/__tests__/__snapshots__/steps.tests.ts.snap
+++ b/packages/frontity/src/functions/create/__tests__/__snapshots__/steps.tests.ts.snap
@@ -107,7 +107,11 @@ Array [
               \\"About Us\\",
               \\"/about-us/\\"
             ]
-          ]
+          ],
+          \\"featured\\": {
+            \\"showOnList\\": false,
+            \\"showOnPost\\": false
+          }
         }
       }
     },
@@ -165,7 +169,11 @@ Array [
               \\"About Us\\",
               \\"/about-us/\\"
             ]
-          ]
+          ],
+          \\"featured\\": {
+            \\"showOnList\\": false,
+            \\"showOnPost\\": false
+          }
         }
       }
     },

--- a/packages/frontity/src/functions/create/steps.ts
+++ b/packages/frontity/src/functions/create/steps.ts
@@ -90,6 +90,7 @@ export const createPackageJson = async ({ name, theme, path }: Options) => {
   const packageJson: PackageJson = {
     name,
     version: "1.0.0",
+    private: true,
     description: "Frontity project",
     keywords: ["frontity"],
     scripts: {

--- a/packages/frontity/src/functions/create/steps.ts
+++ b/packages/frontity/src/functions/create/steps.ts
@@ -130,7 +130,11 @@ export const createFrontitySettings = async (
               ["Travel", "/category/travel/"],
               ["Japan", "/tag/japan/"],
               ["About Us", "/about-us/"]
-            ]
+            ],
+            featured: {
+              showOnList: false,
+              showOnPost: false
+            }
           }
         }
       },

--- a/packages/frontity/src/functions/create/types.ts
+++ b/packages/frontity/src/functions/create/types.ts
@@ -21,6 +21,7 @@ export type Options = {
 export type PackageJson = {
   name: string;
   version: string;
+  private: boolean;
   description: string;
   keywords: string[];
   scripts: {

--- a/packages/frontity/templates/settings-js-template
+++ b/packages/frontity/templates/settings-js-template
@@ -1,3 +1,3 @@
 const settings = $settings$;
 
-module.exports = settings;
+export default settings;

--- a/packages/frontity/templates/settings-ts-template
+++ b/packages/frontity/templates/settings-ts-template
@@ -1,5 +1,5 @@
-import { Settings } from "@frontity/file-settings";
+import { Settings } from "frontity/types";
 
 const settings: Settings = $settings$;
 
-module.exports = settings;
+export default settings;


### PR DESCRIPTION
Includes some missing settings, adds private to project package.json and uses `export default` instead of `module.exports` in `frontity.settings.js` files.