### PR TITLE
fix(yoast): do not use canonical from yoast_meta

### DIFF
--- a/packages/yoast/src/state/index.ts
+++ b/packages/yoast/src/state/index.ts
@@ -1,5 +1,5 @@
 import Yoast from "../../types";
-import { getEntity, getSocialDefaults } from "./utils";
+import { getEntity, getSocialDefaults, getPathname } from "./utils";
 import {
   homeTitle,
   entityTitle,
@@ -71,24 +71,13 @@ const state: Yoast["state"]["yoast"] = {
    * @param state Frontity state
    * @returns Current route's canonical link
    */
-  canonical: ({ state }) => {
-    const data = state.source.get(state.router.link);
-    const entity = getEntity({ state, data });
-
-    const defaultCanonical = `${state.frontity.url}${state.router.link}`;
-
-    if (!entity) return defaultCanonical;
-
-    const yoastCanonical =
-      entity.yoast_meta && entity.yoast_meta.yoast_wpseo_canonical;
-
-    return yoastCanonical || defaultCanonical;
-  },
+  canonical: ({ state }) =>
+    `${state.frontity.url}${getPathname(state.router.link)}`,
 
   /**
    * Derived value that shows the featured image's URL (if link is a post)
    * @param state Frontity state
-   * @returns Current route's canonical link
+   * @returns Current route's featured image URL
    */
   image: ({ state }) => {
     const data = state.source.get(state.router.link);

--- a/packages/yoast/src/state/titles.ts
+++ b/packages/yoast/src/state/titles.ts
@@ -1,7 +1,7 @@
 import { State } from "frontity/types";
 import { Data, Author } from "@frontity/source";
 import humanize from "string-humanize";
-import Yoast, { YoastMeta } from "../../types";
+import Yoast from "../../types";
 import { getEntity, appendPage, getPage, hasName } from "./utils";
 
 export const dateTitle = ({

--- a/packages/yoast/src/state/utils.ts
+++ b/packages/yoast/src/state/utils.ts
@@ -37,17 +37,18 @@ export const getSocialDefaults = ({ state }): YoastSocialDefaults => {
   return {};
 };
 
-export const getPage = route => {
-  // get pathname from route
+export const getPathname = route => {
   const [, pathname] = /^(?:(?:[^:/?#]+):)?(?:\/\/(?:[^/?#]*))?([^?#]*)/.exec(
     route
   );
+  return pathname;
+};
 
-  const [, page] = /^(?:.*)page\/(\d+)\/?(\?.*)?$/.exec(pathname) || [
+export const getPage = route => {
+  const [, page] = /^(?:.*)page\/(\d+)\/?(\?.*)?$/.exec(getPathname(route)) || [
     null,
     "1"
   ];
-
   return parseInt(page, 10);
 };
 


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

Use `state.router.link` instead of `yoast_meta.yoast_wpseo_canonical` to get the canonical URL. 

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 🐞 Bug fix
- [ ] 🚀 New feature
- [ ] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress
