### PR TITLE
fix(core): return 404 if HMR endpoint gets through Webpack to Frontity

### DIFF
--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -35,7 +35,7 @@ export default ({ packages }) => {
     })
   );
 
-  // Ignore HRM if not in dev mode or old browser open.
+  // Ignore HMR if not in dev mode or old browser open.
   app.use(
     get("/__webpack_hmr", ctx => {
       ctx.status = 404;

--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -35,6 +35,14 @@ export default ({ packages }) => {
     })
   );
 
+  // Ignore HRM if not in dev mode or old browser open.
+  app.use(
+    get("/__webpack_hmr", ctx => {
+      ctx.status = 404;
+      ctx.body = "";
+    })
+  );
+
   // Return Frontity favicon for favicon.ico.
   app.use(get("/favicon.ico", serve("./")));
 


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

Fixes https://github.com/frontity/frontity/issues/141.

#### Description of what you did:

When you switch from `dev` to `build && serve` and leave an open browser, it tries to connect to `/__webpack_hmr` for HMR and that results in an error in the console.

This PR adds an ignore for that url.

#### My PR is a:

- [x] 🐞 Bug fix
- [ ] 🚀 New feature
- [ ] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress
