### PR TITLE
Add bundlewatch

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -25,7 +25,7 @@ jobs:
           CI: true
 
       - name: Check bundle size
-      - uses: jackyef/bundlewatch-gh-action@master
+        uses: jackyef/bundlewatch-gh-action@master
         with:
           build-script: npm run lerna build
           bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -1,0 +1,32 @@
+name: "Bundlewatch"
+
+on:
+  pull_request:
+    types: [synchronize, opened]
+
+jobs:
+  bundlewatch:
+    runs-on: ubuntu-latest
+    steps:
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v1
+
+        - name: Setup npm cache
+          uses: actions/cache@v1
+          with:
+            path: ~/.npm
+            key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+            restore-keys: |
+              ${{ runner.os }}-node-
+
+        - name: Install dependencies (root)
+          run: npm ci
+          env:
+            CI: true
+
+        - name: Check bundle size
+        - uses: jackyef/bundlewatch-gh-action@master
+          with:
+            build-script: npm run lerna build
+            bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -8,25 +8,24 @@ jobs:
   bundlewatch:
     runs-on: ubuntu-latest
     steps:
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
 
-        - name: Setup npm cache
-          uses: actions/cache@v1
-          with:
-            path: ~/.npm
-            key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-            restore-keys: |
-              ${{ runner.os }}-node-
+      - name: Setup npm cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-        - name: Install dependencies (root)
-          run: npm ci
-          env:
-            CI: true
+      - name: Install dependencies (root)
+        run: npm ci
+        env:
+          CI: true
 
-        - name: Check bundle size
-        - uses: jackyef/bundlewatch-gh-action@master
-          with:
-            build-script: npm run lerna build
-            bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+      - name: Check bundle size
+      - uses: jackyef/bundlewatch-gh-action@master
+        with:
+          build-script: npm run lerna build
+          bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Check bundle size
         uses: jackyef/bundlewatch-gh-action@master
         with:
-          build-script: npm run lerna build
+          build-script: npx lerna run build
           bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -56,7 +56,6 @@ jobs:
           runs: 3
           temporaryPublicStorage: true
           configPath: ./.github/workflows/lighthouserc.json
-          budgetPath: ./.github/workflows/budget.json
           urls: |
             https://mars-theme-$COMMIT_SHA.now.sh/
             https://mars-theme-$COMMIT_SHA.now.sh/2016/the-beauties-of-gullfoss/

--- a/examples/mars-theme-example/package.json
+++ b/examples/mars-theme-example/package.json
@@ -22,16 +22,5 @@
     "@frontity/wp-source": "^1.4.3",
     "babel-plugin-frontity": "^1.0.1",
     "frontity": "^1.4.3"
-  },
-  "devDependencies": {
-    "bundlewatch": "0.2.5"
-  },
-  "bundlewatch": {
-    "files": [
-      {
-        "path": "./build/static/mars-theme-example*.js",
-        "compression": "none"
-      }
-    ]
   }
 }

--- a/examples/mars-theme-example/package.json
+++ b/examples/mars-theme-example/package.json
@@ -22,5 +22,13 @@
     "@frontity/wp-source": "^1.4.3",
     "babel-plugin-frontity": "^1.0.1",
     "frontity": "^1.4.3"
+  },
+  "bundlewatch": {
+    "files": [
+      {
+        "path": "./build/static/mars-theme-example*.js",
+        "compression": "none"
+      }
+    ]
   }
 }

--- a/examples/mars-theme-example/package.json
+++ b/examples/mars-theme-example/package.json
@@ -23,6 +23,9 @@
     "babel-plugin-frontity": "^1.0.1",
     "frontity": "^1.4.3"
   },
+  "devDependencies": {
+    "bundlewatch": "0.2.5"
+  },
   "bundlewatch": {
     "files": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,6 +1900,24 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -2162,6 +2180,23 @@
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
+    "bundlewatch": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/bundlewatch/-/bundlewatch-0.2.5.tgz",
+      "integrity": "sha512-woAzcef9345Y9yC3lxkkKDZfjIbAV7jGt8Je4FL9WlkS6R3n/39v2cIfivkgN2zRDH9l88sRuWxvyvgr9U90Gg==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.0",
+        "bytes": "^3.0.0",
+        "chalk": "^2.4.0",
+        "commander": "^2.15.1",
+        "glob": "^7.1.2",
+        "gzip-size": "^4.0.0",
+        "jsonpack": "^1.1.5",
+        "lodash.merge": "^4.6.1",
+        "read-pkg-up": "^3.0.0"
+      }
+    },
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
@@ -2172,6 +2207,12 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
       "integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
     },
     "cacache": {
@@ -4008,6 +4049,26 @@
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -4552,6 +4613,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
+    },
+    "gzip-size": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
+      "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^3.0.0"
+      }
     },
     "handlebars": {
       "version": "4.4.0",
@@ -5414,6 +5485,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonpack": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jsonpack/-/jsonpack-1.1.5.tgz",
+      "integrity": "sha1-1CsNz9kaxY7zEQ+W0sWZQEw9wnw=",
+      "dev": true
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -5706,6 +5783,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.set": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@changesets/cli": "^2.4.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
+    "bundlewatch": "0.2.5",
     "cross-env": "^5.2.1",
     "eslint": "^6.2.2",
     "eslint-plugin-cypress": "^2.6.1",
@@ -33,6 +34,14 @@
     "lint-staged": "^8.1.4",
     "prettier": "^1.16.4",
     "typescript": "^3.6.3"
+  },
+  "bundlewatch": {
+    "files": [
+      {
+        "path": "examples/mars-theme-example/build/static/mars-theme-example.*.js",
+        "compression": "none"
+      }
+    ]
   },
   "prettier": {}
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "files": [
       {
         "path": "examples/mars-theme-example/build/static/mars-theme-example.*.js",
-        "compression": "none"
+        "maxSize": "200kb"
       }
     ]
   },


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

Add bundlewatch github action.

Why?
- The `budget.json` file and the corresponding github action are annoying to remember to edit for almost every PR.
- The lighthouse output is hidden in github behind several clicks on the PR.
- With bundlewatch, we get a badge directly on the PR, no more clicking around.
- What is ACTUALLY important IMO is seeing the bundle size increase for each change added package, etc. and **not** trying to be under some artificially prescribed size.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🔝 Improvement

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!