### PR TITLE
Fix the ubuntu version used in the cypress github action

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,9 @@ jobs:
           start: npm run e2e:prod:${{ matrix.ci_node_index }}
           wait-on: "http://localhost:3001"
           wait-on-timeout: 180
-          env: HEADLESS=true DEBUG=cypress:*
+          env:
+            HEADLESS: true
+            DEBUG: cypress:*
           working-directory: e2e
           config: video=true,screenshotOnRunFailure=true
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,11 +34,11 @@ jobs:
           start: npm run e2e:prod:${{ matrix.ci_node_index }}
           wait-on: "http://localhost:3001"
           wait-on-timeout: 180
-          env:
-            HEADLESS: true
-            DEBUG: cypress:*
+          env: HEADLESS=true
           working-directory: e2e
           config: video=true,screenshotOnRunFailure=true
+        env:
+          DEBUG: cypress:*
 
       - name: Upload screenshots on failure
         uses: actions/upload-artifact@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,8 +37,6 @@ jobs:
           env: HEADLESS=true
           working-directory: e2e
           config: video=true,screenshotOnRunFailure=true
-        env:
-          DEBUG: cypress:*
 
       - name: Upload screenshots on failure
         uses: actions/upload-artifact@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
           start: npm run e2e:prod:${{ matrix.ci_node_index }}
           wait-on: "http://localhost:3001"
           wait-on-timeout: 180
-          env: HEADLESS=true,DEBUG=cypress:*
+          env: HEADLESS=true DEBUG=cypress:*
           working-directory: e2e
           config: video=true,screenshotOnRunFailure=true
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: e2e tests 
+name: e2e tests
 
 on: [push]
 
@@ -28,13 +28,13 @@ jobs:
         env:
           CI: true
 
-      - name: Run e2e tests 
+      - name: Run e2e tests
         uses: cypress-io/github-action@v1
         with:
           start: npm run e2e:prod:${{ matrix.ci_node_index }}
           wait-on: "http://localhost:3001"
           wait-on-timeout: 180
-          env: HEADLESS=true
+          env: HEADLESS=true,DEBUG=cypress:*
           working-directory: e2e
           config: video=true,screenshotOnRunFailure=true
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     strategy:
       matrix:


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

<!-- Please describe everything as much as possible -->
The e2e tests were failing because the cypress github action requires `ubuntu-16.04` and `ubuntu-latest` is now `ubuntu-18.04`. This PR solves that problem.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
