### PR TITLE
Fix numeric entities in decode

### DIFF
--- a/.changeset/shy-planes-wink.md
+++ b/.changeset/shy-planes-wink.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+The `decode` function now properly decodes numeric entities.

--- a/packages/frontity/src/decode/__tests__/decode.test.ts
+++ b/packages/frontity/src/decode/__tests__/decode.test.ts
@@ -22,6 +22,14 @@ describe("decode", () => {
     expect(result).toBe("&");
   });
 
+  test("decodes numeric entities", () => {
+    const numeric = "blog&#8217;s";
+    const client = decodeClient(numeric);
+    expect(client).toBe("blog’s");
+    const server = decodeServer(numeric);
+    expect(server).toBe("blog’s");
+  });
+
   test("client preserves the whitespace", () => {
     const result = decodeClient("  &amp; ");
     expect(result).toBe("  & ");
@@ -33,8 +41,10 @@ describe("decode", () => {
   });
 
   test("handles different characters", () => {
-    const result = decodeServer("&equiv; &gamma;");
-    expect(result).toBe("≡ γ");
+    const client = decodeClient("&equiv; &gamma; &#8217;");
+    expect(client).toBe("≡ γ ’");
+    const server = decodeServer("&equiv; &gamma; &#8217;");
+    expect(server).toBe("≡ γ ’");
   });
 
   test("call he.decode if html contains a character that basic decode cannot not handle", () => {

--- a/packages/frontity/src/decode/__tests__/decode.test.ts
+++ b/packages/frontity/src/decode/__tests__/decode.test.ts
@@ -1,5 +1,5 @@
-import decodeServer from "./server";
-import decodeClient from "./client";
+import decodeServer from "../server";
+import decodeClient from "../client";
 import * as he from "he";
 
 jest.mock("he");

--- a/packages/frontity/src/decode/containsHTMLEntities.ts
+++ b/packages/frontity/src/decode/containsHTMLEntities.ts
@@ -1,5 +1,5 @@
 function containsHTMLEntities(text: string) {
-  return /&[a-zA-Z]+(;|\s)/.test(text);
+  return /&(#(([0-9]+)|x([a-fA-F0-9]+))|[a-zA-Z]+)(;|\s)/.test(text);
 }
 
 export default containsHTMLEntities;

--- a/packages/html2react/src/libraries/__tests__/__snapshots__/component.tests.tsx.snap
+++ b/packages/html2react/src/libraries/__tests__/__snapshots__/component.tests.tsx.snap
@@ -34,6 +34,9 @@ Array [
       src="example.ogg"
       type="audio/ogg"
     />
+    <p>
+      Improve your blog’s performance & mobile experience.
+    </p>
   </audio>,
 ]
 `;

--- a/packages/html2react/src/libraries/__tests__/__snapshots__/parse.tests.ts.snap
+++ b/packages/html2react/src/libraries/__tests__/__snapshots__/parse.tests.ts.snap
@@ -83,6 +83,24 @@ Array [
         },
         "type": "element",
       },
+      Object {
+        "content": " Encoded phrase that should be decoded ",
+        "parent": [Circular],
+        "type": "comment",
+      },
+      Object {
+        "children": Array [
+          Object {
+            "content": "Improve your blog’s performance & mobile experience.",
+            "parent": [Circular],
+            "type": "text",
+          },
+        ],
+        "component": "p",
+        "parent": [Circular],
+        "props": Object {},
+        "type": "element",
+      },
     ],
     "component": "audio",
     "props": Object {

--- a/packages/html2react/src/libraries/__tests__/mocks/html.ts
+++ b/packages/html2react/src/libraries/__tests__/mocks/html.ts
@@ -11,4 +11,7 @@ export default `
   <audio autoplay>
     <source src="example.ogg" type="audio/ogg">
   </div>
+
+  <!-- Encoded phrase that should be decoded -->
+  <p>Improve your blog&#8217;s performance &amp; mobile experience.</p>
 `;


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

It looks like we were not taking into account numeric entities in our first regexp so I modified the regexp.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
