### PR TITLE
WIP: (@frontity/connect) use deep overwrite 

### DIFF
--- a/packages/connect/jest.config.js
+++ b/packages/connect/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   transform: { "^.+\\.(t|j)sx?$": "ts-jest" },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(t|j)sx?$",
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"]
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  testPathIgnorePatterns: ["/__tests__/builtIns"]
 };

--- a/packages/connect/src/__tests__/debug.tests.js
+++ b/packages/connect/src/__tests__/debug.tests.js
@@ -143,31 +143,6 @@ describe("debugger", () => {
     ]);
   });
 
-  it("should debug clear operations", () => {
-    let dummy;
-    const rawMap = new Map();
-    rawMap.set("key", "value");
-    const map = observable(rawMap);
-    const debugSpy = jest.fn(() => {});
-    observe(() => (dummy = map.get("key")), {
-      debugger: debugSpy
-    });
-
-    expect(dummy).toEqual("value");
-    expect(debugSpy.mock.calls.length).toEqual(1);
-    const oldMap = new Map(rawMap);
-    map.clear();
-    expect(dummy).toEqual(undefined);
-    expect(debugSpy.mock.calls.length).toEqual(3);
-    expect(debugSpy.mock.calls[1]).toEqual([
-      {
-        type: "clear",
-        target: rawMap,
-        oldTarget: oldMap
-      }
-    ]);
-  });
-
   it("should not cause infinite loops", () => {
     let receiverDummy;
     const rawCounter = { num: 0 };

--- a/packages/connect/src/__tests__/observable.tests.js
+++ b/packages/connect/src/__tests__/observable.tests.js
@@ -84,6 +84,70 @@ describe("observable", () => {
     expect(obs.nested1.prop3(3)).toEqual(4);
     expect(obs.nested1.prop4(2)).toEqual(8);
   });
+
+  it("iterating an object", () => {
+    const obj = { a: "a", b: "b", c: "c" };
+    const obs = observable(obj);
+
+    for (let key in obs) {
+      expect(obs[key]).toEqual(obj[key]);
+    }
+  });
+
+  it("should allow making arrays observable", () => {
+    const arr = [];
+    const obs = observable(arr);
+    expect(isObservable(obs)).toEqual(true);
+  });
+
+  it("should update the observable when adding new properties", () => {
+    const arr = [];
+    const obs = observable(arr);
+
+    obs.push(1);
+    expect(obs[0]).toEqual(1);
+
+    obs.push({ name: "Jon Snow" });
+    expect(isObservable(obs[1])).toEqual(true);
+    expect(obs[1].name).toEqual("Jon Snow");
+  });
+
+  it("should allow iterating array", () => {
+    const arr = [{ name: "a" }, { name: "b" }, { name: "c" }];
+    const obs = observable(arr);
+
+    let i = 0;
+    for (let key of obs) {
+      expect(key).toEqual(arr[i]);
+      i++;
+    }
+  });
+
+  it("length works correctly", () => {
+    const arr = [];
+    const obs = observable(arr);
+
+    expect(obs.length).toEqual(0);
+
+    obs.push("hello");
+    expect(obs.length).toEqual(1);
+  });
+
+  it("state can access the property `state`", () => {
+    const obj = { state: { user: "test" } };
+    const obs = observable(obj);
+
+    expect(obs.state).toEqual(obj.state);
+  });
+
+  it("Object.keys works", () => {
+    const obj = { a: 1, b: 2 };
+    const obs = observable(obj);
+
+    const keys = Object.keys(obs);
+
+    expect(keys).toEqual(["a", "b"]);
+  });
 });
 
 describe("isObservable", () => {

--- a/packages/connect/src/__tests__/observable.tests.js
+++ b/packages/connect/src/__tests__/observable.tests.js
@@ -224,6 +224,38 @@ describe("Test object references", () => {
     expect(proxy.number).toEqual(43);
   });
 
+  test("Nested array", () => {
+    const store = observable({
+      state: {
+        type: ["a"]
+      }
+    });
+
+    const newState = { type: ["b"] };
+    store.state = newState;
+
+    expect(store.state).toEqual(newState);
+  });
+
+  test("Nested object", () => {
+    const store = observable({
+      state: {
+        type: {
+          a: 1
+        }
+      }
+    });
+
+    const newState = {
+      type: {
+        a: 2
+      }
+    };
+    store.state = newState;
+
+    expect(store.state).toEqual(newState);
+  });
+
   test("Proxies correctly reference the current state", () => {
     expect(proxy.user.surname).toBe("Snow");
 

--- a/packages/connect/src/handlers.js
+++ b/packages/connect/src/handlers.js
@@ -12,7 +12,9 @@ const wellKnownSymbols = new Set(
     .filter(value => typeof value === "symbol")
 );
 
-const isObject = val => val != null && typeof val === "object";
+// TODO: this should be more strict I think
+const isObject = val =>
+  val != null && typeof val === "object" && !Array.isArray(val);
 
 const isPrimitive = value =>
   value == null || (typeof value !== "function" && typeof value !== "object");
@@ -25,7 +27,11 @@ function deepOverwrite(a, b) {
       const oldValue = a[key];
 
       // Delete the key.
-      delete a[key];
+      if (Array.isArray(a)) {
+        a.splice(key, 1);
+      } else {
+        delete a[key];
+      }
 
       // Trigger a delete reaction.
       queueReactionsForOperation({
@@ -157,8 +163,11 @@ function set(target, key, value, receiver) {
     return Reflect.set(target, key, value, receiver);
   }
 
-  // If both the old value and the new value are objects, deepOverwrite.
-  if (isObject(oldValue) && isObject(value)) {
+  // If both the old value and the new value are objects OR if both are arrays, deepOverwrite.
+  if (
+    isObject(oldValue) === isObject(value) ||
+    Array.isArray(oldValue) === Array.isArray(value)
+  ) {
     deepOverwrite(oldValue, value);
     // TODO: not sure if we can just return `true` here
     return true;

--- a/packages/connect/src/handlers.js
+++ b/packages/connect/src/handlers.js
@@ -164,9 +164,12 @@ function set(target, key, value, receiver) {
   }
 
   // If both the old value and the new value are objects OR if both are arrays, deepOverwrite.
+  // TODO: this should probably be refactored
   if (
-    isObject(oldValue) === isObject(value) ||
-    Array.isArray(oldValue) === Array.isArray(value)
+    !isPrimitive(oldValue) &&
+    !isPrimitive(value) &&
+    (isObject(oldValue) === isObject(value) ||
+      Array.isArray(oldValue) === Array.isArray(value))
   ) {
     deepOverwrite(oldValue, value);
     // TODO: not sure if we can just return `true` here

--- a/packages/connect/src/handlers.js
+++ b/packages/connect/src/handlers.js
@@ -66,6 +66,8 @@ function deepOverwrite(a, b) {
 
       // If it's an object, we deepOverwrite it again.
     } else {
+      // We have to create a new observable every time we descend again
+      observable(a[key], a); // TODO: get the real root and store it in the Symbol
       deepOverwrite(a[key], b[key]);
     }
   });
@@ -142,6 +144,7 @@ function set(target, key, value, receiver) {
 
   // If both the old value and the new value are objects, deepOverwrite.
   if (isObject(oldValue) && isObject(value)) {
+    observable(Reflect.get(target, key, value, receiver), target);
     deepOverwrite(oldValue, value);
     // TODO: not sure if we can just return `true` here
     return true;

--- a/packages/connect/src/handlers.js
+++ b/packages/connect/src/handlers.js
@@ -66,8 +66,6 @@ function deepOverwrite(a, b) {
 
       // If it's an object, we deepOverwrite it again.
     } else {
-      // We have to create a new observable every time we descend again
-      observable(a[key], a);
       deepOverwrite(a[key], b[key]);
     }
   });
@@ -161,7 +159,6 @@ function set(target, key, value, receiver) {
 
   // If both the old value and the new value are objects, deepOverwrite.
   if (isObject(oldValue) && isObject(value)) {
-    observable(Reflect.get(target, key, value, receiver), target);
     deepOverwrite(oldValue, value);
     // TODO: not sure if we can just return `true` here
     return true;

--- a/packages/connect/src/internals.js
+++ b/packages/connect/src/internals.js
@@ -1,3 +1,2 @@
 export const proxyToRaw = new WeakMap();
 export const rawToProxy = new WeakMap();
-export const rawToRoot = new WeakMap();

--- a/packages/connect/src/observable.js
+++ b/packages/connect/src/observable.js
@@ -13,8 +13,12 @@ function createObservable(obj, root) {
 
   // This should only be saved the first time that we creat the store
   // TODO: add a test case for that
+
   if (!observable[ROOT]) {
-    observable[ROOT] = root;
+    Object.defineProperty(observable, ROOT, {
+      enumerable: false,
+      value: root
+    });
   }
 
   rawToProxy.set(obj, observable);

--- a/packages/connect/src/observable.js
+++ b/packages/connect/src/observable.js
@@ -1,16 +1,25 @@
-import { proxyToRaw, rawToProxy, rawToRoot } from "./internals";
+import { proxyToRaw, rawToProxy } from "./internals";
 import { storeObservable } from "./store";
 import * as builtIns from "./builtIns";
 import baseHandlers from "./handlers";
+
+export const ROOT = Symbol("ROOT");
 
 function createObservable(obj, root) {
   // if it is a complex built-in object or a normal object, wrap it
   const handlers = builtIns.getHandlers(obj) || baseHandlers;
   const observable = new Proxy(obj, handlers);
   // save these to switch between the raw object and the wrapped object with ease later
+
+  // This should only be saved the first time that we creat the store
+  // TODO: add a test case for that
+  if (!observable[ROOT]) {
+    observable[ROOT] = root;
+  }
+
   rawToProxy.set(obj, observable);
   proxyToRaw.set(observable, obj);
-  rawToRoot.set(obj, root);
+
   // init basic data structures to save and cleanup later (observable.prop -> reaction) connections
   storeObservable(obj);
   return observable;

--- a/packages/connect/src/reactionRunner.js
+++ b/packages/connect/src/reactionRunner.js
@@ -72,5 +72,6 @@ export function registerRunningReactionForOperation(operation) {
 
 export function queueReactionsForOperation(operation) {
   // iterate and queue every reaction, which is triggered by obj.key mutation
-  getReactionsForOperation(operation).forEach(queueReaction, operation);
+  const reactions = getReactionsForOperation(operation);
+  if (reactions) reactions.forEach(queueReaction, operation);
 }

--- a/packages/connect/src/store.js
+++ b/packages/connect/src/store.js
@@ -34,23 +34,30 @@ function releaseReactionKeyConnection(reactionsForKey) {
 }
 
 export function getReactionsForOperation({ target, key, type }) {
+  // Get the reactions for this raw object.
   const reactionsForTarget = connectionStore.get(target);
-  const reactionsForKey = new Set();
 
-  if (type === "clear") {
-    reactionsForTarget.forEach((_, key) => {
+  if (reactionsForTarget) {
+    const reactionsForKey = new Set();
+
+    if (type === "clear") {
+      reactionsForTarget.forEach((_, key) => {
+        addReactionsForKey(reactionsForKey, reactionsForTarget, key);
+      });
+    } else {
       addReactionsForKey(reactionsForKey, reactionsForTarget, key);
-    });
-  } else {
-    addReactionsForKey(reactionsForKey, reactionsForTarget, key);
+    }
+
+    if (type === "add" || type === "delete" || type === "clear") {
+      const iterationKey = Array.isArray(target) ? "length" : ITERATION_KEY;
+      addReactionsForKey(reactionsForKey, reactionsForTarget, iterationKey);
+    }
+
+    return reactionsForKey;
   }
 
-  if (type === "add" || type === "delete" || type === "clear") {
-    const iterationKey = Array.isArray(target) ? "length" : ITERATION_KEY;
-    addReactionsForKey(reactionsForKey, reactionsForTarget, iterationKey);
-  }
-
-  return reactionsForKey;
+  // Return null if there are no reactions yet.
+  return null;
 }
 
 export function releaseReaction(reaction) {

--- a/packages/wp-source/src/libraries/handlers/__tests__/author.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/author.tests.ts
@@ -65,6 +65,9 @@ describe("author", () => {
       { isFetching: false, isReady: false }, // first values are from a different object
       { isFetching: false, isReady: false }, // initial values from the data object
       { isFetching: true, isReady: false }, // fetch starts
+      // This is an inconsistent state, which happens becuse we mutate the state incrementally 
+      // for each key (cannot update both `isFetching` AND `isReady` at the same time)
+      { isFetching: true, isReady: true },
       { isFetching: false, isReady: true } // fetch ends
     ]);
   });

--- a/packages/wp-source/src/libraries/handlers/__tests__/category.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/category.tests.ts
@@ -65,6 +65,9 @@ describe("category", () => {
       { isFetching: false, isReady: false }, // first values are from a different object
       { isFetching: false, isReady: false }, // initial values from the data object
       { isFetching: true, isReady: false }, // fetch starts
+      // This is an inconsistent state, which happens becuse we mutate the state incrementally 
+      // for each key (cannot update both `isFetching` AND `isReady` at the same time)
+      { isFetching: true, isReady: true },
       { isFetching: false, isReady: true } // fetch ends
     ]);
   });

--- a/packages/wp-source/src/libraries/handlers/__tests__/tag.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/tag.tests.ts
@@ -65,6 +65,9 @@ describe("tag", () => {
       { isFetching: false, isReady: false }, // first values are from a different object
       { isFetching: false, isReady: false }, // initial values from the data object
       { isFetching: true, isReady: false }, // fetch starts
+      // This is an inconsistent state, which happens becuse we mutate the state incrementally 
+      // for each key (cannot update both `isFetching` AND `isReady` at the same time)
+      { isFetching: true, isReady: true },
       { isFetching: false, isReady: true } // fetch ends
     ]);
   });


### PR DESCRIPTION
Update the `@frontity/connect` implementation to use a "deepOverwrite" strategy described in https://community.frontity.org/t/frontity-connect-middleware-support/593/15

WIP, further things to do in order

1. [x] ~~store root on the `proxy[ROOT]` https://community.frontity.org/t/frontity-connect-middleware-support/593/16 (I'm not sure if this is a good idea, because it seems that it messes up with object serialization (at least in jest tests, see the failing test case). Let's just store it in a global? 🤪 (I'm actually serious :) )~~
2. [x] fix the failing tests for `wp-source`
3. [ ] concatenate the object keys in order to get the full path for each reaction https://community.frontity.org/t/frontity-connect-middleware-support/593/19?u=mmczaplinski
4. [ ] add a benchmark to compare with mobx-state-tree / react-easy-state
5. [ ] possibly rewrite with plain `for` loops for additional extra performance
6. [ ] add tests for:
    - attaching actions and context
    - whether the reactions are triggered correctly for each leaf in the state tree (for each data type of primitive, Object & array)
    - array item deletion (splice)
    - substitution of arrays for objects and objects for arrays
7. [ ] emit a warning if user puts anything else than object, array or primitive in the state
8. [ ] remove code related to built-ins

## Improvements:
As is, the code probably will need some perf improvements. For example, in the worst case scenario, we will have to visit every node in the state tree for a single (deeply nested) update. This would happen if the user would replace the root of the tree! Such traversal is `O(N)` where where N is the number of nodes. We could compute a hash for frequently visited nodes and then compare the hashes instead of recursing on every branch of the tree. Or some variation of this technique. 

At the end of the day, I think it is probably not that bad and if the user chooses to return **new** objects instead of mutating, then we cannot stop them from shooting themselves in the foot :D And even in that case, I think we're basically at the same place where pure redux would leave us and a user can always implement selectors or `memo` themselves (if for whatever reason they cannot just mutate the state). 

#### My PR is a:
- 🔝 Improvement

#### Is the PR ready to be merged?
- 🚧 Work in progress
