### PR TITLE
Remove the typescript option from create-package

### DIFF
--- a/.changeset/witty-seahorses-relate.md
+++ b/.changeset/witty-seahorses-relate.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Remove the typescript option from create-packageBecause it is not implemented yet.Once it is implemented, we can add it back.

--- a/.changeset/witty-seahorses-relate.md
+++ b/.changeset/witty-seahorses-relate.md
@@ -2,4 +2,4 @@
 "frontity": patch
 ---
 
-Remove the typescript option from create-packageBecause it is not implemented yet.Once it is implemented, we can add it back.
+Remove the typescript option from `frontity create-package` because it is not implemented yet. Once it is implemented, we can add it back.

--- a/packages/frontity/src/commands.ts
+++ b/packages/frontity/src/commands.ts
@@ -62,7 +62,6 @@ program
 program
   .command("create-package [name]")
   .option("-n, --namespace <value>", "Sets the namespace for this package")
-  .option("-t, --typescript", "Adds support for TypeScript")
   .description("Creates a new Frontity package in a project.")
   .action(createPackage);
 

--- a/packages/frontity/src/functions/create-package/index.ts
+++ b/packages/frontity/src/functions/create-package/index.ts
@@ -10,16 +10,6 @@ import {
   isDirNotEmpty
 } from "./steps";
 
-//  Steps:
-//    1.  create /packages/[name]/src folder
-//    2.  add /packages/[name]/package.json file using template
-//    3.  if [--typescript]
-//    3.a.1  add /packages/[name]/src/index.ts file using template
-//    3.a.2  add /packages/[name]/types.ts file using template
-//    3.  else
-//    3.b    add /packages/[name]/src/index.js file using template
-//    4.  install package
-
 export default async (options?: Options, emitter?: EventEmitter) => {
   // This functions will emit an event if an emitter is passed in options.
   const emit = (message: string, step?: Promise<void>) => {
@@ -36,9 +26,13 @@ export default async (options?: Options, emitter?: EventEmitter) => {
   try {
     // 1. Make sure ./packages/[name] folder is empty.
     step = isDirNotEmpty(options);
-    emit(`Checking if ${chalk.yellow(options.packagePath)} is not empty.`, step);
+    emit(
+      `Checking if ${chalk.yellow(options.packagePath)} is not empty.`,
+      step
+    );
     const dirNotEmpty = await step;
-    if (dirNotEmpty) throw new Error(`Folder "${options.packagePath}" must be empty.`);
+    if (dirNotEmpty)
+      throw new Error(`Folder "${options.packagePath}" must be empty.`);
 
     // 2. Create ./packages/[name] folder.
     step = ensurePackageDir(options);


### PR DESCRIPTION
#### Description of what you did:

Typescript support in `frontity create-package` it is not implemented yet. Once it is implemented, we can add this back.

#### My PR is a:

- 🐞 Bug fix

#### Is the PR ready to be merged?

- ✅ Yes!
