### PR TITLE
chore(type-declarations): create a type declarations package

### DIFF
--- a/packages/frontity/package.json
+++ b/packages/frontity/package.json
@@ -37,6 +37,7 @@
     "@emotion/styled": "^10.0.11",
     "@frontity/connect": "^1.0.2",
     "@frontity/types": "^1.1.1",
+    "@frontity/type-declarations": "^1.0.0",
     "@loadable/component": "^5.10.1",
     "chalk": "^2.4.2",
     "clipboardy": "^2.1.0",

--- a/packages/type-declarations/index.d.ts
+++ b/packages/type-declarations/index.d.ts
@@ -1,0 +1,11 @@
+declare module "*.bmp";
+declare module "*.gif";
+declare module "*.jpg";
+declare module "*.jpeg";
+declare module "*.png";
+declare module "*.webp";
+declare module "*.svg";
+declare module "*.woff";
+declare module "*.woff2";
+declare module "*.eot";
+declare module "*.ttf";

--- a/packages/type-declarations/package.json
+++ b/packages/type-declarations/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@frontity/type-declarations",
+  "version": "1.0.0",
+  "description": "Types declarations for the different Frontity APIs",
+  "types": "index.d.ts",
+  "keywords": [
+    "frontity",
+    "types",
+    "typescript"
+  ],
+  "homepage": "https://frontity.org",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/frontity/frontity.git"
+  },
+  "bugs": {
+    "url": "https://community.frontity.org"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "allowJs": true
   },
   "exclude": ["**/node_modules/*", "**/dist/*", "**/build/*"],
-  "include": ["packages", "examples"]
+  "include": ["packages", "examples", "e2e"]
 }


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

<!-- Please describe everything as much as possible -->
This is an attempt to declare TypeScript modules for imported files like images, fonts and so on, in a way that Frontity users don't have to do it.

Right now is not working.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🔝 Improvement

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
