### PR TITLE
WIP: feature(frontity/connect): Attaching context, path and state

### DIFF
--- a/packages/connect/jest.config.js
+++ b/packages/connect/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   transform: { "^.+\\.(t|j)sx?$": "ts-jest" },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(t|j)sx?$",
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"]
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  testPathIgnorePatterns: ["/__tests__/builtIns"]
 };

--- a/packages/connect/src/__tests__/debug.tests.js
+++ b/packages/connect/src/__tests__/debug.tests.js
@@ -143,31 +143,6 @@ describe("debugger", () => {
     ]);
   });
 
-  it("should debug clear operations", () => {
-    let dummy;
-    const rawMap = new Map();
-    rawMap.set("key", "value");
-    const map = observable(rawMap);
-    const debugSpy = jest.fn(() => {});
-    observe(() => (dummy = map.get("key")), {
-      debugger: debugSpy
-    });
-
-    expect(dummy).toEqual("value");
-    expect(debugSpy.mock.calls.length).toEqual(1);
-    const oldMap = new Map(rawMap);
-    map.clear();
-    expect(dummy).toEqual(undefined);
-    expect(debugSpy.mock.calls.length).toEqual(3);
-    expect(debugSpy.mock.calls[1]).toEqual([
-      {
-        type: "clear",
-        target: rawMap,
-        oldTarget: oldMap
-      }
-    ]);
-  });
-
   it("should not cause infinite loops", () => {
     let receiverDummy;
     const rawCounter = { num: 0 };

--- a/packages/connect/src/__tests__/observable.tests.js
+++ b/packages/connect/src/__tests__/observable.tests.js
@@ -84,6 +84,70 @@ describe("observable", () => {
     expect(obs.nested1.prop3(3)).toEqual(4);
     expect(obs.nested1.prop4(2)).toEqual(8);
   });
+
+  it("iterating an object", () => {
+    const obj = { a: "a", b: "b", c: "c" };
+    const obs = observable(obj);
+
+    for (let key in obs) {
+      expect(obs[key]).toEqual(obj[key]);
+    }
+  });
+
+  it("should allow making arrays observable", () => {
+    const arr = [];
+    const obs = observable(arr);
+    expect(isObservable(obs)).toEqual(true);
+  });
+
+  it("should update the observable when adding new properties", () => {
+    const arr = [];
+    const obs = observable(arr);
+
+    obs.push(1);
+    expect(obs[0]).toEqual(1);
+
+    obs.push({ name: "Jon Snow" });
+    expect(isObservable(obs[1])).toEqual(true);
+    expect(obs[1].name).toEqual("Jon Snow");
+  });
+
+  it("should allow iterating array", () => {
+    const arr = [{ name: "a" }, { name: "b" }, { name: "c" }];
+    const obs = observable(arr);
+
+    let i = 0;
+    for (let key of obs) {
+      expect(key).toEqual(arr[i]);
+      i++;
+    }
+  });
+
+  it("length works correctly", () => {
+    const arr = [];
+    const obs = observable(arr);
+
+    expect(obs.length).toEqual(0);
+
+    obs.push("hello");
+    expect(obs.length).toEqual(1);
+  });
+
+  it("state can access the property `state`", () => {
+    const obj = { state: { user: "test" } };
+    const obs = observable(obj);
+
+    expect(obs.state).toEqual(obj.state);
+  });
+
+  it("Object.keys works", () => {
+    const obj = { a: 1, b: 2 };
+    const obs = observable(obj);
+
+    const keys = Object.keys(obs);
+
+    expect(keys).toEqual(["a", "b"]);
+  });
 });
 
 describe("isObservable", () => {


### PR DESCRIPTION
#### Description of what you did:

The new version of the state manager will need the `state`,
the `path` and `context` to be nested for each proxified state.
This is a first attempt to add this functionality.

```
proxy = new Proxy(
      {                
        state,       //
        context,   //  <-- Instead of `new Proxy(state, handlers);`
        path         //
      },
      // store the root in handlers possibly
      handlers
    );
```
@luisherranz 
Currently 3/4 of the tests are failing, so there are multiple bugs it seems. I'm pushing this only for you to have a look and see if you can debug it further.

#### My PR is a:

- 🔝 Improvement

#### Is the PR ready to be merged?

- 🚧 Work in progress
