### PR TITLE
fix(yoast): add gracefull fail for missing yoast WP plugin

### DIFF
--- a/packages/yoast/src/state/utils.ts
+++ b/packages/yoast/src/state/utils.ts
@@ -31,8 +31,14 @@ export const getSocialDefaults = ({ state }): YoastSocialDefaults => {
   if (data.isArchive) ({ type, id } = data.items[0]);
   if (data.isPostType) ({ type, id } = data);
 
-  if (type && id)
+  if (type && id) {
+    if (!state.source[type][id].yoast_meta) {
+      throw new Error(
+        `https://github.com/maru3l/wp-api-yoast-meta plugin is missing from WordPress installation`
+      );
+    }
     return state.source[type][id].yoast_meta.yoast_wpseo_social_defaults;
+  }
 
   return {};
 };


### PR DESCRIPTION
closes: #164 

#### Description:
Throw error to fail gracefully if required yoast plugin https://github.com/maru3l/wp-api-yoast-meta  is missing form WordPress installation.

#### My PR is a:

- [x] 🐞 Bug fix
- [ ] 🚀 New feature
- [ ] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress
