### PR TITLE
fix the use-in-view hook

### DIFF
--- a/.changeset/proud-squids-reply.md
+++ b/.changeset/proud-squids-reply.md
@@ -1,0 +1,5 @@
+---
+"@frontity/hooks": patch
+---
+
+Bugfix for useInView hook. Fixes occasional error when attempting to find a nonexistent element in page.

--- a/packages/hooks/use-in-view.ts
+++ b/packages/hooks/use-in-view.ts
@@ -19,7 +19,7 @@ interface UseInView {
 // This is an array with all the `setIntersected` functions
 // created by `useInView`, so we can find the corresponding
 // one to each entry on the IntersectionObserver callback.
-let setFunctions: [
+const setFunctions: [
   Dispatch<SetStateAction<boolean>>,
   React.MutableRefObject<undefined>
 ][] = [];
@@ -30,15 +30,18 @@ let observer: IntersectionObserver;
 // This callback can be called with more than one entry,
 // so we need to filter them and call the corresponding
 // `setIntersected` function for each changed entry.
-let createCallback: IntersectionObserverCallbackCreator = options => {
+const createCallback: IntersectionObserverCallbackCreator = options => {
   return entries => {
     entries.forEach(entry => {
       const setFunction = setFunctions.find(
         set => set[1].current === entry.target
       );
 
-      // This is the `setIntersected` function.
-      setFunction[0](entry.isIntersecting);
+      // Check if we found the ref
+      if (setFunction) {
+        // This is the `setIntersected` function.
+        setFunction[0](entry.isIntersecting);
+      }
 
       if (entry.isIntersecting && options.onlyOnce) {
         observer.unobserve(entry.target);


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

This fixes the occasional 
```
TypeError: setFunction is undefined
```
in the twentytwenty theme

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🔝 Improvement

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!


----

Fixes https://github.com/frontity/frontity/issues/241