### PR TITLE
Use pattern generation instead of redirections

### DIFF
--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -53,17 +53,9 @@ const actions: WpSource["actions"]["source"] = {
   },
 
   init: ({ state, libraries }) => {
-    const { api, isWpCom } = state.source;
-
-    libraries.source.api.init({ api, isWpCom });
-
-    // handlers & redirections:
-    const { handlers, redirections } = libraries.source;
-
-    const patterns = isWpCom ? wpCom : wpOrg;
-    handlers.push(...patterns);
-
     const {
+      api,
+      isWpCom,
       subdirectory,
       homepage,
       postsPage,
@@ -71,79 +63,89 @@ const actions: WpSource["actions"]["source"] = {
       tagBase
     } = state.source;
 
-    if (homepage) {
-      const pattern = concatPath(subdirectory);
-      redirections.push({
-        name: "homepage",
-        priority: 10,
-        pattern,
-        func: () => concatPath(homepage)
-      });
-    }
+    libraries.source.api.init({ api, isWpCom });
 
-    if (postsPage) {
-      const pattern = concatPath(subdirectory, postsPage);
-      redirections.push({
-        name: "posts page",
-        priority: 10,
-        pattern,
-        func: () => "/"
-      });
-    }
+    // handlers & redirections:
+    const { handlers, redirections } = libraries.source;
 
-    if (categoryBase) {
-      // add new direction
-      const pattern = concatPath(subdirectory, categoryBase, "/:subpath+");
-      redirections.push({
-        name: "category base",
-        priority: 10,
-        pattern,
-        func: ({ subpath }) => `/category/${subpath}/`
-      });
-      // remove old direction
-      redirections.push({
-        name: "category base (reverse)",
-        priority: 10,
-        pattern: concatPath(subdirectory, "/category/(.*)/"),
-        func: () => ""
-      });
-    }
+    const patterns = isWpCom
+      ? wpCom
+      : wpOrg({ subdirectory, homepage, postsPage, categoryBase, tagBase });
+    handlers.push(...patterns);
 
-    if (tagBase) {
-      // add new direction
-      const pattern = concatPath(subdirectory, tagBase, "/:subpath+");
-      redirections.push({
-        name: "tag base",
-        priority: 10,
-        pattern,
-        func: ({ subpath }) => `/tag/${subpath}/`
-      });
-      // remove old direction
-      redirections.push({
-        name: "tag base (reverse)",
-        priority: 10,
-        pattern: concatPath(subdirectory, "/tag/(.*)/"),
-        func: () => ""
-      });
-    }
+    // if (homepage) {
+    //   const pattern = concatPath(subdirectory);
+    //   redirections.push({
+    //     name: "homepage",
+    //     priority: 10,
+    //     pattern,
+    //     func: () => concatPath(homepage)
+    //   });
+    // }
 
-    if (subdirectory) {
-      // add new direction
-      const pattern = concatPath(subdirectory, "/:subpath*");
-      redirections.push({
-        name: "subdirectory",
-        priority: 10,
-        pattern,
-        func: ({ subpath = "" }) => `/${subpath}${subpath ? "/" : ""}`
-      });
-      // remove old direction
-      redirections.push({
-        name: "subdirectory (reverse)",
-        priority: 10,
-        pattern: "/(.*)",
-        func: () => ""
-      });
-    }
+    // if (postsPage) {
+    //   const pattern = concatPath(subdirectory, postsPage);
+    //   redirections.push({
+    //     name: "posts page",
+    //     priority: 10,
+    //     pattern,
+    //     func: () => "/"
+    //   });
+    // }
+
+    // if (categoryBase) {
+    //   // add new direction
+    //   const pattern = concatPath(subdirectory, categoryBase, "/:subpath+");
+    //   redirections.push({
+    //     name: "category base",
+    //     priority: 10,
+    //     pattern,
+    //     func: ({ subpath }) => `/category/${subpath}/`
+    //   });
+    //   // remove old direction
+    //   redirections.push({
+    //     name: "category base (reverse)",
+    //     priority: 10,
+    //     pattern: concatPath(subdirectory, "/category/(.*)/"),
+    //     func: () => ""
+    //   });
+    // }
+
+    // if (tagBase) {
+    //   // add new direction
+    //   const pattern = concatPath(subdirectory, tagBase, "/:subpath+");
+    //   redirections.push({
+    //     name: "tag base",
+    //     priority: 10,
+    //     pattern,
+    //     func: ({ subpath }) => `/tag/${subpath}/`
+    //   });
+    //   // remove old direction
+    //   redirections.push({
+    //     name: "tag base (reverse)",
+    //     priority: 10,
+    //     pattern: concatPath(subdirectory, "/tag/(.*)/"),
+    //     func: () => ""
+    //   });
+    // }
+
+    // if (subdirectory) {
+    //   // add new direction
+    //   const pattern = concatPath(subdirectory, "/:subpath*");
+    //   redirections.push({
+    //     name: "subdirectory",
+    //     priority: 10,
+    //     pattern,
+    //     func: ({ subpath = "" }) => `/${subpath}${subpath ? "/" : ""}`
+    //   });
+    //   // remove old direction
+    //   redirections.push({
+    //     name: "subdirectory (reverse)",
+    //     priority: 10,
+    //     pattern: "/(.*)",
+    //     func: () => ""
+    //   });
+    // }
   }
 };
 export default actions;

--- a/packages/wp-source/src/libraries/patterns/wp-org.ts
+++ b/packages/wp-source/src/libraries/patterns/wp-org.ts
@@ -1,3 +1,5 @@
+import WpSource from "../../..";
+import { concatPath } from "../route-utils";
 import {
   postArchive,
   category,
@@ -6,92 +8,133 @@ import {
   date,
   post,
   attachment,
-  postType
+  postType,
+  page
 } from "../handlers";
 
-export default [
-  {
-    name: "post archive",
-    priority: 10,
-    pattern: "/",
-    func: postArchive
-  },
-  {
-    name: "category",
-    priority: 20,
-    pattern: "/category/:slug",
-    func: category
-  },
-  {
-    name: "subcategory",
-    priority: 20,
-    pattern: "/category/(.*)/:slug", // subcategories
-    func: category
-  },
-  {
-    name: "tag",
-    priority: 20,
-    pattern: "/tag/:slug",
-    func: tag
-  },
-  {
-    name: "author",
-    priority: 20,
-    pattern: "/author/:slug",
-    func: author
-  },
-  {
-    name: "date",
-    priority: 20,
-    pattern: "/:year(\\d+)/:month(\\d+)?/:day(\\d+)?",
-    func: date
-  },
-  {
-    name: "post by day",
-    priority: 30,
-    pattern: "/:year(\\d+)/:month(\\d+)/:day(\\d+)/:slug", // day & name
-    func: post
-  },
-  {
-    name: "post by month",
-    priority: 40,
-    pattern: "/:year(\\d+)/:month(\\d+)/:slug", // month & name
-    func: post
-  },
-  {
-    name: "post by id",
-    priority: 50,
-    pattern: "/archives/:id", // numeric
-    func: post
-  },
-  {
-    name: "attachment from post by day",
-    priority: 60,
-    pattern: "/:year(\\d+)/:month(\\d+)/:day(\\d+)/:postSlug/:slug", // day & name
-    func: attachment
-  },
-  {
-    name: "attachment from post by month",
-    priority: 70,
-    pattern: "/:year(\\d+)/:month(\\d+)/:postSlug/:slug", // month & name
-    func: attachment
-  },
-  {
-    name: "attachment from post by id",
-    priority: 80,
-    pattern: "/archives/:postId/:slug", // numeric
-    func: attachment
-  },
-  {
-    name: "post type",
-    priority: 90,
-    pattern: "/:slug", // post or page or attachment
-    func: postType
-  },
-  {
-    name: "sub post type",
-    priority: 90,
-    pattern: "/(.*)/:slug", // page or attachment
-    func: postType
+const wpOrgHandlers = ({
+  subdirectory,
+  homepage,
+  postsPage,
+  categoryBase,
+  tagBase
+}: {
+  subdirectory: string;
+  homepage: string;
+  postsPage: string;
+  categoryBase: string;
+  tagBase: string;
+}): WpSource["libraries"]["source"]["handlers"] => {
+  const handlers = [
+    {
+      name: "post archive",
+      priority: 10,
+      pattern: concatPath(subdirectory, postsPage),
+      func: postArchive
+    },
+    {
+      name: "category",
+      priority: 20,
+      pattern: concatPath(subdirectory, categoryBase, ":slug"),
+      func: category
+    },
+    {
+      name: "subcategory",
+      priority: 20,
+      pattern: concatPath(subdirectory, categoryBase, "/(.*)/:slug"), // subcategories
+      func: category
+    },
+    {
+      name: "tag",
+      priority: 20,
+      pattern: concatPath(subdirectory, tagBase, ":slug"),
+      func: tag
+    },
+    {
+      name: "author",
+      priority: 20,
+      pattern: concatPath(subdirectory, "/author/:slug"),
+      func: author
+    },
+    {
+      name: "date",
+      priority: 20,
+      pattern: concatPath(
+        subdirectory,
+        "/:year(\\d+)/:month(\\d+)?/:day(\\d+)?"
+      ),
+      func: date
+    },
+    {
+      name: "post by day",
+      priority: 30,
+      pattern: concatPath(
+        subdirectory,
+        "/:year(\\d+)/:month(\\d+)/:day(\\d+)/:slug"
+      ), // day & name
+      func: post
+    },
+    {
+      name: "post by month",
+      priority: 40,
+      pattern: concatPath(subdirectory, "/:year(\\d+)/:month(\\d+)/:slug"), // month & name
+      func: post
+    },
+    {
+      name: "post by id",
+      priority: 50,
+      pattern: concatPath(subdirectory, "/archives/:id"), // numeric
+      func: post
+    },
+    {
+      name: "attachment from post by day",
+      priority: 60,
+      pattern: concatPath(
+        subdirectory,
+        "/:year(\\d+)/:month(\\d+)/:day(\\d+)/:postSlug/:slug"
+      ), // day & name
+      func: attachment
+    },
+    {
+      name: "attachment from post by month",
+      priority: 70,
+      pattern: concatPath(
+        subdirectory,
+        "/:year(\\d+)/:month(\\d+)/:postSlug/:slug"
+      ), // month & name
+      func: attachment
+    },
+    {
+      name: "attachment from post by id",
+      priority: 80,
+      pattern: concatPath(subdirectory, "/archives/:postId/:slug"), // numeric
+      func: attachment
+    },
+    {
+      name: "post type",
+      priority: 90,
+      pattern: concatPath(subdirectory, "/:slug"), // post or page or attachment
+      func: postType
+    },
+    {
+      name: "sub post type",
+      priority: 90,
+      pattern: concatPath(subdirectory, "/(.*)/:slug"), // page or attachment
+      func: postType
+    }
+  ];
+
+  // add homepage
+  if (homepage) {
+    handlers.push({
+      name: "homepage",
+      priority: 10,
+      pattern: concatPath(subdirectory, homepage),
+      func: args => page({ ...args, params: { slug: homepage } })
+    });
   }
-];
+
+  return handlers;
+};
+
+export default wpOrgHandlers;

--- a/packages/wp-source/src/state.ts
+++ b/packages/wp-source/src/state.ts
@@ -22,8 +22,8 @@ const state: WpSource["state"]["source"] = {
   subdirectory: "",
   homepage: "",
   postsPage: "",
-  categoryBase: "",
-  tagBase: ""
+  categoryBase: "category",
+  tagBase: "tag"
 };
 
 export default state;


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

Use `wp-source` settings to modify handler patterns instead of create redirections.

For example, is `state.source.tagBase` is set to `wp-tag`, then change the tag handler pattern to start with `"/wp-tag/"` instead of `"/tag/"`, and not use redirects for those cases.

#### My PR is a:

- 🔝 Improvement

#### Is the PR ready to be merged?

- ❌ No!
