### PR TITLE
Improve mars-theme (comments, examples...)

### DIFF
--- a/packages/mars-theme/src/components/index.js
+++ b/packages/mars-theme/src/components/index.js
@@ -7,6 +7,44 @@ import Page404 from "./page404.js";
 import Loading from "./loading";
 import Title from "./title";
 
+// Theme is the root React component of our theme. The one we will export
+// in roots.
+const Theme = ({ state }) => {
+  // Get information about the current URL.
+  const data = state.source.get(state.router.link);
+
+  return (
+    <>
+      {/* Add some metatags to the <head> of the HTML. */}
+      <Title />
+      <Head>
+        <meta name="description" content={state.frontity.description} />
+        <html lang="en" />
+      </Head>
+
+      {/* Add some global styles for the whole site, like body or a's. 
+      Not classes here because we use CSS-in-JS. Only global HTML tags. */}
+      <Global styles={globalStyles} />
+
+      {/* Add the header of the site. */}
+      <HeadContainer>
+        <Header />
+      </HeadContainer>
+
+      {/* Add the main section. It renders a different component depending
+      on the type of URL we are in. */}
+      <Main>
+        {(data.isFetching && <Loading />) ||
+          (data.isArchive && <List />) ||
+          (data.isPostType && <Post />) ||
+          (data.is404 && <Page404 />)}
+      </Main>
+    </>
+  );
+};
+
+export default connect(Theme);
+
 const globalStyles = css`
   body {
     margin: 0;
@@ -20,32 +58,6 @@ const globalStyles = css`
   }
 `;
 
-const Theme = ({ state }) => {
-  const data = state.source.get(state.router.link);
-
-  return (
-    <>
-      <Head>
-        <meta name="description" content={state.frontity.description} />
-        <html lang="en" />
-      </Head>
-      <Title />
-      <Global styles={globalStyles} />
-      <HeadContainer>
-        <Header />
-      </HeadContainer>
-      <Body>
-        {data.isFetching && <Loading />}
-        {data.isArchive && <List />}
-        {data.isPostType && <Post />}
-        {data.is404 && <Page404 />}
-      </Body>
-    </>
-  );
-};
-
-export default connect(Theme);
-
 const HeadContainer = styled.div`
   display: flex;
   align-items: center;
@@ -53,7 +65,7 @@ const HeadContainer = styled.div`
   background-color: #1f38c5;
 `;
 
-const Body = styled.div`
+const Main = styled.div`
   display: flex;
   justify-content: center;
   background-image: linear-gradient(

--- a/packages/mars-theme/src/components/list/list-item.js
+++ b/packages/mars-theme/src/components/list/list-item.js
@@ -13,11 +13,13 @@ const Item = ({ state, item }) => {
         <Title dangerouslySetInnerHTML={{ __html: item.title.rendered }} />
       </Link>
       <div>
-        <StyledLink link={author.link}>
-          <Author>
-            By <b>{author.name}</b>
-          </Author>
-        </StyledLink>
+        {author && (
+          <StyledLink link={author.link}>
+            <Author>
+              By <b>{author.name}</b>
+            </Author>
+          </StyledLink>
+        )}
         <Fecha>
           {" "}
           on <b>{date.toDateString()}</b>
@@ -26,7 +28,9 @@ const Item = ({ state, item }) => {
       {state.theme.featured.showOnList && (
         <FeaturedMedia id={item.featured_media} />
       )}
-      <Excerpt dangerouslySetInnerHTML={{ __html: item.excerpt.rendered }} />
+      {item.excerpt && (
+        <Excerpt dangerouslySetInnerHTML={{ __html: item.excerpt.rendered }} />
+      )}
     </article>
   );
 };

--- a/packages/mars-theme/src/components/post.js
+++ b/packages/mars-theme/src/components/post.js
@@ -34,11 +34,13 @@ const Post = ({ state, actions, libraries }) => {
         {/* Only display author and date on posts */}
         {data.isPost && (
           <div>
-            <StyledLink link={author.link}>
-              <Author>
-                By <b>{author.name}</b>
-              </Author>
-            </StyledLink>
+            {author && (
+              <StyledLink link={author.link}>
+                <Author>
+                  By <b>{author.name}</b>
+                </Author>
+              </StyledLink>
+            )}
             <Fecha>
               {" "}
               on <b>{date.toDateString()}</b>

--- a/packages/mars-theme/src/components/post.js
+++ b/packages/mars-theme/src/components/post.js
@@ -5,25 +5,33 @@ import List from "./list";
 import FeaturedMedia from "./featured-media";
 
 const Post = ({ state, actions, libraries }) => {
-  // Get info of current post.
+  // Get information about the current URL.
   const data = state.source.get(state.router.link);
-  // Get the the post.
+  // Get the data of the post.
   const post = state.source[data.type][data.id];
-  // Get the author.
+  // Get the data of the author.
   const author = state.source.author[post.author];
-  // Get a date for humans.
+  // Get a human readable date.
   const date = new Date(post.date);
 
-  // Prefetch home posts and the list component.
+  // Get the html2react component.
+  const Html2React = libraries.html2react.Component;
+
+  // Once the post has loaded in the DOM, prefetch both the
+  // home posts and the list component so if the user visits
+  // the home page, everything is ready and it loads instantly.
   useEffect(() => {
     actions.source.fetch("/");
     List.preload();
   }, []);
 
+  // Load the post, but only if the data is ready.
   return data.isReady ? (
     <Container>
       <div>
         <Title dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
+
+        {/* Only display author and date on posts */}
         {data.isPost && (
           <div>
             <StyledLink link={author.link}>
@@ -38,12 +46,17 @@ const Post = ({ state, actions, libraries }) => {
           </div>
         )}
       </div>
+
+      {/* Look at the settings to see if we should include the featured image */}
       {state.theme.featured.showOnPost && (
         <FeaturedMedia id={post.featured_media} />
       )}
-      <Body>
-        <libraries.html2react.Component html={post.content.rendered} />
-      </Body>
+
+      {/* Render the content using the Html2React component so the HTML is processed
+       by the processors we included in the libraries.html2react.processors array. */}
+      <Content>
+        <Html2React html={post.content.rendered} />
+      </Content>
     </Container>
   ) : null;
 };
@@ -79,7 +92,9 @@ const Fecha = styled.p`
   display: inline;
 `;
 
-const Body = styled.div`
+// This component is the parent of the `content.rendered` HTML. We can use nested
+// selectors to style that HTML.
+const Content = styled.div`
   color: rgba(12, 17, 43, 0.8);
   word-break: break-word;
 

--- a/packages/mars-theme/src/index.js
+++ b/packages/mars-theme/src/index.js
@@ -22,14 +22,13 @@ const marsTheme = {
   // Actions are functions that modify the state or deal with other parts of
   // Frontity like libraries.
   actions: {
-    theme: {
-      // Init is a special action run both in the server and the client. It is used
-      // to initilize things, usually from other packages.
-      init: ({ libraries }) => {
-        // In this case, we add a processor to html2react to process the <img> tags
-        // inside the content HTML. You can add your own processors too.
-        libraries.html2react.processors.push(image);
-      }
+    theme: {}
+  },
+  libraries: {
+    html2react: {
+      // Add a processor to html2react so it processes the <img> tags
+      // inside the content HTML. You can add your own processors too.
+      processors: [image]
     }
   }
 };

--- a/packages/mars-theme/src/index.js
+++ b/packages/mars-theme/src/index.js
@@ -1,17 +1,16 @@
 import Theme from "./components";
 import image from "@frontity/html2react/processors/image";
 
-const before = ({ libraries }) => {
-  // We use html2react to process the <img> tags inside the content HTML.
-  libraries.html2react.processors.push(image);
-};
-
 const marsTheme = {
   name: "@frontity/mars-theme",
   roots: {
+    // In Frontity, any package can add React components to the site.
+    // We use roots for that, scoped to the "theme" namespace.
     theme: Theme
   },
   state: {
+    // State is where the packages store their default settings and other
+    // relevant state. It is scoped to the "theme" namespace.
     theme: {
       menu: [],
       featured: {
@@ -20,10 +19,17 @@ const marsTheme = {
       }
     }
   },
+  // Actions are functions that modify the state or deal with other parts of
+  // Frontity like libraries.
   actions: {
     theme: {
-      beforeSSR: before,
-      beforeCSR: before
+      // Init is a special action run both in the server and the client. It is used
+      // to initilize things, usually from other packages.
+      init: ({ libraries }) => {
+        // In this case, we add a processor to html2react to process the <img> tags
+        // inside the content HTML. You can add your own processors too.
+        libraries.html2react.processors.push(image);
+      }
     }
   }
 };


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Tasks done:

- [x] Use `Html2React` instead of `libraries.html2react.Component` in JSX.
- [x] Move html2react processors to libraries.
- [x] Make excerpts and authors optional (sometimes they are missing in some WP installations or in some custom post types).

#### Remaining tasks:

- [ ] Add comments to every line of code.
- [ ] Create a menu that can be opened and closed with state (@DAreRodz can you do this?)
- [ ] Add `afterCSR` example (can be dark/light theme).
- [ ] Add `beforeSSR` example.
- [ ] Add derived state example.
- [ ] Add a custom post type and a custom taxonomy.

The remaining tasks are planned to be done in a different PR.
There is an issue open with those tasks (#223).

#### My PR is a:

🔝 Improvement

#### Main update on the:

⏩ Framework

#### Is the PR ready to be merged?

✅ Yes!