### PR TITLE
chore(types): change types dev dependencies for dependencies

### DIFF
--- a/packages/tiny-router/package.json
+++ b/packages/tiny-router/package.json
@@ -24,11 +24,11 @@
     "access": "public"
   },
   "dependencies": {
+    "@frontity/router": "^1.0.11",
+    "@frontity/source": "^1.0.10",
     "frontity": "^1.2.1"
   },
   "devDependencies": {
-    "@frontity/router": "^1.0.11",
-    "@frontity/source": "^1.0.10",
     "@types/jest": "^24.0.11",
     "jest": "^24.7.1",
     "ts-jest": "^24.0.2",

--- a/packages/wp-source/package.json
+++ b/packages/wp-source/package.json
@@ -24,8 +24,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@frontity/connect": "^1.0.1",
-    "@frontity/source": "^1.0.10",
     "@types/jest": "^24.0.11",
     "frontity": "^1.2.1",
     "jest": "^24.7.1",
@@ -33,6 +31,8 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
+    "@frontity/connect": "^1.0.1",
+    "@frontity/source": "^1.0.10",
     "cross-fetch": "^3.0.2",
     "normalizr": "^3.3.0",
     "path-to-regexp": "^3.0.0"


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 🐞 Bug fix
- [ ] 🚀 New feature
- [ ] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress

#### What did I do?

I moved the types dependencies that are currently dev dependencies to normal dependencies so they are installed in `node_modules` when creating a new project.