### PR TITLE
Changes in `source` and `route` API.

### DIFF
--- a/packages/core/src/server/utils/__tests__/__snapshots__/initial-state.tests.ts.snap
+++ b/packages/core/src/server/utils/__tests__/__snapshots__/initial-state.tests.ts.snap
@@ -1,102 +1,144 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`initialState should return a valid initial link 1`] = `
+Object {
+  "frontity": Object {
+    "initialLink": "/category/nature/page/2",
+    "menu1": Array [
+      "Overwrrite by pacakge1",
+      "With a second item",
+    ],
+    "mode": "html",
+    "name": "site",
+    "packages": Array [
+      "package1",
+      "package2",
+    ],
+    "platform": "server",
+    "prop1": "overwritten by package2",
+    "url": "https://site.com",
+  },
+  "package1": Object {
+    "prop2": "prop2",
+  },
+  "package2": Object {
+    "prop3": "prop2",
+  },
+}
+`;
+
+exports[`initialState should return a valid initial link with hash 1`] = `
+Object {
+  "frontity": Object {
+    "initialLink": "/page/2#some-hash",
+    "menu1": Array [
+      "Overwrrite by pacakge1",
+      "With a second item",
+    ],
+    "mode": "html",
+    "name": "site",
+    "packages": Array [
+      "package1",
+      "package2",
+    ],
+    "platform": "server",
+    "prop1": "overwritten by package2",
+    "url": "https://site.com",
+  },
+  "package1": Object {
+    "prop2": "prop2",
+  },
+  "package2": Object {
+    "prop3": "prop2",
+  },
+}
+`;
+
+exports[`initialState should return a valid initial link with home 1`] = `
+Object {
+  "frontity": Object {
+    "initialLink": "/",
+    "menu1": Array [
+      "Overwrrite by pacakge1",
+      "With a second item",
+    ],
+    "mode": "html",
+    "name": "site",
+    "packages": Array [
+      "package1",
+      "package2",
+    ],
+    "platform": "server",
+    "prop1": "overwritten by package2",
+    "url": "https://site.com",
+  },
+  "package1": Object {
+    "prop2": "prop2",
+  },
+  "package2": Object {
+    "prop3": "prop2",
+  },
+}
+`;
+
+exports[`initialState should return a valid initial link with query 1`] = `
+Object {
+  "frontity": Object {
+    "initialLink": "/page/2?some=query",
+    "menu1": Array [
+      "Overwrrite by pacakge1",
+      "With a second item",
+    ],
+    "mode": "html",
+    "name": "site",
+    "packages": Array [
+      "package1",
+      "package2",
+    ],
+    "platform": "server",
+    "prop1": "overwritten by package2",
+    "url": "https://site.com",
+  },
+  "package1": Object {
+    "prop2": "prop2",
+  },
+  "package2": Object {
+    "prop3": "prop2",
+  },
+}
+`;
+
+exports[`initialState should return a valid initial link with query and hash 1`] = `
+Object {
+  "frontity": Object {
+    "initialLink": "/page/2?some=query#some-hash",
+    "menu1": Array [
+      "Overwrrite by pacakge1",
+      "With a second item",
+    ],
+    "mode": "html",
+    "name": "site",
+    "packages": Array [
+      "package1",
+      "package2",
+    ],
+    "platform": "server",
+    "prop1": "overwritten by package2",
+    "url": "https://site.com",
+  },
+  "package1": Object {
+    "prop2": "prop2",
+  },
+  "package2": Object {
+    "prop3": "prop2",
+  },
+}
+`;
+
 exports[`initialState should return a valid initial state 1`] = `
 Object {
   "frontity": Object {
-    "initial": Object {
-      "page": 1,
-      "path": "/post",
-    },
-    "menu1": Array [
-      "Overwrrite by pacakge1",
-      "With a second item",
-    ],
-    "mode": "html",
-    "name": "site",
-    "packages": Array [
-      "package1",
-      "package2",
-    ],
-    "platform": "server",
-    "prop1": "overwritten by package2",
-    "url": "https://site.com",
-  },
-  "package1": Object {
-    "prop2": "prop2",
-  },
-  "package2": Object {
-    "prop3": "prop2",
-  },
-}
-`;
-
-exports[`initialState should return a valid path and page 1`] = `
-Object {
-  "frontity": Object {
-    "initial": Object {
-      "page": 2,
-      "path": "/category/nature/",
-    },
-    "menu1": Array [
-      "Overwrrite by pacakge1",
-      "With a second item",
-    ],
-    "mode": "html",
-    "name": "site",
-    "packages": Array [
-      "package1",
-      "package2",
-    ],
-    "platform": "server",
-    "prop1": "overwritten by package2",
-    "url": "https://site.com",
-  },
-  "package1": Object {
-    "prop2": "prop2",
-  },
-  "package2": Object {
-    "prop3": "prop2",
-  },
-}
-`;
-
-exports[`initialState should return a valid path and page with home 1`] = `
-Object {
-  "frontity": Object {
-    "initial": Object {
-      "page": 1,
-      "path": "/",
-    },
-    "menu1": Array [
-      "Overwrrite by pacakge1",
-      "With a second item",
-    ],
-    "mode": "html",
-    "name": "site",
-    "packages": Array [
-      "package1",
-      "package2",
-    ],
-    "platform": "server",
-    "prop1": "overwritten by package2",
-    "url": "https://site.com",
-  },
-  "package1": Object {
-    "prop2": "prop2",
-  },
-  "package2": Object {
-    "prop3": "prop2",
-  },
-}
-`;
-
-exports[`initialState should return a valid path and page with paginated home 1`] = `
-Object {
-  "frontity": Object {
-    "initial": Object {
-      "page": 2,
-      "path": "/",
-    },
+    "initialLink": "/post",
     "menu1": Array [
       "Overwrrite by pacakge1",
       "With a second item",

--- a/packages/core/src/server/utils/__tests__/initial-state.tests.ts
+++ b/packages/core/src/server/utils/__tests__/initial-state.tests.ts
@@ -45,18 +45,28 @@ describe("initialState", () => {
     expect(initialState({ settings, url })).toMatchSnapshot();
   });
 
-  it("should return a valid path and page", () => {
+  it("should return a valid initial link", () => {
     const url = new URL("https://site.com/category/nature/page/2");
     expect(initialState({ settings, url })).toMatchSnapshot();
   });
 
-  it("should return a valid path and page with home", () => {
+  it("should return a valid initial link with home", () => {
     const url = new URL("https://site.com");
     expect(initialState({ settings, url })).toMatchSnapshot();
   });
 
-  it("should return a valid path and page with paginated home", () => {
-    const url = new URL("https://site.com/page/2");
+  it("should return a valid initial link with query", () => {
+    const url = new URL("https://site.com/page/2?some=query");
+    expect(initialState({ settings, url })).toMatchSnapshot();
+  });
+
+  it("should return a valid initial link with hash", () => {
+    const url = new URL("https://site.com/page/2#some-hash");
+    expect(initialState({ settings, url })).toMatchSnapshot();
+  });
+
+  it("should return a valid initial link with query and hash", () => {
+    const url = new URL("https://site.com/page/2?some=query#some-hash");
     expect(initialState({ settings, url })).toMatchSnapshot();
   });
 });

--- a/packages/core/src/server/utils/initial-state.ts
+++ b/packages/core/src/server/utils/initial-state.ts
@@ -14,16 +14,7 @@ export default ({
       name: settings.name,
       mode: settings.mode,
       platform: "server",
-      initial: {
-        path: (/^(.*)page\/\d+\/?$/.exec(url.pathname) || [
-          null,
-          url.pathname
-        ])[1],
-        page: parseInt(
-          (/^.*page\/(\d+)\/?$/.exec(url.pathname) || [null, "1"])[1],
-          10
-        )
-      },
+      initialLink: `${url.pathname}${url.search}${url.hash}`,
       packages: settings.packages.map(pkg => pkg.name)
     }
   };

--- a/packages/mars-theme/src/components/header.js
+++ b/packages/mars-theme/src/components/header.js
@@ -6,7 +6,7 @@ import Nav from "./nav";
 const Header = ({ state }) => (
   <>
     <Container>
-      <StyledLink path="/">
+      <StyledLink link="/">
         <Title>{state.frontity.title}</Title>
       </StyledLink>
       <Description>{state.frontity.description}</Description>

--- a/packages/mars-theme/src/components/link.js
+++ b/packages/mars-theme/src/components/link.js
@@ -1,10 +1,7 @@
 import React from "react";
 import { connect } from "frontity";
 
-const Link = ({ actions, libraries, link, className, children }) => {
-  // normalizes link
-  link = libraries.source.stringify(link);
-
+const Link = ({ actions, link, className, children }) => {
   const onClick = event => {
     event.preventDefault();
     // Set the router to the new url.

--- a/packages/mars-theme/src/components/link.js
+++ b/packages/mars-theme/src/components/link.js
@@ -1,28 +1,19 @@
 import React from "react";
 import { connect } from "frontity";
 
-const Link = ({
-  actions,
-  libraries,
-  path,
-  page,
-  query,
-  className,
-  children
-}) => {
-  // If page is passed, build final href.
-  // const href = page ? `${path}page/${page}` : path;
-  const href = libraries.source.getRoute({ path, page, query });
+const Link = ({ actions, libraries, link, className, children }) => {
+  // normalizes link
+  link = libraries.source.stringify(link);
 
   const onClick = event => {
     event.preventDefault();
     // Set the router to the new url.
-    actions.router.set({ path, page, query });
+    actions.router.set(link);
     window.scrollTo(0, 0);
   };
 
   return (
-    <a href={href} onClick={onClick} className={className}>
+    <a href={link} onClick={onClick} className={className}>
       {children}
     </a>
   );

--- a/packages/mars-theme/src/components/list/list-item.js
+++ b/packages/mars-theme/src/components/list/list-item.js
@@ -9,10 +9,10 @@ const Item = ({ state, item }) => {
 
   return (
     <Container>
-      <Link path={item.link}>
+      <Link link={item.link}>
         <Title dangerouslySetInnerHTML={{ __html: item.title.rendered }} />
       </Link>
-      <Link path={author.link}>
+      <Link link={author.link}>
         <Author>
           By <b>{author.name}</b>
         </Author>

--- a/packages/mars-theme/src/components/list/list.js
+++ b/packages/mars-theme/src/components/list/list.js
@@ -5,8 +5,7 @@ import Pagination from "./pagination";
 
 const List = ({ state }) => {
   // Get the data of the current list.
-  const { path, page } = state.router;
-  const data = state.source.get({ path, page });
+  const data = state.source.get(state.router.link);
 
   return (
     <Container>

--- a/packages/mars-theme/src/components/list/pagination.js
+++ b/packages/mars-theme/src/components/list/pagination.js
@@ -2,30 +2,42 @@ import React, { useEffect } from "react";
 import { connect } from "frontity";
 import Link from "../link";
 
-const Pagination = ({ state, actions }) => {
-  const { totalPages } = state.source.get(state.router.path);
-  const isThereNextPage = state.router.page < totalPages;
-  const isTherePreviousPage = state.router.page > 1;
+const Pagination = ({ state, actions, libraries }) => {
+  const currentLink = state.router.link;
+
+  const { totalPages } = state.source.get(currentLink);
+  const { path, page, query } = libraries.source.parse(currentLink);
+
+  const isThereNextPage = page < totalPages;
+  const isTherePreviousPage = page > 1;
+
+  const nextPageLink = libraries.source.stringify({
+    path,
+    page: page + 1,
+    query
+  });
+
+  const prevPageLink = libraries.source.stringify({
+    path,
+    page: page - 1,
+    query
+  });
 
   // Fetch the next page if it hasn't been fetched yet.
   useEffect(() => {
-    if (isThereNextPage)
-      actions.source.fetch({
-        path: state.router.path,
-        page: state.router.page + 1
-      });
+    if (isThereNextPage) actions.source.fetch(nextPageLink);
   }, []);
 
   return (
     <div>
       {isThereNextPage && (
-        <Link path={state.router.path} page={state.router.page + 1}>
+        <Link link={nextPageLink}>
           <em>← Older posts</em>
         </Link>
       )}
       {isTherePreviousPage && isThereNextPage && " - "}
       {isTherePreviousPage && (
-        <Link path={state.router.path} page={state.router.page - 1}>
+        <Link link={prevPageLink}>
           <em>Newer posts →</em>
         </Link>
       )}

--- a/packages/mars-theme/src/components/nav.js
+++ b/packages/mars-theme/src/components/nav.js
@@ -4,9 +4,9 @@ import Link from "./link";
 
 const Nav = ({ state }) => (
   <Container>
-    {state.theme.menu.map(item => (
-      <Item key={item[0]} isSelected={state.router.path === item[1]}>
-        <Link path={item[1]}>{item[0]}</Link>
+    {state.theme.menu.map(([name, link]) => (
+      <Item key={name} isSelected={state.router.link === link}>
+        <Link link={link}>{name}</Link>
       </Item>
     ))}
   </Container>

--- a/packages/mars-theme/src/components/post.js
+++ b/packages/mars-theme/src/components/post.js
@@ -6,7 +6,7 @@ import FeaturedMedia from "./featured-media";
 
 const Post = ({ state, actions }) => {
   // Get info of current post.
-  const data = state.source.get(state.router.path);
+  const data = state.source.get(state.router.link);
   // Get the the post.
   const post = state.source[data.type][data.id];
   // Get the author.
@@ -26,7 +26,7 @@ const Post = ({ state, actions }) => {
         <Title dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
         {data.isPost && (
           <>
-            <Link path={author.link}>
+            <Link link={author.link}>
               <Author>
                 By <b>{author.name}</b>
               </Author>

--- a/packages/mars-theme/src/components/theme.js
+++ b/packages/mars-theme/src/components/theme.js
@@ -20,7 +20,7 @@ const globalStyles = css`
 `;
 
 const Theme = ({ state }) => {
-  const data = state.source.get(state.router);
+  const data = state.source.get(state.router.link);
 
   let Content = <Loading />;
 

--- a/packages/router/__tests__/index.test.ts
+++ b/packages/router/__tests__/index.test.ts
@@ -3,16 +3,12 @@ import Router from "..";
 const router: Router = {
   state: {
     router: {
-      path: "/some-path",
-      page: 2,
-      query: {
-        k1: "v1"
-      }
+      link: "/some-path/page/2/?k1=v1"
     }
   },
   actions: {
     router: {
-      set: state => routeOrParams => {
+      set: state => link => {
         /* do something */
       }
     }

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -1,25 +1,15 @@
 import { Package, Action } from "frontity/types";
 
-export type RouteOrParams =
-  | string
-  | {
-      path: string;
-      page?: number;
-      query?: Record<string, any>;
-    };
-
 interface Router<T = null> extends Package {
   state: {
     frontity?: Package["state"]["frontity"];
     router: {
-      path: string;
-      page: number;
-      query: Record<string, any>;
+      link: string;
     };
   };
   actions: {
     router: {
-      set: Action<T extends null ? Router : T, RouteOrParams>;
+      set: Action<T extends null ? Router : T, string>;
     };
   };
 }

--- a/packages/source/index.ts
+++ b/packages/source/index.ts
@@ -32,8 +32,8 @@ interface Source<T = null> extends Package {
   libraries: {
     source: {
       populate: Function;
-      getParams: (routeOrParams: string | RouteParams) => RouteParams;
-      getRoute: (routeOrParams: string | RouteParams) => string;
+      parse: (routeOrParams: string | RouteParams) => RouteParams;
+      stringify: (routeOrParams: string | RouteParams) => string;
     };
   };
 }

--- a/packages/source/index.ts
+++ b/packages/source/index.ts
@@ -33,8 +33,9 @@ interface Source<T = null> extends Package {
   libraries: {
     source: {
       populate: Function;
-      parse: (routeOrParams: string | RouteParams) => RouteParams;
-      stringify: (routeOrParams: string | RouteParams) => string;
+      parse: (route: string) => RouteParams;
+      stringify: (routeParams: RouteParams) => string;
+      normalize: (route: string) => string;
     };
   };
 }

--- a/packages/source/index.ts
+++ b/packages/source/index.ts
@@ -6,6 +6,7 @@ export type RouteParams = {
   path: string;
   page?: number;
   query?: Record<string, any>;
+  hash?: string;
 };
 
 export type Data = Data;
@@ -13,7 +14,7 @@ export type Data = Data;
 interface Source<T = null> extends Package {
   state: {
     source: {
-      get: Derived<T extends null ? Source : T, (pathOrLink: string) => Data>;
+      get: Derived<T extends null ? Source : T, (link: string) => Data>;
       data: Record<string, Data>;
       category: Record<string, Taxonomy>;
       tag: Record<string, Taxonomy>;
@@ -25,7 +26,7 @@ interface Source<T = null> extends Package {
   };
   actions: {
     source: {
-      fetch: Action<T extends null ? Source : T, string | RouteParams>;
+      fetch: Action<T extends null ? Source : T, string>;
       init?: Action<T extends null ? Source : T>;
     };
   };

--- a/packages/source/src/__tests__/source.tests.ts
+++ b/packages/source/src/__tests__/source.tests.ts
@@ -26,8 +26,8 @@ const source1 = (libraries: Source["libraries"]): Source => {
     libraries: {
       source: {
         populate: () => {},
-        getParams: () => ({ path: "" }),
-        getRoute: () => "/route/"
+        parse: () => ({ path: "" }),
+        stringify: () => "/route/"
       }
     }
   };
@@ -76,8 +76,8 @@ const source2: MySource = {
   libraries: {
     source: {
       populate: () => {},
-      getParams: () => ({ path: "" }),
-      getRoute: () => "/route/"
+      parse: () => ({ path: "" }),
+      stringify: () => "/route/"
     }
   }
 };

--- a/packages/source/src/__tests__/source.tests.ts
+++ b/packages/source/src/__tests__/source.tests.ts
@@ -27,7 +27,8 @@ const source1 = (libraries: Source["libraries"]): Source => {
       source: {
         populate: () => {},
         parse: () => ({ path: "" }),
-        stringify: () => "/route/"
+        stringify: () => "/route/",
+        normalize: () => "/route/"
       }
     }
   };
@@ -77,7 +78,8 @@ const source2: MySource = {
     source: {
       populate: () => {},
       parse: () => ({ path: "" }),
-      stringify: () => "/route/"
+      stringify: () => "/route/",
+      normalize: () => "/route/"
     }
   }
 };

--- a/packages/tiny-router/index.ts
+++ b/packages/tiny-router/index.ts
@@ -20,8 +20,7 @@ interface TinyRouter extends Router {
   };
   libraries: {
     source?: {
-      getParams: Source["libraries"]["source"]["getParams"];
-      getRoute: Source["libraries"]["source"]["getRoute"];
+      stringify: Source["libraries"]["source"]["stringify"];
     };
   };
 }

--- a/packages/tiny-router/index.ts
+++ b/packages/tiny-router/index.ts
@@ -20,7 +20,7 @@ interface TinyRouter extends Router {
   };
   libraries: {
     source?: {
-      stringify: Source["libraries"]["source"]["stringify"];
+      normalize: Source["libraries"]["source"]["normalize"];
     };
   };
 }

--- a/packages/tiny-router/src/__tests__/index.test.ts
+++ b/packages/tiny-router/src/__tests__/index.test.ts
@@ -4,10 +4,10 @@ import tinyRouter from "..";
 import TinyRouter from "../..";
 
 let config: TinyRouter;
-let stringify: jest.Mock;
+let normalize: jest.Mock;
 
 beforeEach(() => {
-  stringify = jest.fn();
+  normalize = jest.fn();
 
   config = {
     name: "@frontity/tiny-router",
@@ -26,7 +26,7 @@ beforeEach(() => {
     },
     libraries: {
       source: {
-        stringify
+        normalize
       }
     }
   };
@@ -37,38 +37,38 @@ describe("actions", () => {
     const store = createStore(config);
 
     const link = "/some-post/";
-    const stringified = "/some-post/";
+    const normalized = "/some-post/";
 
-    stringify.mockReturnValue(stringified);
+    normalize.mockReturnValue(normalized);
 
     store.actions.router.set(link);
-    expect(stringify).toHaveBeenCalledWith(link);
-    expect(store.state.router.link).toBe(stringified);
+    expect(normalize).toHaveBeenCalledWith(link);
+    expect(store.state.router.link).toBe(normalized);
   });
 
   test("set() should work with full URLs", () => {
     const store = createStore(config);
 
     const link = "https://blog.example/some-post/page/3/?some=query";
-    const stringified = "/some-post/page/3/?some=query";
+    const normalized = "/some-post/page/3/?some=query";
 
-    stringify.mockReturnValue(stringified);
+    normalize.mockReturnValue(normalized);
 
     store.actions.router.set(link);
-    expect(stringify).toHaveBeenCalledWith(link);
-    expect(store.state.router.link).toBe(stringified);
+    expect(normalize).toHaveBeenCalledWith(link);
+    expect(store.state.router.link).toBe(normalized);
   });
 
   test("init() should populate the initial link", () => {
     const store = createStore(config);
 
-    stringify.mockReturnValue("/initial/link/");
+    normalize.mockReturnValue("/initial/link/");
 
     store.actions.router.init();
 
     // check that first state is correct
-    expect(stringify).toHaveBeenCalledTimes(1);
-    expect(stringify).toHaveBeenCalledWith("/initial/link/");
+    expect(normalize).toHaveBeenCalledTimes(1);
+    expect(normalize).toHaveBeenCalledWith("/initial/link/");
     expect(store.state.router.link).toBe("/initial/link/");
   });
 
@@ -77,7 +77,7 @@ describe("actions", () => {
     const store = createStore(config);
     store.actions.router.init();
 
-    stringify.mockReturnValueOnce("/tag/japan/page/3/");
+    normalize.mockReturnValueOnce("/tag/japan/page/3/");
 
     // check that first state is correct
     expect(window.history.state).toMatchObject({ link: "/" });

--- a/packages/tiny-router/src/__tests__/index.test.ts
+++ b/packages/tiny-router/src/__tests__/index.test.ts
@@ -13,7 +13,8 @@ beforeEach(() => {
     name: "@frontity/tiny-router",
     state: {
       frontity: {
-        platform: "server"
+        platform: "server",
+        initialLink: "/initial/link/"
       },
       router: { ...tinyRouter.state.router }
     },
@@ -58,6 +59,19 @@ describe("actions", () => {
     expect(store.state.router.link).toBe(stringified);
   });
 
+  test("init() should populate the initial link", () => {
+    const store = createStore(config);
+
+    stringify.mockReturnValue("/initial/link/");
+
+    store.actions.router.init();
+
+    // check that first state is correct
+    expect(stringify).toHaveBeenCalledTimes(1);
+    expect(stringify).toHaveBeenCalledWith("/initial/link/");
+    expect(store.state.router.link).toBe("/initial/link/");
+  });
+
   test("init() should add event listener to handle popstate events", () => {
     config.state.frontity.platform = "client";
     const store = createStore(config);
@@ -66,9 +80,7 @@ describe("actions", () => {
     stringify.mockReturnValueOnce("/tag/japan/page/3/");
 
     // check that first state is correct
-    expect(window.history.state).toMatchObject({
-      link: "/"
-    });
+    expect(window.history.state).toMatchObject({ link: "/" });
 
     // check reactions to "popstate" events
     let currentLink = store.state.router.link;

--- a/packages/tiny-router/src/actions.ts
+++ b/packages/tiny-router/src/actions.ts
@@ -7,9 +7,9 @@ export const set: TinyRouter["actions"]["router"]["set"] = ({
   actions,
   libraries
 }) => link => {
-  const { stringify } = libraries.source;
+  const { normalize } = libraries.source;
   // normalizes link
-  link = stringify(link);
+  link = normalize(link);
 
   state.router.link = link;
 
@@ -28,7 +28,7 @@ export const init: TinyRouter["actions"]["router"]["init"] = ({
 }) => {
   if (state.frontity.platform === "server") {
     // Populate the router info with the initial path and page.
-    state.router.link = libraries.source.stringify(state.frontity.initialLink);
+    state.router.link = libraries.source.normalize(state.frontity.initialLink);
     console.log(state.frontity.initialLink, state.router.link);
   } else {
     // Replace the current url with the same one but with state.

--- a/packages/tiny-router/src/actions.ts
+++ b/packages/tiny-router/src/actions.ts
@@ -28,7 +28,8 @@ export const init: TinyRouter["actions"]["router"]["init"] = ({
 }) => {
   if (state.frontity.platform === "server") {
     // Populate the router info with the initial path and page.
-    state.router.link = libraries.source.stringify(state.frontity.initial);
+    state.router.link = libraries.source.stringify(state.frontity.initialLink);
+    console.log(state.frontity.initialLink, state.router.link);
   } else {
     // Replace the current url with the same one but with state.
     window.history.replaceState({ link: state.router.link }, "");

--- a/packages/tiny-router/src/actions.ts
+++ b/packages/tiny-router/src/actions.ts
@@ -6,18 +6,16 @@ export const set: TinyRouter["actions"]["router"]["set"] = ({
   state,
   actions,
   libraries
-}) => routeOrParams => {
-  const { getParams, getRoute } = libraries.source;
-  const { path, page, query } = getParams(routeOrParams);
-  const route = getRoute(routeOrParams);
+}) => link => {
+  const { stringify } = libraries.source;
+  // normalizes link
+  link = stringify(link);
 
-  state.router.path = path;
-  state.router.page = page;
-  state.router.query = query;
+  state.router.link = link;
 
   if (state.frontity.platform === "client" && !isPopState) {
-    window.history.pushState({ path, page, query: { ...query } }, "", route);
-    if (state.router.autoFetch) actions.source.fetch({ path, page, query });
+    window.history.pushState({ link }, "", link);
+    if (state.router.autoFetch) actions.source.fetch(link);
   } else {
     isPopState = false;
   }
@@ -30,18 +28,14 @@ export const init: TinyRouter["actions"]["router"]["init"] = ({
 }) => {
   if (state.frontity.platform === "server") {
     // Populate the router info with the initial path and page.
-    const params = libraries.source.getParams(state.frontity.initial);
-    state.router.path = params.path;
-    state.router.page = params.page;
-    state.router.query = params.query;
+    state.router.link = libraries.source.stringify(state.frontity.initial);
   } else {
     // Replace the current url with the same one but with state.
-    const { path, page, query } = state.router;
-    window.history.replaceState({ path, page, query: { ...query } }, "");
+    window.history.replaceState({ link: state.router.link }, "");
     // Listen to changes in history.
-    window.addEventListener("popstate", ({ state: params }) => {
+    window.addEventListener("popstate", ({ state }) => {
       isPopState = true;
-      actions.router.set(params);
+      actions.router.set(state.link);
     });
   }
 };
@@ -50,5 +44,5 @@ export const beforeSSR: TinyRouter["actions"]["router"]["beforeSSR"] = async ({
   state,
   actions
 }) => {
-  if (state.router.autoFetch) await actions.source.fetch(state.router);
+  if (state.router.autoFetch) await actions.source.fetch(state.router.link);
 };

--- a/packages/tiny-router/src/index.ts
+++ b/packages/tiny-router/src/index.ts
@@ -5,9 +5,7 @@ const tinyRouter: TinyRouter = {
   name: "@frontity/tiny-router",
   state: {
     router: {
-      path: "/",
-      page: 1,
-      query: {},
+      link: "/",
       autoFetch: true
     }
   },

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -11,11 +11,7 @@ export interface Package {
       // Automatically populated:
       name?: string;
       mode?: string;
-      initial?: {
-        path: string;
-        page: number;
-        query?: Record<string, any>;
-      };
+      initialLink?: string;
       packages?: string[];
       platform?: "client" | "server";
       // Populated by the user:

--- a/packages/wp-source/index.ts
+++ b/packages/wp-source/index.ts
@@ -42,6 +42,7 @@ interface WpSource extends Source {
       ) => Promise<EntityData[]>;
       parse: Source<WpSource>["libraries"]["source"]["parse"];
       stringify: Source<WpSource>["libraries"]["source"]["stringify"];
+      normalize: Source<WpSource>["libraries"]["source"]["normalize"];
     };
   };
 }

--- a/packages/wp-source/index.ts
+++ b/packages/wp-source/index.ts
@@ -40,8 +40,8 @@ interface WpSource extends Source {
         state: State<WpSource>["source"],
         response: Response
       ) => Promise<EntityData[]>;
-      getParams: Source<WpSource>["libraries"]["source"]["getParams"];
-      getRoute: Source<WpSource>["libraries"]["source"]["getRoute"];
+      parse: Source<WpSource>["libraries"]["source"]["parse"];
+      stringify: Source<WpSource>["libraries"]["source"]["stringify"];
     };
   };
 }

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -3,13 +3,13 @@ import { parse, stringify } from "./libraries/route-utils";
 import { wpOrg, wpCom } from "./libraries/patterns";
 
 const actions: WpSource["actions"]["source"] = {
-  fetch: ({ state, libraries }) => async routeOrParams => {
+  fetch: ({ state, libraries }) => async link => {
     const { source } = state;
     const { resolver } = libraries.source;
 
     // Get route and route params
-    const route = stringify(routeOrParams);
-    const routeParams = parse(routeOrParams);
+    const route = stringify(link);
+    const routeParams = parse(link);
 
     // Get current data object
     const data = source.data[route];

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -1,5 +1,5 @@
 import WpSource from "../";
-import { getParams, getRoute } from "./libraries/route-utils";
+import { parse, stringify } from "./libraries/route-utils";
 import { wpOrg, wpCom } from "./libraries/patterns";
 
 const actions: WpSource["actions"]["source"] = {
@@ -8,8 +8,8 @@ const actions: WpSource["actions"]["source"] = {
     const { resolver } = libraries.source;
 
     // Get route and route params
-    const route = getRoute(routeOrParams);
-    const routeParams = getParams(routeOrParams);
+    const route = stringify(routeOrParams);
+    const routeParams = parse(routeOrParams);
 
     // Get current data object
     const data = source.data[route];

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -1,5 +1,5 @@
 import WpSource from "../";
-import { parse, stringify } from "./libraries/route-utils";
+import { parse, normalize } from "./libraries/route-utils";
 import { wpOrg, wpCom } from "./libraries/patterns";
 
 const actions: WpSource["actions"]["source"] = {
@@ -8,7 +8,7 @@ const actions: WpSource["actions"]["source"] = {
     const { resolver } = libraries.source;
 
     // Get route and route params
-    const route = stringify(link);
+    const route = normalize(link);
     const routeParams = parse(link);
 
     // Get current data object

--- a/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
+++ b/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
@@ -1,22 +1,22 @@
-import { getParams, getRoute } from "../route-utils";
+import { parse, stringify } from "../route-utils";
 
-describe("route utils - getParams", () => {
+describe("route utils - parse", () => {
   test("from params (fixes path)", () => {
-    expect(getParams({ path: "/some/path" })).toEqual({
+    expect(parse({ path: "/some/path" })).toEqual({
       path: "/some/path/",
       page: 1,
       query: {}
     });
   });
   test("from params (path is a name)", () => {
-    expect(getParams({ path: "custom-list" })).toEqual({
+    expect(parse({ path: "custom-list" })).toEqual({
       path: "custom-list/",
       page: 1,
       query: {}
     });
   });
   test("from params (path, page)", () => {
-    expect(getParams({ path: "/some/path/", page: 2 })).toEqual({
+    expect(parse({ path: "/some/path/", page: 2 })).toEqual({
       path: "/some/path/",
       page: 2,
       query: {}
@@ -24,7 +24,7 @@ describe("route utils - getParams", () => {
   });
   test("from params (path, page, query)", () => {
     expect(
-      getParams({
+      parse({
         path: "/some/path",
         page: 2,
         query: {
@@ -43,7 +43,7 @@ describe("route utils - getParams", () => {
   });
   test("from params (root, page, query)", () => {
     expect(
-      getParams({
+      parse({
         path: "/",
         page: 2,
         query: {
@@ -61,35 +61,35 @@ describe("route utils - getParams", () => {
     });
   });
   test("from path", () => {
-    expect(getParams("/some/path/")).toEqual({
+    expect(parse("/some/path/")).toEqual({
       path: "/some/path/",
       page: 1,
       query: {}
     });
   });
   test("from path (contains 'page')", () => {
-    expect(getParams("/some-page/page/2")).toEqual({
+    expect(parse("/some-page/page/2")).toEqual({
       path: "/some-page/",
       page: 2,
       query: {}
     });
   });
   test("from path (fixes path)", () => {
-    expect(getParams("/some/path")).toEqual({
+    expect(parse("/some/path")).toEqual({
       path: "/some/path/",
       page: 1,
       query: {}
     });
   });
   test("from path and page", () => {
-    expect(getParams("/some/path/page/2/")).toEqual({
+    expect(parse("/some/path/page/2/")).toEqual({
       path: "/some/path/",
       page: 2,
       query: {}
     });
   });
   test("from path and query", () => {
-    expect(getParams("/some/path/?k1=v1&k2=v2")).toEqual({
+    expect(parse("/some/path/?k1=v1&k2=v2")).toEqual({
       path: "/some/path/",
       page: 1,
       query: {
@@ -99,7 +99,7 @@ describe("route utils - getParams", () => {
     });
   });
   test("from path, page and query", () => {
-    expect(getParams("/some/path/page/2?k1=v1&k2=v2")).toEqual({
+    expect(parse("/some/path/page/2?k1=v1&k2=v2")).toEqual({
       path: "/some/path/",
       page: 2,
       query: {
@@ -109,21 +109,21 @@ describe("route utils - getParams", () => {
     });
   });
   test("from root path", () => {
-    expect(getParams("/")).toEqual({
+    expect(parse("/")).toEqual({
       path: "/",
       page: 1,
       query: {}
     });
   });
   test("from root path and page", () => {
-    expect(getParams("/page/2/")).toEqual({
+    expect(parse("/page/2/")).toEqual({
       path: "/",
       page: 2,
       query: {}
     });
   });
   test("from root path, page and query", () => {
-    expect(getParams("/page/2?k1=v1&k2=v2")).toEqual({
+    expect(parse("/page/2?k1=v1&k2=v2")).toEqual({
       path: "/",
       page: 2,
       query: {
@@ -133,9 +133,7 @@ describe("route utils - getParams", () => {
     });
   });
   test("from full URL", () => {
-    expect(
-      getParams("https://test.frontity.org/some/path/?k1=v1&k2=v2")
-    ).toEqual({
+    expect(parse("https://test.frontity.org/some/path/?k1=v1&k2=v2")).toEqual({
       path: "/some/path/",
       page: 1,
       query: {
@@ -145,14 +143,14 @@ describe("route utils - getParams", () => {
     });
   });
   test("from name", () => {
-    expect(getParams("custom-list")).toEqual({
+    expect(parse("custom-list")).toEqual({
       path: "custom-list/",
       page: 1,
       query: {}
     });
   });
   test("from name (page)", () => {
-    expect(getParams("custom-list/page/2")).toEqual({
+    expect(parse("custom-list/page/2")).toEqual({
       path: "custom-list/",
       page: 2,
       query: {}
@@ -160,21 +158,21 @@ describe("route utils - getParams", () => {
   });
 });
 
-describe("route utils - getRoute", () => {
+describe("route utils - stringify", () => {
   test("from params (fixes path)", () => {
-    expect(getRoute({ path: "/some/path" })).toBe("/some/path/");
+    expect(stringify({ path: "/some/path" })).toBe("/some/path/");
   });
   test("from params (path is a name)", () => {
-    expect(getRoute({ path: "custom-list" })).toBe("custom-list/");
+    expect(stringify({ path: "custom-list" })).toBe("custom-list/");
   });
   test("from params (path, page)", () => {
-    expect(getRoute({ path: "/some/path/", page: 2 })).toBe(
+    expect(stringify({ path: "/some/path/", page: 2 })).toBe(
       "/some/path/page/2/"
     );
   });
   test("from params (path, page, query)", () => {
     expect(
-      getRoute({
+      stringify({
         path: "/some/path",
         page: 2,
         query: {
@@ -186,7 +184,7 @@ describe("route utils - getRoute", () => {
   });
   test("from params (root, page, query)", () => {
     expect(
-      getRoute({
+      stringify({
         path: "/",
         page: 2,
         query: {
@@ -197,44 +195,46 @@ describe("route utils - getRoute", () => {
     ).toBe("/page/2/?k1=v1&k2=v2");
   });
   test("from path", () => {
-    expect(getRoute("/some/path/")).toBe("/some/path/");
+    expect(stringify("/some/path/")).toBe("/some/path/");
   });
   test("from path (contains 'page')", () => {
-    expect(getRoute("/some-page/")).toBe("/some-page/");
+    expect(stringify("/some-page/")).toBe("/some-page/");
   });
   test("from path (fixes path)", () => {
-    expect(getRoute("/some/path")).toBe("/some/path/");
+    expect(stringify("/some/path")).toBe("/some/path/");
   });
   test("from path and page", () => {
-    expect(getRoute("/some/path/page/2/")).toBe("/some/path/page/2/");
+    expect(stringify("/some/path/page/2/")).toBe("/some/path/page/2/");
   });
   test("from path and query", () => {
-    expect(getRoute("/some/path/?k1=v1&k2=v2")).toBe("/some/path/?k1=v1&k2=v2");
+    expect(stringify("/some/path/?k1=v1&k2=v2")).toBe(
+      "/some/path/?k1=v1&k2=v2"
+    );
   });
   test("from path, page and query", () => {
-    expect(getRoute("/some/path/page/2?k1=v1&k2=v2")).toBe(
+    expect(stringify("/some/path/page/2?k1=v1&k2=v2")).toBe(
       "/some/path/page/2/?k1=v1&k2=v2"
     );
   });
 
   test("from root path", () => {
-    expect(getRoute("/")).toEqual("/");
+    expect(stringify("/")).toEqual("/");
   });
   test("from root path and page", () => {
-    expect(getRoute("/page/2")).toEqual("/page/2/");
+    expect(stringify("/page/2")).toEqual("/page/2/");
   });
   test("from root path, page and query", () => {
-    expect(getRoute("/page/2?k1=v1&k2=v2")).toEqual("/page/2/?k1=v1&k2=v2");
+    expect(stringify("/page/2?k1=v1&k2=v2")).toEqual("/page/2/?k1=v1&k2=v2");
   });
   test("from full URL", () => {
     expect(
-      getRoute("https://test.frontity.org/some/path/page/2?k1=v1&k2=v2")
+      stringify("https://test.frontity.org/some/path/page/2?k1=v1&k2=v2")
     ).toBe("/some/path/page/2/?k1=v1&k2=v2");
   });
   test("from name", () => {
-    expect(getRoute("custom-list")).toBe("custom-list/");
+    expect(stringify("custom-list")).toBe("custom-list/");
   });
   test("from name (page)", () => {
-    expect(getRoute("custom-list/page/2/")).toBe("custom-list/page/2/");
+    expect(stringify("custom-list/page/2/")).toBe("custom-list/page/2/");
   });
 });

--- a/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
+++ b/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
@@ -1,65 +1,6 @@
-import { parse, stringify } from "../route-utils";
+import { parse, stringify, normalize } from "../route-utils";
 
 describe("route utils - parse", () => {
-  test("from params (fixes path)", () => {
-    expect(parse({ path: "/some/path" })).toEqual({
-      path: "/some/path/",
-      page: 1,
-      query: {}
-    });
-  });
-  test("from params (path is a name)", () => {
-    expect(parse({ path: "custom-list" })).toEqual({
-      path: "custom-list/",
-      page: 1,
-      query: {}
-    });
-  });
-  test("from params (path, page)", () => {
-    expect(parse({ path: "/some/path/", page: 2 })).toEqual({
-      path: "/some/path/",
-      page: 2,
-      query: {}
-    });
-  });
-  test("from params (path, page, query)", () => {
-    expect(
-      parse({
-        path: "/some/path",
-        page: 2,
-        query: {
-          k1: "v1",
-          k2: "v2"
-        }
-      })
-    ).toEqual({
-      path: "/some/path/",
-      page: 2,
-      query: {
-        k1: "v1",
-        k2: "v2"
-      }
-    });
-  });
-  test("from params (root, page, query)", () => {
-    expect(
-      parse({
-        path: "/",
-        page: 2,
-        query: {
-          k1: "v1",
-          k2: "v2"
-        }
-      })
-    ).toEqual({
-      path: "/",
-      page: 2,
-      query: {
-        k1: "v1",
-        k2: "v2"
-      }
-    });
-  });
   test("from path", () => {
     expect(parse("/some/path/")).toEqual({
       path: "/some/path/",
@@ -194,47 +135,53 @@ describe("route utils - stringify", () => {
       })
     ).toBe("/page/2/?k1=v1&k2=v2");
   });
+});
+
+describe("route utils - normalize", () => {
   test("from path", () => {
-    expect(stringify("/some/path/")).toBe("/some/path/");
+    expect(normalize("/some/path/")).toBe("/some/path/");
   });
   test("from path (contains 'page')", () => {
-    expect(stringify("/some-page/")).toBe("/some-page/");
+    expect(normalize("/some-page/")).toBe("/some-page/");
   });
   test("from path (fixes path)", () => {
-    expect(stringify("/some/path")).toBe("/some/path/");
+    expect(normalize("/some/path")).toBe("/some/path/");
   });
   test("from path and page", () => {
-    expect(stringify("/some/path/page/2/")).toBe("/some/path/page/2/");
+    expect(normalize("/some/path/page/2")).toBe("/some/path/page/2/");
   });
   test("from path and query", () => {
-    expect(stringify("/some/path/?k1=v1&k2=v2")).toBe(
-      "/some/path/?k1=v1&k2=v2"
-    );
+    expect(normalize("/some/path?k1=v1&k2=v2")).toBe("/some/path/?k1=v1&k2=v2");
   });
   test("from path, page and query", () => {
-    expect(stringify("/some/path/page/2?k1=v1&k2=v2")).toBe(
+    expect(normalize("/some/path/page/2?k1=v1&k2=v2")).toBe(
       "/some/path/page/2/?k1=v1&k2=v2"
     );
   });
 
   test("from root path", () => {
-    expect(stringify("/")).toEqual("/");
+    expect(normalize("/")).toEqual("/");
   });
   test("from root path and page", () => {
-    expect(stringify("/page/2")).toEqual("/page/2/");
+    expect(normalize("/page/2")).toEqual("/page/2/");
   });
   test("from root path, page and query", () => {
-    expect(stringify("/page/2?k1=v1&k2=v2")).toEqual("/page/2/?k1=v1&k2=v2");
+    expect(normalize("/page/2?k1=v1&k2=v2")).toEqual("/page/2/?k1=v1&k2=v2");
   });
   test("from full URL", () => {
     expect(
-      stringify("https://test.frontity.org/some/path/page/2?k1=v1&k2=v2")
+      normalize("https://test.frontity.org/some/path/page/2?k1=v1&k2=v2")
     ).toBe("/some/path/page/2/?k1=v1&k2=v2");
   });
+  test("from root URL", () => {
+    expect(normalize("https://test.frontity.org?k1=v1&k2=v2")).toBe(
+      "/?k1=v1&k2=v2"
+    );
+  });
   test("from name", () => {
-    expect(stringify("custom-list")).toBe("custom-list/");
+    expect(normalize("custom-list")).toBe("custom-list/");
   });
   test("from name (page)", () => {
-    expect(stringify("custom-list/page/2/")).toBe("custom-list/page/2/");
+    expect(normalize("custom-list/page/2/")).toBe("custom-list/page/2/");
   });
 });

--- a/packages/wp-source/src/libraries/handlers/author.ts
+++ b/packages/wp-source/src/libraries/handlers/author.ts
@@ -4,8 +4,8 @@ import getTotal from "./utils/get-total";
 import getTotalPages from "./utils/get-total-pages";
 
 const authorHandler: Handler = async (source, { route, params, libraries }) => {
-  const { api, populate, getParams } = libraries.source;
-  const { page, query } = getParams(route);
+  const { api, populate, parse } = libraries.source;
+  const { page, query } = parse(route);
 
   // 1. search id in state or get it from WP REST API
   const { slug } = params;

--- a/packages/wp-source/src/libraries/handlers/date.ts
+++ b/packages/wp-source/src/libraries/handlers/date.ts
@@ -3,8 +3,8 @@ import getTotal from "./utils/get-total";
 import getTotalPages from "./utils/get-total-pages";
 
 const dateHandler: Handler = async (source, { route, params, libraries }) => {
-  const { api, populate, getParams } = libraries.source;
-  const { page, query } = getParams(route);
+  const { api, populate, parse } = libraries.source;
+  const { page, query } = parse(route);
 
   // 1. build date properties
   const year = parseInt(params.year);

--- a/packages/wp-source/src/libraries/handlers/postArchive.ts
+++ b/packages/wp-source/src/libraries/handlers/postArchive.ts
@@ -3,8 +3,8 @@ import getTotal from "./utils/get-total";
 import getTotalPages from "./utils/get-total-pages";
 
 const postArchiveHandler: Handler = async (source, { route, libraries }) => {
-  const { api, populate, getParams } = libraries.source;
-  const { page, query } = getParams(route);
+  const { api, populate, parse } = libraries.source;
+  const { page, query } = parse(route);
 
   // 2. fetch the specified page
   const response = await api.get({

--- a/packages/wp-source/src/libraries/handlers/taxonomy.ts
+++ b/packages/wp-source/src/libraries/handlers/taxonomy.ts
@@ -14,7 +14,7 @@ const taxonomyHandler = ({
   truths?: Record<string, true>;
 }): Handler => async (source, { route, params, libraries }) => {
   const { api, populate, parse } = libraries.source;
-  const { page } = parse(route);
+  const { page, query } = parse(route);
 
   // 1. search id in state or get it from WP REST API
   const { slug } = params;
@@ -25,7 +25,7 @@ const taxonomyHandler = ({
   // 2. fetch the specified page
   const response = await api.get({
     endpoint: postType.endpoint,
-    params: { [postType.param]: id, search: params.s, page, _embed: true }
+    params: { [postType.param]: id, search: query.s, page, _embed: true }
   });
 
   // 3. throw an error if page is out of range

--- a/packages/wp-source/src/libraries/handlers/taxonomy.ts
+++ b/packages/wp-source/src/libraries/handlers/taxonomy.ts
@@ -13,8 +13,8 @@ const taxonomyHandler = ({
   props?: Record<string, string>;
   truths?: Record<string, true>;
 }): Handler => async (source, { route, params, libraries }) => {
-  const { api, populate, getParams } = libraries.source;
-  const { page } = getParams(route);
+  const { api, populate, parse } = libraries.source;
+  const { page } = parse(route);
 
   // 1. search id in state or get it from WP REST API
   const { slug } = params;

--- a/packages/wp-source/src/libraries/route-utils.ts
+++ b/packages/wp-source/src/libraries/route-utils.ts
@@ -1,28 +1,28 @@
 import { RouteParams } from "@frontity/source";
 import WpSource from "../../";
 
-export const parse: WpSource["libraries"]["source"]["parse"] = routeOrParams =>
-  typeof routeOrParams === "string"
-    ? routeToParams(routeOrParams)
-    : {
-        path: addFinalSlash(routeOrParams.path),
-        page: routeOrParams.page || 1,
-        query: routeOrParams.query || {}
-      };
+export const parse: WpSource["libraries"]["source"]["parse"] = route =>
+  routeToParams(route);
 
-export const stringify: WpSource["libraries"]["source"]["stringify"] = routeOrParams =>
-  typeof routeOrParams === "string"
-    ? normalize(routeOrParams)
-    : paramsToRoute(routeOrParams);
+export const stringify: WpSource["libraries"]["source"]["stringify"] = routeParams =>
+  paramsToRoute(routeParams);
 
-export default { parse, stringify };
+export const normalize = (route: string): string =>
+  paramsToRoute(routeToParams(route));
+
+export default { parse, stringify, normalize };
 
 // UTILS
 
 export const routeToParams = (route: string): RouteParams => {
-  route = removeDomain(route);
-
-  const [fullPath, query] = route.split("?");
+  const [
+    ,
+    fullPath,
+    query,
+    hash
+  ] = /^(?:(?:[^:/?#]+):)?(?:\/\/(?:[^/?#]*))?([^?#]*)(?:\?([^#]*))?(#.*)?/.exec(
+    route
+  );
   const [, path, page] = /^(.*)page\/(\d+)\/?(\?.*)?$/.exec(fullPath) || [
     null,
     fullPath,
@@ -32,14 +32,16 @@ export const routeToParams = (route: string): RouteParams => {
   return {
     path: addFinalSlash(path),
     page: parseInt(page, 10),
-    query: queryToObj(query)
+    query: queryToObj(query),
+    hash
   };
 };
 
 export const paramsToRoute = ({
   path = "/",
   page = 1,
-  query = {}
+  query = {},
+  hash = ""
 }: RouteParams): string => {
   // correct path
   path = addFinalSlash(path);
@@ -47,15 +49,7 @@ export const paramsToRoute = ({
   const pathAndPage = page > 1 ? `${path}page/${page}/` : path;
   const queryStr = objToQuery(query);
 
-  return `${pathAndPage}${queryStr}`;
-};
-
-export const normalize = (route: string): string =>
-  paramsToRoute(routeToParams(route));
-
-export const removeDomain = (input: string): string => {
-  const [, result] = /^(?:https?:\/\/[^\/]*)?(\/?.*)$/.exec(input);
-  return result || "/";
+  return `${pathAndPage}${queryStr}${hash}`;
 };
 
 export const addFinalSlash = (path: string): string =>

--- a/packages/wp-source/src/libraries/route-utils.ts
+++ b/packages/wp-source/src/libraries/route-utils.ts
@@ -1,7 +1,7 @@
 import { RouteParams } from "@frontity/source";
 import WpSource from "../../";
 
-export const getParams: WpSource["libraries"]["source"]["getParams"] = routeOrParams =>
+export const parse: WpSource["libraries"]["source"]["parse"] = routeOrParams =>
   typeof routeOrParams === "string"
     ? routeToParams(routeOrParams)
     : {
@@ -10,12 +10,12 @@ export const getParams: WpSource["libraries"]["source"]["getParams"] = routeOrPa
         query: routeOrParams.query || {}
       };
 
-export const getRoute: WpSource["libraries"]["source"]["getRoute"] = routeOrParams =>
+export const stringify: WpSource["libraries"]["source"]["stringify"] = routeOrParams =>
   typeof routeOrParams === "string"
     ? normalize(routeOrParams)
     : paramsToRoute(routeOrParams);
 
-export default { getParams, getRoute };
+export default { parse, stringify };
 
 // UTILS
 

--- a/packages/wp-source/src/libraries/schemas/attachments.ts
+++ b/packages/wp-source/src/libraries/schemas/attachments.ts
@@ -1,6 +1,6 @@
 import { schema } from "normalizr";
 import { author } from "./authors";
-import { removeDomain } from "../route-utils";
+import { normalize } from "../route-utils";
 
 export const attachment = new schema.Entity(
   "attachment",
@@ -12,7 +12,7 @@ export const attachment = new schema.Entity(
   {
     processStrategy(entity) {
       const result = { ...entity };
-      result.link = removeDomain(result.link);
+      result.link = normalize(result.link);
       return result;
     }
   }

--- a/packages/wp-source/src/libraries/schemas/authors.ts
+++ b/packages/wp-source/src/libraries/schemas/authors.ts
@@ -1,5 +1,5 @@
 import { schema } from "normalizr";
-import { removeDomain } from "../route-utils";
+import { normalize } from "../route-utils";
 
 export const author = new schema.Entity(
   "author",
@@ -7,7 +7,7 @@ export const author = new schema.Entity(
   {
     processStrategy(entity) {
       const result = { ...entity };
-      result.link = removeDomain(result.link);
+      result.link = normalize(result.link);
       return result;
     }
   }

--- a/packages/wp-source/src/libraries/schemas/postTypes.ts
+++ b/packages/wp-source/src/libraries/schemas/postTypes.ts
@@ -2,7 +2,7 @@ import { schema } from "normalizr";
 import { taxonomy } from "./taxonomies";
 import { author } from "./authors";
 import { attachment } from "./attachments";
-import { removeDomain } from "../route-utils";
+import { normalize } from "../route-utils";
 
 const taxonomies = new schema.Array(new schema.Array(taxonomy));
 
@@ -12,7 +12,7 @@ export const postType = new schema.Entity(
   {
     processStrategy(entity) {
       const result = { ...entity };
-      result.link = removeDomain(result.link);
+      result.link = normalize(result.link);
       return result;
     }
   }

--- a/packages/wp-source/src/libraries/schemas/taxonomies.ts
+++ b/packages/wp-source/src/libraries/schemas/taxonomies.ts
@@ -1,5 +1,5 @@
 import { schema } from "normalizr";
-import { removeDomain } from "../route-utils";
+import { normalize } from "../route-utils";
 
 export const taxonomy = new schema.Entity(
   "taxonomy",
@@ -7,7 +7,7 @@ export const taxonomy = new schema.Entity(
   {
     processStrategy(entity) {
       const result = { ...entity };
-      result.link = removeDomain(result.link);
+      result.link = normalize(result.link);
       result.taxonomy =
         result.taxonomy === "post_tag" ? "tag" : result.taxonomy;
       return result;

--- a/packages/wp-source/src/state.ts
+++ b/packages/wp-source/src/state.ts
@@ -1,9 +1,9 @@
 import WpSource from "..";
-import { getRoute } from "./libraries/route-utils";
+import { stringify } from "./libraries/route-utils";
 
 const state: WpSource["state"]["source"] = {
   get: ({ state }) => routeOrParams =>
-    state.source.data[getRoute(routeOrParams)] || {},
+    state.source.data[stringify(routeOrParams)] || {},
   data: {},
   category: {},
   tag: {},

--- a/packages/wp-source/src/state.ts
+++ b/packages/wp-source/src/state.ts
@@ -1,8 +1,8 @@
 import WpSource from "..";
-import { stringify } from "./libraries/route-utils";
+import { normalize } from "./libraries/route-utils";
 
 const state: WpSource["state"]["source"] = {
-  get: ({ state }) => link => state.source.data[stringify(link)] || {},
+  get: ({ state }) => link => state.source.data[normalize(link)] || {},
   data: {},
   category: {},
   tag: {},

--- a/packages/wp-source/src/state.ts
+++ b/packages/wp-source/src/state.ts
@@ -2,8 +2,7 @@ import WpSource from "..";
 import { stringify } from "./libraries/route-utils";
 
 const state: WpSource["state"]["source"] = {
-  get: ({ state }) => routeOrParams =>
-    state.source.data[stringify(routeOrParams)] || {},
+  get: ({ state }) => link => state.source.data[stringify(link)] || {},
   data: {},
   category: {},
   tag: {},


### PR DESCRIPTION
Summary:
- Rename `getRoute` to `stringify` and `getParams` to `parse` in `source.libraries`.
- Accept only strings in `router.set`, `source.fetch` and `source.get`.
- Get rid of `path`, `page`, `query` in `router` and add `link`.
- Rename `frontity.initial` to `frontity.initialLink` and convert it to a string.
- Adapt `mars-theme` to these changes.
- Extra: fix a bug in `taxonomy` handler.