### PR TITLE
Fix duplicated array elements in the state

### DIFF
--- a/.changeset/calm-onions-call.md
+++ b/.changeset/calm-onions-call.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Prevent array elements stored in the state to be duplicated during CSR

--- a/packages/core/src/client/store.ts
+++ b/packages/core/src/client/store.ts
@@ -12,7 +12,7 @@ export default ({
   state: Package["state"];
 }) => {
   state.frontity.platform = "client";
-  const merged = mergePackages({ packages, state });
+  const merged = mergePackages({ packages, state, overwriteArrays: true });
   const store = createStore(merged);
   return store;
 };

--- a/packages/core/src/utils/__tests__/merge-packages.tests.tsx
+++ b/packages/core/src/utils/__tests__/merge-packages.tests.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/display-name, @typescript-eslint/camelcase */
+
 import React from "react";
 import mergePackages from "../merge-packages";
 
@@ -13,12 +15,13 @@ const state = {
     packages: ["package-1", "package-2", "package-3"]
   }
 };
+
 const packages = {
   package_1_html: {
     name: "package1",
     roots: {
-      namespace1: () => <div>"namespace1"</div>,
-      namespace2: () => <div>"namespace2"</div>
+      namespace1: () => <div>namespace1</div>,
+      namespace2: () => <div>namespace2</div>
     },
     state: {
       namespace1: {
@@ -38,7 +41,7 @@ const packages = {
   package_2_html: {
     name: "package2",
     roots: {
-      namespace3: () => <div>"namespace3"</div>
+      namespace3: () => <div>namespace3</div>
     },
     state: {
       namespace1: {
@@ -64,7 +67,7 @@ const packages = {
   package_3_html: () => ({
     name: "package3",
     roots: {
-      namespace4: () => <div>"namespace4"</div>
+      namespace4: () => <div>namespace4</div>
     },
     state: {
       namespace4: {
@@ -92,6 +95,24 @@ describe("mergePackages", () => {
 
   it("should deep clone state", () => {
     const merged = mergePackages({ packages, state });
+    expect(state.frontity).not.toBe(merged.state.frontity);
+    expect(packages.package_2_html.state.namespace3).not.toBe(
+      merged.state.namespace3
+    );
+  });
+
+  it("should overwrite arrays if the 'overwriteArrays' option is true", () => {
+    const { state: initialState } = mergePackages({ packages, state });
+    const merged = mergePackages({
+      packages,
+      state: initialState,
+      overwriteArrays: true
+    });
+    expect(merged.state.namespace1.array1).toEqual(["item1", "item2", "item3"]);
+  });
+
+  it("should deep clone state if the 'overwriteArrays' option is true", () => {
+    const merged = mergePackages({ packages, state, overwriteArrays: true });
     expect(state.frontity).not.toBe(merged.state.frontity);
     expect(packages.package_2_html.state.namespace3).not.toBe(
       merged.state.namespace3

--- a/packages/core/src/utils/merge-packages.ts
+++ b/packages/core/src/utils/merge-packages.ts
@@ -4,16 +4,23 @@ import getVariable from "./get-variable";
 
 type PackageFunction = () => Package;
 
+// Callback that replaces arrays (to be used by deepmerge).
+const overwriteMerge: deepmerge.Options["arrayMerge"] = (_, sourceArray) => {
+  return sourceArray;
+};
+
 // Merge all packages together in a single config that can be passed
 // to createStore.
 export default ({
   packages,
-  state
+  state,
+  overwriteArrays = false
 }: {
   packages: {
     [name: string]: Package | PackageFunction;
   };
   state: Package["state"];
+  overwriteArrays?: boolean;
 }): Package => {
   let config: Package = {
     roots: {},
@@ -31,7 +38,8 @@ export default ({
     });
   });
   config.state = deepmerge(config.state, state, {
-    clone: true
+    clone: true,
+    arrayMerge: overwriteArrays ? overwriteMerge : undefined
   });
   delete config.name;
   return config;


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

<!-- Please describe everything as much as possible -->
This PR adds a `overwriteArrays` option to the `mergePackages` function, allowing it to overwrite arrays in the Frontity state when is set to `true`. Also, that option is used in the client's `createStore` function in order to replace state arrays by those generated during SSR.

Fixes #237

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
