### PR TITLE
CLI: Add theme param to create

### DIFF
--- a/.changeset/tidy-pets-yawn.md
+++ b/.changeset/tidy-pets-yawn.md
@@ -1,0 +1,5 @@
+---
+"frontity": minor
+---
+
+Add a new option `--theme` option which allows specifying the starter theme on the command line. If the theme is not specified, the user can pick a theme from an interactive prompt.

--- a/.changeset/tidy-pets-yawn.md
+++ b/.changeset/tidy-pets-yawn.md
@@ -2,4 +2,4 @@
 "frontity": minor
 ---
 
-Add a new option `--theme` option which allows specifying the starter theme on the command line. If the theme is not specified, the user can pick a theme from an interactive prompt.
+Add a new option `--theme` which allows specifying the starter theme on the command line. If the theme is not specified, the user can pick a theme from an interactive prompt.

--- a/packages/frontity/package.json
+++ b/packages/frontity/package.json
@@ -73,6 +73,7 @@
     "@types/stack-trace": "0.0.29",
     "@types/tar": "^4.0.0",
     "jest": "^24.7.1",
+    "lodash.omit": "4.5.0",
     "ts-jest": "^24.0.2"
   }
 }

--- a/packages/frontity/src/__tests__/__snapshots__/create.cli.test.ts.snap
+++ b/packages/frontity/src/__tests__/__snapshots__/create.cli.test.ts.snap
@@ -56,11 +56,17 @@ Array [
     Array [
       Object {
         "choices": Array [
-          "@frontity/mars-theme",
-          "@frontity/twentytwenty-theme",
+          Object {
+            "name": "@frontity/mars-theme (default)",
+            "value": "@frontity/mars-theme",
+          },
+          Object {
+            "name": "@frontity/twentytwenty-theme",
+            "value": "@frontity/twentytwenty-theme",
+          },
         ],
         "default": "@frontity/mars-theme",
-        "message": "Enter a starter theme to clone:",
+        "message": "Pick a starter theme to clone:",
         "name": "theme",
         "type": "list",
       },

--- a/packages/frontity/src/__tests__/__snapshots__/create.cli.test.ts.snap
+++ b/packages/frontity/src/__tests__/__snapshots__/create.cli.test.ts.snap
@@ -1,20 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CLI create FRONTITY_NAME='test-project'; frontity create --no-prompt 1`] = `"test-project"`;
+exports[`CLI create FRONTITY_NAME='test-project'; frontity create --no-prompt 1`] = `
+Object {
+  "name": "test-project",
+  "theme": undefined,
+  "typescript": false,
+}
+`;
 
-exports[`CLI create FRONTITY_NAME='test-project'; frontity create --no-prompt 2`] = `false`;
+exports[`CLI create FRONTITY_TYPESCRIPT='true'; frontity create 'test-project' --no-prompt 1`] = `
+Object {
+  "name": "test-project",
+  "theme": undefined,
+  "typescript": true,
+}
+`;
 
-exports[`CLI create FRONTITY_TYPESCRIPT='true'; frontity create 'test-project' --no-prompt 1`] = `"test-project"`;
+exports[`CLI create frontity create 'test-project' --theme 'test-theme' 1`] = `
+Object {
+  "name": "test-project",
+  "theme": "test-theme",
+  "typescript": true,
+}
+`;
 
-exports[`CLI create FRONTITY_TYPESCRIPT='true'; frontity create 'test-project' --no-prompt 2`] = `true`;
+exports[`CLI create frontity create 'test-project' --typescript 1`] = `
+Object {
+  "name": "test-project",
+  "theme": undefined,
+  "typescript": true,
+}
+`;
 
-exports[`CLI create frontity create 'test-project' --typescript 1`] = `"test-project"`;
-
-exports[`CLI create frontity create 'test-project' --typescript 2`] = `true`;
-
-exports[`CLI create frontity create 'test-project' 1`] = `"test-project"`;
-
-exports[`CLI create frontity create 'test-project' 2`] = `false`;
+exports[`CLI create frontity create 'test-project' 1`] = `
+Object {
+  "name": "test-project",
+  "theme": "test-theme",
+  "typescript": false,
+}
+`;
 
 exports[`CLI create frontity create 1`] = `
 Array [
@@ -26,6 +50,10 @@ Array [
         "name": "name",
         "type": "input",
       },
+    ],
+  ],
+  Array [
+    Array [
       Object {
         "default": "@frontity/mars-theme",
         "message": "Enter a starter theme to clone:",

--- a/packages/frontity/src/__tests__/__snapshots__/create.cli.test.ts.snap
+++ b/packages/frontity/src/__tests__/__snapshots__/create.cli.test.ts.snap
@@ -55,10 +55,14 @@ Array [
   Array [
     Array [
       Object {
+        "choices": Array [
+          "@frontity/mars-theme",
+          "@frontity/twentytwenty-theme",
+        ],
         "default": "@frontity/mars-theme",
         "message": "Enter a starter theme to clone:",
         "name": "theme",
-        "type": "input",
+        "type": "list",
       },
     ],
   ],

--- a/packages/frontity/src/__tests__/__snapshots__/create.test.ts.snap
+++ b/packages/frontity/src/__tests__/__snapshots__/create.test.ts.snap
@@ -4,6 +4,7 @@ exports[`create goes through all steps 1`] = `
 Object {
   "name": "random-name",
   "path": "/path/to/project",
+  "theme": "@frontity/mars-theme",
 }
 `;
 
@@ -19,7 +20,7 @@ exports[`create goes through all steps 3`] = `
 Array [
   Array [
     "random-name",
-    undefined,
+    "@frontity/mars-theme",
     "/path/to/project",
   ],
 ]
@@ -31,6 +32,7 @@ Array [
     "js",
     "random-name",
     "/path/to/project",
+    "@frontity/mars-theme",
   ],
 ]
 `;
@@ -38,7 +40,7 @@ Array [
 exports[`create goes through all steps 5`] = `
 Array [
   Array [
-    undefined,
+    "@frontity/mars-theme",
     "/path/to/project",
   ],
 ]

--- a/packages/frontity/src/__tests__/create.cli.test.ts
+++ b/packages/frontity/src/__tests__/create.cli.test.ts
@@ -27,13 +27,15 @@ describe("CLI create", () => {
     mockedUtils.errorLogger = jest.fn();
   });
 
+  const options = {
+    name: undefined,
+    typescript: undefined,
+    useCwd: undefined,
+    theme: undefined,
+    prompt: true
+  };
+
   test("frontity create", async done => {
-    const options = {
-      name: undefined,
-      typescript: undefined,
-      useCwd: undefined,
-      prompt: true
-    };
     await create(options);
 
     expect(mockedInquirer.prompt.mock.calls).toMatchSnapshot();
@@ -51,16 +53,11 @@ describe("CLI create", () => {
   });
 
   test("frontity create 'test-project'", () => {
-    const options = {
-      name: "test-project",
-      typescript: undefined,
-      useCwd: undefined,
-      prompt: true
-    };
-
     // Don't need to await because we only check the args
     // that the create command was called with
-    create(options);
+    const name = "test-project";
+
+    create({ ...options, name });
 
     // the path will differ depending on whether we run the test locally or on
     expect(mockedCreateCmd.default.mock.calls[0][0].name).toMatchSnapshot();
@@ -69,23 +66,19 @@ describe("CLI create", () => {
     ).toMatchSnapshot();
 
     expect(mockedCreateCmd.default).toHaveBeenCalledWith({
-      name: options.name,
+      name: name,
       typescript: false,
-      path: resolve(process.cwd(), options.name)
+      path: resolve(process.cwd(), name)
     });
   });
 
   test("frontity create 'test-project' --typescript", () => {
-    const options = {
-      name: "test-project",
-      typescript: true,
-      useCwd: undefined,
-      prompt: true
-    };
-
     // Don't need to await because we only check the args
     // that the create command was called with
-    create(options);
+    const name = "test-project";
+    const typescript = true;
+
+    create({ ...options, name, typescript });
 
     // the path will differ depending on whether we run the test locally or on
     expect(mockedCreateCmd.default.mock.calls[0][0].name).toMatchSnapshot();
@@ -94,22 +87,15 @@ describe("CLI create", () => {
     ).toMatchSnapshot();
 
     expect(mockedCreateCmd.default).toHaveBeenCalledWith({
-      name: options.name,
-      typescript: true,
-      path: resolve(process.cwd(), options.name)
+      name: name,
+      typescript,
+      path: resolve(process.cwd(), name)
     });
   });
 
   test("frontity create --no-prompt", async () => {
-    const options = {
-      name: undefined,
-      typescript: true,
-      useCwd: undefined,
-      prompt: false
-    };
-
     try {
-      await create(options);
+      await create({ ...options, typescript: true, prompt: false });
     } catch (err) {
       expect(err.message).toBe("You need to provide the name for the project");
     }
@@ -118,13 +104,6 @@ describe("CLI create", () => {
   test("FRONTITY_NAME='test-project'; frontity create --no-prompt", () => {
     const name = "test-project";
     process.env.FRONTITY_NAME = name;
-
-    const options = {
-      name: undefined,
-      typescript: undefined,
-      useCwd: undefined,
-      prompt: false
-    };
 
     // Don't need to await because we only check the args
     // that the create command was called with
@@ -144,18 +123,12 @@ describe("CLI create", () => {
   });
 
   test("FRONTITY_TYPESCRIPT='true'; frontity create 'test-project' --no-prompt", () => {
+    const name = "test-project";
     process.env.FRONTITY_TYPESCRIPT = "true";
-
-    const options = {
-      name: "test-project",
-      typescript: undefined,
-      useCwd: undefined,
-      prompt: false
-    };
 
     // Don't need to await because we only check the args
     // that the create command was called with
-    create(options);
+    create({ ...options, name });
 
     // the path will differ depending on whether we run the test locally or on
     expect(mockedCreateCmd.default.mock.calls[0][0].name).toMatchSnapshot();
@@ -164,9 +137,9 @@ describe("CLI create", () => {
     ).toMatchSnapshot();
 
     expect(mockedCreateCmd.default).toHaveBeenCalledWith({
-      name: options.name,
+      name: name,
       typescript: true,
-      path: resolve(process.cwd(), options.name)
+      path: resolve(process.cwd(), name)
     });
   });
 });

--- a/packages/frontity/src/__tests__/create.cli.test.ts
+++ b/packages/frontity/src/__tests__/create.cli.test.ts
@@ -47,7 +47,7 @@ describe("CLI create", () => {
       { message: "Enter a name for the project:" }
     ]);
     expect(mockedInquirer.prompt.mock.calls[1][0]).toMatchObject([
-      { message: "Enter a starter theme to clone:" }
+      { message: "Pick a starter theme to clone:" }
     ]);
 
     expect(mockedInquirer.prompt.mock.calls[2][0]).toMatchObject([

--- a/packages/frontity/src/__tests__/create.test.ts
+++ b/packages/frontity/src/__tests__/create.test.ts
@@ -74,8 +74,7 @@ describe("create", () => {
         throw error;
       });
 
-      const emitter = create(options);
-      await emitter;
+      await create(options);
     } catch (err) {
       expect(err.message).toBe("Mocked Error");
       expect(mockedSteps.revertProgress).toHaveBeenCalledWith(
@@ -98,8 +97,7 @@ describe("create", () => {
         throw error;
       });
 
-      const emitter = create(options);
-      await emitter;
+      await create(options);
       throw new Error("This should not be reached");
     } catch (err) {
       expect(err.message).toBe("Mocked Error");
@@ -122,8 +120,7 @@ describe("create", () => {
         throw error;
       });
 
-      const emitter = create(options);
-      await emitter;
+      await create(options);
       throw new Error("This should never be reached");
     } catch (err) {
       expect(err.message).toBe("Mocked Error");
@@ -153,8 +150,7 @@ describe("create", () => {
         throw error;
       });
 
-      const emitter = create(options);
-      await emitter;
+      await create(options);
     } catch (err) {
       expect(err.message).toBe("Mocked Error");
     }

--- a/packages/frontity/src/__tests__/create.test.ts
+++ b/packages/frontity/src/__tests__/create.test.ts
@@ -159,4 +159,41 @@ describe("create", () => {
       expect(err.message).toBe("Mocked Error");
     }
   });
+
+  test("If no theme is specified, clone the default", async () => {
+    const options = {
+      name: "random-name",
+      path: "/path/to/project"
+    };
+
+    // Restore the original implementation
+    const { normalizeOptions } = jest.requireActual("../steps");
+    mockedSteps.normalizeOptions.mockImplementation(normalizeOptions);
+
+    mockedSteps.ensureProjectDir.mockResolvedValueOnce(false);
+
+    await create(options);
+
+    expect(mockedSteps.cloneStarterTheme).toHaveBeenCalledTimes(1);
+    expect(mockedSteps.cloneStarterTheme).toHaveBeenCalledWith(
+      "@frontity/mars-theme",
+      options.path
+    );
+  });
+
+  test("Clone the specified theme", async () => {
+    const options = {
+      name: "random-name",
+      path: "/path/to/project",
+      theme: "@frontity/twentytwenty-theme"
+    };
+
+    await create(options);
+
+    expect(mockedSteps.cloneStarterTheme).toHaveBeenCalledTimes(1);
+    expect(mockedSteps.cloneStarterTheme).toHaveBeenCalledWith(
+      options.theme,
+      options.path
+    );
+  });
 });

--- a/packages/frontity/src/__tests__/create.test.ts
+++ b/packages/frontity/src/__tests__/create.test.ts
@@ -22,7 +22,8 @@ describe("create", () => {
   test("goes through all steps", async () => {
     const options = {
       name: "random-name",
-      path: "/path/to/project"
+      path: "/path/to/project",
+      theme: "@frontity/mars-theme"
     };
     await create(options);
     expect(mockedSteps.normalizeOptions.mock.calls[0][1]).toMatchSnapshot();
@@ -34,20 +35,31 @@ describe("create", () => {
   });
 
   test("works correctly when `options.typescript` is false", async () => {
+    // Restore the original implementation
+    const { normalizeOptions } = jest.requireActual("../steps");
+    mockedSteps.normalizeOptions.mockImplementation(normalizeOptions);
+
     const options = {
       name: "random-name",
       path: "/path/to/project",
       typescript: false
     };
+
     await create(options);
+
     expect(mockedSteps.createFrontitySettings).toHaveBeenCalledWith(
       "js",
       options.name,
-      options.path
+      options.path,
+      "@frontity/mars-theme"
     );
   });
 
   test("works correctly when `options.typescript` is true", async () => {
+    // Restore the original implementation
+    const { normalizeOptions } = jest.requireActual("../steps");
+    mockedSteps.normalizeOptions.mockImplementation(normalizeOptions);
+
     const options = {
       name: "random-name",
       path: "/path/to/project",
@@ -57,7 +69,8 @@ describe("create", () => {
     expect(mockedSteps.createFrontitySettings).toHaveBeenCalledWith(
       "ts",
       options.name,
-      options.path
+      options.path,
+      "@frontity/mars-theme"
     );
   });
 

--- a/packages/frontity/src/__tests__/steps.test.ts
+++ b/packages/frontity/src/__tests__/steps.test.ts
@@ -169,8 +169,9 @@ describe("createFrontitySettings", () => {
     const name = "random-name";
     const path = "/path/to/project";
     const extension = "js";
+    const theme = "@frontity/mars-theme";
 
-    await createFrontitySettings(extension, name, path);
+    await createFrontitySettings(extension, name, path, theme);
     expect(mockedFsExtra.readFile).toHaveBeenCalled();
     expect(mockedFsExtra.writeFile.mock.calls).toMatchSnapshot();
   });
@@ -179,8 +180,9 @@ describe("createFrontitySettings", () => {
     const name = "random-name";
     const path = "/path/to/project";
     const extension = "ts";
+    const theme = "@frontity/mars-theme";
 
-    await createFrontitySettings(extension, name, path);
+    await createFrontitySettings(extension, name, path, theme);
     expect(mockedFsExtra.readFile).toHaveBeenCalled();
     expect(mockedFsExtra.writeFile.mock.calls).toMatchSnapshot();
   });

--- a/packages/frontity/src/cli/create.ts
+++ b/packages/frontity/src/cli/create.ts
@@ -9,16 +9,19 @@ import { Options } from "../steps/types";
 
 export default async ({
   name,
+  theme,
   typescript,
   useCwd,
   prompt: promptUser
 }: {
   name: string;
+  theme: string;
   typescript: boolean;
   useCwd: boolean;
   prompt: boolean;
 }) => {
   name = name || process.env.FRONTITY_NAME;
+  theme = theme || process.env.FRONTITY_THEME;
   typescript = typescript || !!process.env.FRONTITY_TYPESCRIPT;
   useCwd = useCwd || !!process.env.FRONTITY_USE_CWD;
 

--- a/packages/frontity/src/cli/create.ts
+++ b/packages/frontity/src/cli/create.ts
@@ -1,7 +1,7 @@
 import { resolve } from "path";
 import ora from "ora";
 import chalk from "chalk";
-import { prompt, Question } from "inquirer";
+import { prompt, Question, ListQuestion } from "inquirer";
 import create from "../commands/create";
 import { subscribe } from "../steps";
 import { errorLogger, log } from "../utils";
@@ -47,20 +47,24 @@ export default async ({
     options.name = name;
   }
 
-  if (!theme && promptUser) {
-    const questions: Question[] = [
+  // The theme was provided as a CLI option
+  if (theme) {
+    options.theme = theme;
+  } else if (promptUser) {
+    // The theme was NOT provided as a CLI option
+    // In this case, we prompt the user
+    const questions: ListQuestion[] = [
       {
         name: "theme",
-        type: "input",
+        type: "list",
         message: "Enter a starter theme to clone:",
-        default: "@frontity/mars-theme"
+        default: "@frontity/mars-theme",
+        choices: ["@frontity/mars-theme", "@frontity/twentytwenty-theme"]
       }
     ];
 
     const answers = await prompt(questions);
     options.theme = answers.theme;
-  } else {
-    options.theme = theme;
   }
 
   options.typescript = typescript;

--- a/packages/frontity/src/cli/create.ts
+++ b/packages/frontity/src/cli/create.ts
@@ -57,9 +57,18 @@ export default async ({
       {
         name: "theme",
         type: "list",
-        message: "Enter a starter theme to clone:",
+        message: "Pick a starter theme to clone:",
         default: "@frontity/mars-theme",
-        choices: ["@frontity/mars-theme", "@frontity/twentytwenty-theme"]
+        choices: [
+          {
+            name: "@frontity/mars-theme (default)",
+            value: "@frontity/mars-theme"
+          },
+          {
+            name: "@frontity/twentytwenty-theme",
+            value: "@frontity/twentytwenty-theme"
+          }
+        ]
       }
     ];
 

--- a/packages/frontity/src/cli/create.ts
+++ b/packages/frontity/src/cli/create.ts
@@ -38,7 +38,17 @@ export default async ({
         type: "input",
         message: "Enter a name for the project:",
         default: "my-frontity-project"
-      },
+      }
+    ];
+
+    const answers = await prompt(questions);
+    options.name = answers.name;
+  } else {
+    options.name = name;
+  }
+
+  if (!theme && promptUser) {
+    const questions: Question[] = [
       {
         name: "theme",
         type: "input",
@@ -48,10 +58,9 @@ export default async ({
     ];
 
     const answers = await prompt(questions);
-    options.name = answers.name;
     options.theme = answers.theme;
   } else {
-    options.name = name;
+    options.theme = theme;
   }
 
   options.typescript = typescript;

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -47,6 +47,7 @@ program
 // options: --typescript, --use-cwd.
 program
   .command("create [name]")
+  .option("-h, --theme <theme>", "The theme to use")
   .option("-t, --typescript", "Adds support for TypeScript")
   .option("-c, --use-cwd", "Generates the project in the current directory.")
   .option("-n, --no-prompt", "Skips prompting the user for options")

--- a/packages/frontity/src/commands/create.ts
+++ b/packages/frontity/src/commands/create.ts
@@ -55,7 +55,7 @@ const create = async (
 
     // 4. Creates `frontity.settings`.
     const extension = typescript ? "ts" : "js";
-    step = createFrontitySettings(extension, name, path);
+    step = createFrontitySettings(extension, name, path, theme);
     emitMessage(
       `Creating ${chalk.yellow(`frontity.settings.${extension}`)}.`,
       step

--- a/packages/frontity/src/commands/create.ts
+++ b/packages/frontity/src/commands/create.ts
@@ -62,7 +62,7 @@ const create = async (
     );
     await step;
 
-    // 5. Clones `@frontity/mars-theme` inside `packages`.
+    // 5. Clones the theme inside `packages`.
     step = cloneStarterTheme(theme, path);
     emitMessage(`Cloning ${chalk.green(theme)}.`, step);
     await step;

--- a/packages/frontity/src/steps/index.ts
+++ b/packages/frontity/src/steps/index.ts
@@ -118,7 +118,8 @@ export const createPackageJson = async (
 export const createFrontitySettings = async (
   extension: string,
   name: string,
-  path: string
+  path: string,
+  theme: string
 ) => {
   const frontitySettings = {
     name,
@@ -131,7 +132,7 @@ export const createFrontitySettings = async (
     },
     packages: [
       {
-        name: "@frontity/mars-theme",
+        name: theme,
         state: {
           theme: {
             menu: [


### PR DESCRIPTION
#### Description of what you did:

This PR adds the ability to pick a theme when running the `frontity create`.

- A new option `--theme` which allows specifying the starter theme on the command line. 
- If the theme is not specified, the user can pick a theme from an interactive prompt
- If the command is run with `--no-prompt`, fall back to the default theme (mars-theme)

(A few unrelated and small improvements to the tests for the CLI also made it here, by the way)

#### My PR is a:

- 🚀 New feature

#### Is the PR ready to be merged?

- 🚧 Work in progress

----

Fixes #132  