### PR TITLE
feat(core): make localhost wait for webpack to avoid returning an error

### DIFF
--- a/packages/core/src/scripts/utils/create-app.ts
+++ b/packages/core/src/scripts/utils/create-app.ts
@@ -27,17 +27,33 @@ export default async ({
   let clientFinished = false;
   let serverFinished = false;
   let isListening = false;
+
+  const url = `${isHttps ? "https" : "http"}://localhost:${port}`;
+
+  app.use((_, ___, next) => {
+    if (!isListening) {
+      const interval = setInterval(() => {
+        if (isListening) {
+          clearInterval(interval);
+          next();
+        }
+      }, 1000);
+    } else {
+      next();
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(
+      `\n\nSERVER STARTED -- Listening @ ${url}\n  - mode: ${mode}\n  - target: ${target}\n\n`
+    );
+  });
+
+  open(`${isHttps ? "https" : "http"}://localhost:${port}`);
+
   const start = () => {
     if (clientFinished && serverFinished && !isListening) {
       isListening = true;
-      server.listen(port, () => {
-        console.log(
-          `\n\nSERVER STARTED -- Listening @ ${
-            isHttps ? "https" : "http"
-          }://localhost:${port}\n  - mode: ${mode}\n  - target: ${target}`
-        );
-      });
-      open(`${isHttps ? "https" : "http"}://localhost:${port}`);
     }
   };
   // Check if webpack has finished (both the client and server bundles).


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

Now, in development mode, express waits until webpack has finished bundling everything. Previously it returned an error and people had to refresh the page.

#### My PR is a:

- [ ] 🐞 Bug fix
- [ ] 🚀 New feature
- [x] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress
