### PR TITLE
fix(wp-source): do not set `isHome` in `postArchive` handler

### DIFF
--- a/packages/wp-source/src/libraries/handlers/postArchive.ts
+++ b/packages/wp-source/src/libraries/handlers/postArchive.ts
@@ -29,8 +29,7 @@ const postArchiveHandler: Handler = async ({ route, state, libraries }) => {
     totalPages,
     isArchive: true,
     isPostTypeArchive: true,
-    isPostArchive: true,
-    isHome: false
+    isPostArchive: true
   });
 };
 

--- a/packages/wp-source/src/libraries/handlers/postArchive.ts
+++ b/packages/wp-source/src/libraries/handlers/postArchive.ts
@@ -30,7 +30,7 @@ const postArchiveHandler: Handler = async ({ route, state, libraries }) => {
     isArchive: true,
     isPostTypeArchive: true,
     isPostArchive: true,
-    isHome: true
+    isHome: false
   });
 };
 


### PR DESCRIPTION
Fixes an issue with Custom Homepage content merging with Posts Page!

<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

Fixes #178.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 🐞 Bug fix
- [ ] 🚀 New feature
- [ ] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress
