### PR TITLE
fix(core): delete package name from merged store

### DIFF
--- a/packages/core/src/utils/__tests__/merge-packages.tests.tsx
+++ b/packages/core/src/utils/__tests__/merge-packages.tests.tsx
@@ -15,6 +15,7 @@ const state = {
 };
 const packages = {
   package_1_html: {
+    name: "package1",
     roots: {
       namespace1: () => <div>"namespace1"</div>,
       namespace2: () => <div>"namespace2"</div>
@@ -35,6 +36,7 @@ const packages = {
     }
   },
   package_2_html: {
+    name: "package2",
     roots: {
       namespace3: () => <div>"namespace3"</div>
     },
@@ -60,6 +62,7 @@ const packages = {
     }
   },
   package_3_html: () => ({
+    name: "package3",
     roots: {
       namespace4: () => <div>"namespace4"</div>
     },

--- a/packages/core/src/utils/merge-packages.ts
+++ b/packages/core/src/utils/merge-packages.ts
@@ -33,5 +33,6 @@ export default ({
   config.state = deepmerge(config.state, state, {
     clone: true
   });
+  delete config.name;
   return config;
 };


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

After the merge, the name of a random package was appearing in the store and showing when people use `frontity` in the browser console.

It doesn't appear now.

Fixes #95.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
