### PR TITLE
fix(webpack): add support for images in Windows

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "pre-commit": "lint-staged && NODE_ENV=test npm run test",
-    "pre-push": "NODE_ENV=test npm run test:push"
+    "pre-commit": "lint-staged && cross-env NODE_ENV=test npm run test",
+    "pre-push": "cross-env NODE_ENV=test npm run test:push"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,6 +2186,15 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cross-env": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz",
+      "integrity": "sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
+    "cross-env": "^5.2.1",
     "eslint": "^6.2.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.15.2",

--- a/packages/core/src/config/webpack/modules.ts
+++ b/packages/core/src/config/webpack/modules.ts
@@ -47,7 +47,7 @@ export default ({
             loader: "file-loader",
             options: {
               name(file) {
-                const filename = /([^\/]+)\.(?:png|jpe?g|gif|svg)$/.exec(
+                const filename = /([^\/\\]+)\.(?:png|jpe?g|gif|svg)$/.exec(
                   file
                 ) || [, "image"];
                 return mode === "development"

--- a/packages/frontity/src/functions/create/__tests__/steps.tests.ts
+++ b/packages/frontity/src/functions/create/__tests__/steps.tests.ts
@@ -11,11 +11,13 @@ import {
 import * as utils from "../../../utils";
 import * as fsExtra from "fs-extra";
 import * as fetch from "node-fetch";
+import * as path from "path";
 import * as childProcess from "child_process";
 import * as tar from "tar";
 
 jest.mock("../../../utils");
 jest.mock("fs-extra");
+jest.mock("path");
 jest.mock("node-fetch");
 jest.mock("child_process");
 jest.mock("tar");
@@ -23,8 +25,13 @@ jest.mock("tar");
 const mockedUtils = utils as jest.Mocked<typeof utils>;
 const mockedFsExtra = fsExtra as jest.Mocked<typeof fsExtra>;
 const mockedFetch = fetch as jest.Mocked<typeof fetch>;
+const mockedPath = path as jest.Mocked<typeof path>;
 const mockedChildProcess = childProcess as jest.Mocked<typeof childProcess>;
 const mockedTar = tar as jest.Mocked<typeof tar>;
+
+beforeEach(() => {
+  mockedPath.resolve.mockImplementation((...dirs) => dirs.join("/").replace("./", ""));
+})
 
 describe("normalizeOptions", () => {
   beforeEach(() => {


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

I fixed the regexp of the images file name to take into account Windows paths as well `\`.

I also fixed husky and some tests of the frontity cli to pass on Windows and be able to push changes.

Fixes https://github.com/frontity/frontity/issues/189.

#### My PR is a:

- [x] 🐞 Bug fix
- [ ] 🚀 New feature
- [ ] 🔝 Improvement

#### Main update on the:

- [ ] Documentation
- [x] Framework

#### Is the PR ready to be merged?

- [x] Yes!
- [ ] Work in progress
