### PR TITLE
TwentyTwenty LightHouse improvements

### DIFF
--- a/examples/twentytwenty-theme-example/frontity.settings.js
+++ b/examples/twentytwenty-theme-example/frontity.settings.js
@@ -39,7 +39,7 @@ export default {
             showOnPost: true
           },
           // Whether to auto-fetch links on a page. Values can be "no" | "all" | "in-view" | "hover"
-          autoPreFetch: "all",
+          autoPreFetch: "hover",
           /**
            * At the moment, we only include the ascii characters of Inter font.
            * Values can be "us-ascii" | "latin" | "all"

--- a/packages/twentytwenty-theme/src/components/archive/archive-pagination.js
+++ b/packages/twentytwenty-theme/src/components/archive/archive-pagination.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { connect, styled } from "frontity";
 import Link from "../link";
 
@@ -10,7 +10,7 @@ import Link from "../link";
  * The `state`, `actions`, `libraries` props are provided by the global context,
  * when we wrap this component in `connect(...)`
  */
-const Pagination = ({ state, actions, libraries }) => {
+const Pagination = ({ state, libraries }) => {
   // Get the total posts to be displayed based for the current link
   const { totalPages } = state.source.get(state.router.link);
   const { path, page, query } = libraries.source.parse(state.router.link);
@@ -34,11 +34,6 @@ const Pagination = ({ state, actions, libraries }) => {
     page: page - 1,
     query
   });
-
-  // Pre-fetch the the next page if it hasn't been fetched yet.
-  useEffect(() => {
-    if (isThereNextPage) actions.source.fetch(nextPageLink);
-  }, []);
 
   return (
     <div>

--- a/packages/twentytwenty-theme/src/components/archive/archive.js
+++ b/packages/twentytwenty-theme/src/components/archive/archive.js
@@ -1,6 +1,6 @@
 import { connect } from "frontity";
 import React, { Fragment, useEffect } from "react";
-import Article from "../post/post-item";
+import PostItem from "../post/post-item";
 import ArchiveHeader from "./archive-header";
 import Pagination from "./archive-pagination";
 import PostSeparator from "../post/post-separator";
@@ -42,11 +42,12 @@ const Archive = ({ state, showExcerpt, showMedia }) => {
         // Render one Item component for each one.
         return (
           <Fragment key={item.id}>
-            <Article
+            <PostItem
               key={item.id}
               item={item}
               showExcerpt={_showExcerpt}
               showMedia={showMedia}
+              loading={index === 0 ? "eager" : "lazy"}
             />
             {!isLastArticle && <PostSeparator />}
           </Fragment>

--- a/packages/twentytwenty-theme/src/components/footer.js
+++ b/packages/twentytwenty-theme/src/components/footer.js
@@ -35,7 +35,7 @@ const Footer = ({ state }) => {
             &copy; {currentYear}{" "}
             <Link link={state.frontity.url}>{state.frontity.title}</Link>
           </Copyright>
-          <PoweredBy>Powered by Frontity</PoweredBy>
+          <PoweredBy>Powered by WordPress & Frontity</PoweredBy>
         </Credits>
         <BackToTop />
       </SiteFooterInner>

--- a/packages/twentytwenty-theme/src/components/post/featured-media.js
+++ b/packages/twentytwenty-theme/src/components/post/featured-media.js
@@ -3,7 +3,7 @@ import { connect, styled } from "frontity";
 import Img from "@frontity/components/image";
 import SectionContainer from "../styles/section-container";
 
-const FeaturedMedia = ({ state, id, className }) => {
+const FeaturedMedia = ({ state, id, className, loading = "eager" }) => {
   const media = state.source.attachment[id];
 
   if (!media) return null;
@@ -28,6 +28,7 @@ const FeaturedMedia = ({ state, id, className }) => {
           alt={media.title.rendered}
           src={media.source_url}
           srcSet={srcset}
+          loading={loading}
         />
       </SectionContainer>
     </Figure>

--- a/packages/twentytwenty-theme/src/components/post/post-item.js
+++ b/packages/twentytwenty-theme/src/components/post/post-item.js
@@ -19,7 +19,8 @@ const PostItem = ({
   item,
   libraries,
   showExcerpt,
-  showMedia = true
+  showMedia = true,
+  loading
 }) => {
   // Get all categories
   const allCategories = state.source.category;
@@ -65,7 +66,7 @@ const PostItem = ({
        * list of featured posts, we render the media.
        */}
       {state.theme.featuredMedia.showOnArchive && showMedia && (
-        <FeaturedMedia id={item.featured_media} />
+        <FeaturedMedia id={item.featured_media} loading={loading} />
       )}
 
       {/* If the post has an excerpt (short summary text), we render it */}

--- a/packages/twentytwenty-theme/src/components/post/post.js
+++ b/packages/twentytwenty-theme/src/components/post/post.js
@@ -1,5 +1,5 @@
 import { styled, connect } from "frontity";
-import React, { useEffect } from "react";
+import React from "react";
 import FeaturedMedia from "./featured-media";
 import {
   EntryContent,
@@ -13,7 +13,7 @@ import PostCategories from "./post-categories";
 import PostMeta from "./post-meta";
 import PostTags from "./post-tags";
 
-const Post = ({ state, actions, libraries }) => {
+const Post = ({ state, libraries }) => {
   // Get information about the current URL.
   const data = state.source.get(state.router.link);
   // Get the data of the post.
@@ -42,15 +42,6 @@ const Post = ({ state, actions, libraries }) => {
    * So, we'll look up the details of each tag in allTags
    */
   const tags = post.tags && post.tags.map(tagId => allTags[tagId]);
-
-  /**
-   * Once the post has loaded in the DOM, prefetch both the
-   * home posts and the list component so if the user visits
-   * the home page, everything is ready and it loads instantly.
-   */
-  useEffect(() => {
-    actions.source.fetch("/");
-  }, []);
 
   // Load the post, but only if the data is ready.
   return data.isReady ? (


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

I've opened this PR to improve the LightHouse score of the TwentyTwenty theme.

Some things we can try suggestions:
- [ ] Preconnect to required origins.
- [ ] Improve autoPrefetch.

### Preconnect to required origins.
We can solve adding the `link` tag in `@wp-source` with the domain of the API if it's different from the `state.frontity.url` domain.

### Improve autoPrefetch

We can switch to `"hover"` and add `"in-view"` (not yet implemented). We can also add some of the optimizations that this library applies:
https://github.com/gijo-varghese/flying-pages


#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🔝 Improvement

#### Is the PR ready to be merged?

- 🚧 Work in progress
