### PR TITLE
refactor(redirections): allow to execute several followed redirects in priority order

### DIFF
--- a/packages/wp-source/index.ts
+++ b/packages/wp-source/index.ts
@@ -8,6 +8,7 @@ export type Pattern<F extends Function = (params: any) => any> = {
   priority: number;
   pattern: string;
   func: F;
+  isRequired?: boolean;
 };
 
 export type Handler = (args: {

--- a/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
+++ b/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
@@ -40,13 +40,13 @@ Array [
     "func": [Function],
     "name": "category base",
     "pattern": "/wp-cat/:subpath+/",
-    "priority": 10,
+    "priority": 20,
   },
   Object {
     "func": [Function],
-    "name": "category base (reverse)",
+    "name": "ignore default category base",
     "pattern": "/category/(.*)/",
-    "priority": 10,
+    "priority": 20,
   },
 ]
 `;
@@ -57,13 +57,13 @@ Array [
     "func": [Function],
     "name": "tag base",
     "pattern": "/wp-tag/:subpath+/",
-    "priority": 10,
+    "priority": 20,
   },
   Object {
     "func": [Function],
-    "name": "tag base (reverse)",
+    "name": "ignore default tag base",
     "pattern": "/tag/(.*)/",
-    "priority": 10,
+    "priority": 20,
   },
 ]
 `;
@@ -74,7 +74,7 @@ Array [
     "func": [Function],
     "name": "homepage",
     "pattern": "/",
-    "priority": 10,
+    "priority": 20,
   },
 ]
 `;
@@ -85,7 +85,7 @@ Array [
     "func": [Function],
     "name": "posts page",
     "pattern": "/all-posts/",
-    "priority": 10,
+    "priority": 20,
   },
 ]
 `;
@@ -94,51 +94,51 @@ exports[`init should add redirect if 'subirectory' is present 1`] = `
 Array [
   Object {
     "func": [Function],
-    "name": "homepage",
-    "pattern": "/blog/",
-    "priority": 10,
-  },
-  Object {
-    "func": [Function],
-    "name": "posts page",
-    "pattern": "/blog/all-posts/",
-    "priority": 10,
-  },
-  Object {
-    "func": [Function],
-    "name": "category base",
-    "pattern": "/blog/wp-cat/:subpath+/",
-    "priority": 10,
-  },
-  Object {
-    "func": [Function],
-    "name": "category base (reverse)",
-    "pattern": "/blog/category/(.*)/",
-    "priority": 10,
-  },
-  Object {
-    "func": [Function],
-    "name": "tag base",
-    "pattern": "/blog/wp-tag/:subpath+/",
-    "priority": 10,
-  },
-  Object {
-    "func": [Function],
-    "name": "tag base (reverse)",
-    "pattern": "/blog/tag/(.*)/",
-    "priority": 10,
-  },
-  Object {
-    "func": [Function],
     "name": "subdirectory",
     "pattern": "/blog/:subpath*/",
     "priority": 10,
   },
   Object {
     "func": [Function],
-    "name": "subdirectory (reverse)",
+    "name": "ignore root",
     "pattern": "/(.*)",
     "priority": 10,
+  },
+  Object {
+    "func": [Function],
+    "name": "homepage",
+    "pattern": "/",
+    "priority": 20,
+  },
+  Object {
+    "func": [Function],
+    "name": "posts page",
+    "pattern": "/all-posts/",
+    "priority": 20,
+  },
+  Object {
+    "func": [Function],
+    "name": "category base",
+    "pattern": "/wp-cat/:subpath+/",
+    "priority": 20,
+  },
+  Object {
+    "func": [Function],
+    "name": "ignore default category base",
+    "pattern": "/category/(.*)/",
+    "priority": 20,
+  },
+  Object {
+    "func": [Function],
+    "name": "tag base",
+    "pattern": "/wp-tag/:subpath+/",
+    "priority": 20,
+  },
+  Object {
+    "func": [Function],
+    "name": "ignore default tag base",
+    "pattern": "/tag/(.*)/",
+    "priority": 20,
   },
 ]
 `;

--- a/packages/wp-source/src/libraries/__tests__/redirections.tests.ts
+++ b/packages/wp-source/src/libraries/__tests__/redirections.tests.ts
@@ -1,53 +1,41 @@
-import { getMatch } from "../get-match";
-
-// Some redirections
-const redirections: {
-  name: string;
-  priority: number;
-  pattern: string;
-  func: (params: Record<string, string>) => string;
-}[] = [
-  {
-    name: "",
-    priority: 10,
-    pattern: "/",
-    func: () => "/about-us/"
-  },
-  {
-    name: "",
-    priority: 10,
-    pattern: "/posts/",
-    func: () => "/"
-  },
-  {
-    name: "",
-    priority: 10,
-    pattern: "/wp-cat/:subpath+",
-    func: ({ subpath }) => `/category/${subpath}/`
-  },
-  {
-    name: "",
-    priority: 10,
-    pattern: "/category/(.*)",
-    func: () => ""
-  },
-  {
-    name: "",
-    priority: 10,
-    pattern: "/blog/:subpath*/",
-    func: ({ subpath = "" }) => `/${subpath}${subpath ? "/" : ""}`
-  }
-];
-
-const redirect = (path, redirections) => {
-  const match = getMatch(path, redirections);
-  if (!match) return path;
-  return match.func(match.params);
-};
+import { redirect } from "../redirect";
 
 // Add redirects
-describe("getMatch", () => {
-  test("redirects different routes", async () => {
+describe("redirect", () => {
+  test("redirects different routes (same priority)", () => {
+    // Some redirections
+    const redirections: {
+      name: string;
+      priority: number;
+      pattern: string;
+      func: (params: Record<string, string>) => string;
+    }[] = [
+      {
+        name: "",
+        priority: 10,
+        pattern: "/",
+        func: () => "/about-us/"
+      },
+      {
+        name: "",
+        priority: 10,
+        pattern: "/posts/",
+        func: () => "/"
+      },
+      {
+        name: "",
+        priority: 10,
+        pattern: "/wp-cat/:subpath+",
+        func: ({ subpath }) => `/category/${subpath}/`
+      },
+      {
+        name: "",
+        priority: 10,
+        pattern: "/category/(.*)",
+        func: () => ""
+      }
+    ];
+
     expect(redirect("/", redirections)).toBe("/about-us/");
     expect(redirect("/about-us/", redirections)).toBe("/about-us/");
     expect(redirect("/posts/", redirections)).toBe("/");
@@ -56,7 +44,68 @@ describe("getMatch", () => {
       "/category/nature/forests/"
     );
     expect(redirect("/category/nature", redirections)).toBe("");
-    expect(redirect("/blog/", redirections)).toBe("/");
-    expect(redirect("/blog/some-post/", redirections)).toBe("/some-post/");
+  });
+
+  test("executes redirections in priority order", () => {
+    // Some redirections
+    const redirections: {
+      name: string;
+      priority: number;
+      pattern: string;
+      func: (params: Record<string, string>) => string;
+    }[] = [
+      {
+        name: "",
+        priority: 0,
+        pattern: "/:mainpath+/amp/",
+        func: ({ mainpath }) => `/${mainpath}/`
+      },
+      {
+        name: "",
+        priority: 0,
+        pattern: "/(.*)",
+        func: () => ""
+      },
+      {
+        name: "",
+        priority: 10,
+        pattern: "/subdir/:subpath*",
+        func: ({ subpath }) => (subpath ? `/${subpath}/` : "/")
+      },
+      {
+        name: "",
+        priority: 10,
+        pattern: "/(.*)",
+        func: () => ""
+      },
+      {
+        name: "",
+        priority: 20,
+        pattern: "/wp-cat/:subpath+",
+        func: ({ subpath }) => `/category/${subpath}/`
+      },
+      {
+        name: "",
+        priority: 20,
+        pattern: "/category/(.*)",
+        func: () => ""
+      }
+    ];
+    expect(redirect("/", redirections)).toBe("");
+    expect(redirect("/posts/", redirections)).toBe("");
+    expect(redirect("/subdir/", redirections)).toBe("");
+    expect(redirect("/amp/", redirections)).toBe("");
+    expect(redirect("/subdir/amp/", redirections)).toBe("/");
+    expect(redirect("/subdir/posts/amp/", redirections)).toBe("/posts/");
+    expect(
+      redirect("/subdir/the-beauties-of-gullfoss/amp/", redirections)
+    ).toBe("/the-beauties-of-gullfoss/");
+    expect(redirect("/subdir/wp-cat/nature/amp/", redirections)).toBe(
+      "/category/nature/"
+    );
+    expect(redirect("/subdir/wp-cat/nature/forests/amp/", redirections)).toBe(
+      "/category/nature/forests/"
+    );
+    expect(redirect("/subdir/category/nature/amp/", redirections)).toBe("");
   });
 });

--- a/packages/wp-source/src/libraries/get-match.ts
+++ b/packages/wp-source/src/libraries/get-match.ts
@@ -3,7 +3,7 @@ import pathToRegexp, { Key } from "path-to-regexp";
 
 type GetMatch = <T extends Pattern>(
   path: string,
-  list: T[]
+  patternOrList: T | T[]
 ) => {
   params: Record<string, string>;
   func: T["func"];
@@ -14,7 +14,8 @@ type ExecMatch = (
   match: { regexp: RegExp; keys: Key[] }
 ) => Record<string, string>;
 
-export const getMatch: GetMatch = (path, list) => {
+export const getMatch: GetMatch = (path, patternOrList) => {
+  const list = patternOrList instanceof Array ? patternOrList : [patternOrList];
   const result = list
     .sort(({ priority: p1 }, { priority: p2 }) => p1 - p2)
     .map(({ name, priority, pattern, func }) => {

--- a/packages/wp-source/src/libraries/redirect.ts
+++ b/packages/wp-source/src/libraries/redirect.ts
@@ -9,7 +9,7 @@ export const redirect = (
   redirections.sort(({ priority: p1 }, { priority: p2 }) => p1 - p2);
 
   // apply redirections in order
-  let lastPriority = 0;
+  let lastPriority = -1;
   for (let redirect of redirections) {
     const match = getMatch(path, redirect);
     if (match && redirect.priority > lastPriority) {

--- a/packages/wp-source/src/libraries/redirect.ts
+++ b/packages/wp-source/src/libraries/redirect.ts
@@ -1,0 +1,23 @@
+import { getMatch } from "./get-match";
+import WpSource from "../..";
+
+export const redirect = (
+  path: string,
+  redirections: WpSource["libraries"]["source"]["redirections"]
+) => {
+  // sort redirections
+  redirections.sort(({ priority: p1 }, { priority: p2 }) => p1 - p2);
+
+  // apply redirections in order
+  let lastPriority = 0;
+  for (let redirect of redirections) {
+    const match = getMatch(path, redirect);
+    if (match && redirect.priority > lastPriority) {
+      // update path
+      lastPriority = redirect.priority;
+      path = match.func(match.params);
+    }
+  }
+
+  return path;
+};


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

The idea of this PR was to execute redirections sequentially in order to transform a route. For example, given the following route

```/blog/wp-tag/nature/```

instead of creating a redirection like

```javascript
const redirect = {
  name: "change-tag-route",
  priority: 10,
  pattern: "/blog/wp-tag/:slug/amp/",
  handler: ({ slug )} => `/tag/${slug}`
}
```

be able to use three redirections like

```javascript
const redirections = [
  {
    name: "remove-subdir",
    priority: 10,
    pattern: "/blog/:route+",
    handler: ({ route )} => `/${route}`
  },
  {
    name: "remove-amp-suffix",
    priority: 20,
    pattern: "/:route+/amp/",
    handler: ({ route )} => `/${route}`
  },
  {
    name: "change-tag-base",
    priority: 30,
    pattern: "/wp-tag/:slug/",
    handler: ({ slug )} => `/tag/${slug}`
  }
]
```

This approach, although it makes it more direct to create redirects based on settings, has shown to have problems, for example, when you want some routes to be ignored because they start with the wrong prefix (and thus should return `404`).

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 🐞 Bug fix
- [ ] 🚀 New feature
- [x] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress
