### PR TITLE
Frontity: Add the typescript dependency back

### DIFF
--- a/.changeset/young-cobras-serve.md
+++ b/.changeset/young-cobras-serve.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Fix missing typescript dependency in the frontity package. This package is the one responsible to inject typescript in a Frontity Project and the Frontity CLI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11661,9 +11661,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint-staged": "^8.1.4",
     "prettier": "^1.16.4",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8.2"
   },
   "prettier": {}
 }

--- a/packages/frontity/package.json
+++ b/packages/frontity/package.json
@@ -57,7 +57,8 @@
     "simple-entity-decode": "^0.0.3",
     "tar": "^4.4.8",
     "ts-node": "^8.0.3",
-    "typed-emitter": "^0.2.0"
+    "typed-emitter": "^0.2.0",
+    "typescript": "^3.8.2"
   },
   "devDependencies": {
     "@frontity/core": "^1.5.0",


### PR DESCRIPTION


<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

When I refactored the tests I moved all the typescript dependencies to the root and the `frontity` package was missing typescript when installed via `npx`. This PR adds it back because `frontity` is the one injecting typescript in a Frontity Project and CLI.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
