### PR TITLE
Fix broken auto fetch on hover twentytwenty-theme

### DIFF
--- a/.changeset/nine-laws-whisper.md
+++ b/.changeset/nine-laws-whisper.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Don't auto fetch on hover when the link is external.

--- a/packages/twentytwenty-theme/src/components/link.js
+++ b/packages/twentytwenty-theme/src/components/link.js
@@ -52,7 +52,8 @@ const Link = ({
       rel={isExternal ? "noopener noreferrer" : rel}
       onMouseEnter={() => {
         // Prefetch the link's content when the user hovers on the link
-        if (state.theme.autoPreFetch === "hover") actions.source.fetch(link);
+        if (state.theme.autoPreFetch === "hover" && !isExternal)
+          actions.source.fetch(link);
       }}
     >
       {children}


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

I've just noticed that the `TypeError: Cannot read property 'split' of undefined` we were getting in the twentytwenty-theme was due to an error in the auto fetch on hover, which was not checking if the link was external. It is so simple that I just fixed it directly.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
