### PR TITLE
Add comments handler

### DIFF
--- a/packages/source/src/data.ts
+++ b/packages/source/src/data.ts
@@ -4,6 +4,8 @@ export type EntityData = {
   type: string;
   id: number;
   link: string;
+  parent: number;
+  children: Array<Object>;
 };
 
 export type Data =

--- a/packages/wp-source/src/libraries/handlers/comments.ts
+++ b/packages/wp-source/src/libraries/handlers/comments.ts
@@ -24,12 +24,12 @@ const commentsHandler: Handler = async ({
   // 2. populate response
   const rawItems = await populate({ response, state });
   const parentItems = {};
-  rawItems.map(item => {
+  rawItems.forEach(item => {
     parentItems[item.parent] = [...(parentItems[item.parent] || []), item];
   });
   const items = parentItems[0];
   const addChildren = arr => {
-    arr.map(item => {
+    arr.forEach(item => {
       if (parentItems[item.id]) {
         item.children = parentItems[item.id];
         addChildren(item.children);

--- a/packages/wp-source/src/libraries/handlers/comments.ts
+++ b/packages/wp-source/src/libraries/handlers/comments.ts
@@ -8,7 +8,7 @@ const commentsHandler: Handler = async ({
 }) => {
   const { api, populate, parse, getTotal, getTotalPages } = libraries.source;
   const { page, query } = parse(route);
-  const { postId } = params;
+  const postId = parseInt(params.postId);
 
   // 1. fetch the specified page
   const response = await api.get({

--- a/packages/wp-source/src/libraries/handlers/comments.ts
+++ b/packages/wp-source/src/libraries/handlers/comments.ts
@@ -1,0 +1,63 @@
+import { Handler } from "../../../types";
+
+const commentsHandler: Handler = async ({
+  route,
+  params,
+  state,
+  libraries
+}) => {
+  const { api, populate, parse, getTotal, getTotalPages } = libraries.source;
+  const { path, page, query } = parse(route);
+  const { postId } = params;
+
+  // 1. search id in state or get it from WP REST API
+  let { id } = state.source.get(path);
+  if (!id) {
+    // Request author from WP
+    const response = await api.get({
+      endpoint: "comments",
+      params: { post: postId }
+    });
+    const [entity] = await populate({ response, state });
+    if (!entity)
+      throw new Error(
+        `entity from endpoint "comments" with postId "${postId}" not found`
+      );
+    id = entity.id;
+  }
+
+  // 2. fetch the specified page
+  const response = await api.get({
+    endpoint: "comments",
+    params: {
+      post: postId,
+      search: query.s,
+      page,
+      _embed: true,
+      ...state.source.params
+    }
+  });
+
+  // 3. populate response
+  const items = await populate({ response, state });
+  if (page > 1 && items.length === 0)
+    throw new Error(`comments for post "${postId}" don't have page ${page}`);
+
+  // 4. get posts and pages count
+  const total = getTotal(response);
+  const totalPages = getTotalPages(response);
+
+  // 5. add data to source
+  const currentPageData = state.source.data[route];
+  const firstPageData = state.source.data[path];
+
+  Object.assign(currentPageData, {
+    id: firstPageData.id,
+    items,
+    total,
+    totalPages,
+    isComments: true
+  });
+};
+
+export default commentsHandler;

--- a/packages/wp-source/src/libraries/handlers/comments.ts
+++ b/packages/wp-source/src/libraries/handlers/comments.ts
@@ -49,10 +49,9 @@ const commentsHandler: Handler = async ({
 
   // 5. add data to source
   const currentPageData = state.source.data[route];
-  const firstPageData = state.source.data[path];
 
   Object.assign(currentPageData, {
-    id: firstPageData.id,
+    postId,
     items,
     total,
     totalPages,

--- a/packages/wp-source/src/libraries/handlers/index.ts
+++ b/packages/wp-source/src/libraries/handlers/index.ts
@@ -1,4 +1,5 @@
 import author from "./author";
+import comments from "./comments";
 import date from "./date";
 import taxonomyHandler from "./taxonomy";
 import postTypeHandler from "./postType";
@@ -26,7 +27,7 @@ export const postArchive = postTypeArchiveHandler({
 });
 
 // Other handlers
-export { author, date };
+export { author, comments, date };
 
 // Handlers generators
 export { taxonomyHandler, postTypeHandler, postTypeArchiveHandler };

--- a/packages/wp-source/src/libraries/patterns/wp-com.ts
+++ b/packages/wp-source/src/libraries/patterns/wp-com.ts
@@ -3,6 +3,7 @@ import {
   category,
   tag,
   author,
+  comments,
   date,
   post,
   page
@@ -32,6 +33,12 @@ export default [
     priority: 20,
     pattern: "/author/:slug",
     func: author
+  },
+  {
+    name: "comments",
+    priority: 20,
+    pattern: "comments/:postId",
+    func: comments
   },
   {
     name: "date",

--- a/packages/wp-source/src/libraries/patterns/wp-com.ts
+++ b/packages/wp-source/src/libraries/patterns/wp-com.ts
@@ -37,7 +37,7 @@ export default [
   {
     name: "comments",
     priority: 20,
-    pattern: "comments/:postId",
+    pattern: "comments/:postId(\\d+)", //numeric
     func: comments
   },
   {

--- a/packages/wp-source/src/libraries/patterns/wp-org.ts
+++ b/packages/wp-source/src/libraries/patterns/wp-org.ts
@@ -3,6 +3,7 @@ import {
   category,
   tag,
   author,
+  comments,
   date,
   post,
   attachment,
@@ -33,6 +34,12 @@ export default [
     priority: 20,
     pattern: "/author/:slug",
     func: author
+  },
+  {
+    name: "comments",
+    priority: 20,
+    pattern: "comments/:postId",
+    func: comments
   },
   {
     name: "date",

--- a/packages/wp-source/src/libraries/patterns/wp-org.ts
+++ b/packages/wp-source/src/libraries/patterns/wp-org.ts
@@ -38,7 +38,7 @@ export default [
   {
     name: "comments",
     priority: 20,
-    pattern: "comments/:postId",
+    pattern: "comments/:postId(\\d+)", // numeric
     func: comments
   },
   {

--- a/packages/wp-source/src/libraries/populate.ts
+++ b/packages/wp-source/src/libraries/populate.ts
@@ -60,7 +60,11 @@ const populate: WpSource["libraries"]["source"]["populate"] = async ({
           isFetching: false
         });
 
-      if (schema === "postType" || schema === "attachment") {
+      if (
+        schema === "postType" ||
+        schema === "attachment" ||
+        schema === "comment"
+      ) {
         if (!state.source[entity.type]) state.source[entity.type] = {};
         state.source[entity.type][entity.id] = entity;
         Object.assign(entityData, {

--- a/packages/wp-source/src/libraries/populate.ts
+++ b/packages/wp-source/src/libraries/populate.ts
@@ -89,8 +89,8 @@ const populate: WpSource["libraries"]["source"]["populate"] = async ({
 
   // Return type, id and link of added entities
   return (isList ? result : [result]).map(({ id: entityId, schema }) => {
-    const { type, id, link } = entities[schema][entityId];
-    return { type, id, link };
+    const { type, id, link, parent } = entities[schema][entityId];
+    return { type, id, link, parent };
   });
 };
 

--- a/packages/wp-source/src/libraries/schemas/comments.ts
+++ b/packages/wp-source/src/libraries/schemas/comments.ts
@@ -1,0 +1,15 @@
+import { schema } from "normalizr";
+import { normalize } from "../route-utils";
+
+export const comment = new schema.Entity(
+  "comment",
+  {},
+  {
+    processStrategy(entity) {
+      const result = { ...entity };
+      result.link = normalize(result.link);
+      return result;
+    }
+  }
+);
+export const comments = new schema.Array(comment);

--- a/packages/wp-source/src/libraries/schemas/index.ts
+++ b/packages/wp-source/src/libraries/schemas/index.ts
@@ -2,6 +2,7 @@ import { schema } from "normalizr";
 import { postType } from "./postTypes";
 import { taxonomy } from "./taxonomies";
 import { author } from "./authors";
+import { comment } from "./comments";
 import { attachment } from "./attachments";
 
 export const entity = new schema.Union(
@@ -9,12 +10,14 @@ export const entity = new schema.Union(
     postType,
     taxonomy,
     author,
+    comment,
     attachment
   },
   val => {
     if (val.taxonomy) return "taxonomy";
     else if (val.media_type) return "attachment";
     else if (val.name) return "author";
+    else if (val.type === "comment") return "comment";
     return "postType";
   }
 );


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

The idea of this PR is to add a comments handler so users can fetch the comments of a post easily. In this implementation users should use `fetch("comments/:postId")` and it'll populate `state.source.comment[commentId]` with all the comments and `state.source.data["comments/:postId"]` with an array of the comments of the post.

I'm just starting and take a deeper look. In fact, it didn't pass the test :smile: Here are some questions I have right now and things I have to consider:
- Pass the tests.
- Should we create a schema for `comments` or reuse `postType`? I've created a new one, but not sure if it's necessary.
- At `handlers/comments.ts` I have to understand better and modify the 1st point, where we search id in state. Should we do something similar looking for the postId?
- Should we add hierarchy at data so it's easier to know the replies of comments?
- Still have to test it at WP.com.
- Have to take a look at pages and number of comments.
- Have to take a look at the errors.
- I wasn't sure what data to add: isComments / areComments / nothing?
- I wasn't sure when to use comment or comments while declaring the variables :)

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🚀 New feature

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- 🚧 Work in progress

