### PR TITLE
Update connect with upstream fixes

### DIFF
--- a/packages/connect/src/connect.js
+++ b/packages/connect/src/connect.js
@@ -18,8 +18,6 @@ const context = createContext();
 
 export const Provider = context.Provider;
 
-const hasHooks = typeof useState === "function";
-
 const mapStateToStores = state => {
   // find store properties and map them to their none observable raw value
   // to do not trigger none static this.setState calls
@@ -36,7 +34,7 @@ export function connect(Comp) {
 
   let ReactiveComp;
 
-  if (isStatelessComp && hasHooks) {
+  if (isStatelessComp) {
     // use a hook based reactive wrapper when we can
     ReactiveComp = props => {
       // set a flag to know when the component is unmounted.
@@ -67,9 +65,6 @@ export function connect(Comp) {
           unobserve(render);
         };
       }, []);
-
-      ReactiveComp.displayName = Comp.displayName || Comp.name;
-      ReactiveComp = memo(ReactiveComp);
 
       // run the reactive render instead of the original one
       return render({ ...props, ...frontity });
@@ -158,6 +153,7 @@ export function connect(Comp) {
   }
 
   ReactiveComp.displayName = Comp.displayName || Comp.name;
+
   // static props are inherited by class components,
   // but have to be copied for function components
   if (isStatelessComp) {
@@ -166,5 +162,5 @@ export function connect(Comp) {
     }
   }
 
-  return ReactiveComp;
+  return isStatelessComp ? memo(ReactiveComp) : ReactiveComp;
 }

--- a/packages/connect/src/connect.js
+++ b/packages/connect/src/connect.js
@@ -37,7 +37,7 @@ export function connect(Comp) {
 
   if (isStatelessComp && hasHooks) {
     // use a hook based reactive wrapper when we can
-    ReactiveComp = memo(props => {
+    ReactiveComp = props => {
       // set a flag to know when the component is unmounted.
       const _isMounted = useRef(true);
 
@@ -66,9 +66,12 @@ export function connect(Comp) {
         };
       }, []);
 
+      ReactiveComp.displayName = Comp.displayName || Comp.name;
+      ReactiveComp = memo(ReactiveComp);
+
       // run the reactive render instead of the original one
       return render({ ...props, ...frontity });
-    });
+    };
   } else {
     const BaseComp = isStatelessComp ? Component : Comp;
     // a HOC which overwrites render, shouldComponentUpdate and componentWillUnmount

--- a/packages/connect/src/connect.js
+++ b/packages/connect/src/connect.js
@@ -57,7 +57,7 @@ export function connect(Comp) {
             scheduler: () => _isMounted.current && triggerRender(),
             lazy: true
           }),
-        []
+        [Comp]
       );
 
       // cleanup the reactive connections after the very last render of the component

--- a/packages/connect/src/connect.js
+++ b/packages/connect/src/connect.js
@@ -7,7 +7,8 @@ import {
   useState,
   useEffect,
   useContext,
-  useRef
+  useRef,
+  useCallback
 } from "react";
 import { observe, unobserve, raw, isObservable } from ".";
 
@@ -43,6 +44,7 @@ export function connect(Comp) {
 
       // use a dummy setState to update the component
       const [, setState] = useState();
+      const triggerRender = useCallback(() => setState({}), []);
 
       // get frontity from the context;
       const frontity = useContext(context);
@@ -52,7 +54,7 @@ export function connect(Comp) {
       const render = useMemo(
         () =>
           observe(Comp, {
-            scheduler: () => _isMounted.current && setState({}),
+            scheduler: () => _isMounted.current && triggerRender(),
             lazy: true
           }),
         []


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

I took a look at the latest changes of `react-easy-state` and I have started this PR to update our fork with their bugfixes:

- [x] Add displayName before memo for React DevTools
- [x] Use useCallback for the rerender trigger
- [x] Reload reactive render when Comp changes (for HMR)
- [ ] Fix cursor jumps to end of input fields
   - `react-easy-state` fix: https://github.com/RisingStack/react-easy-state/pull/113 (look only for the view.js, schedule.js and queue.js files).
- [ ] Fix reactivity with class components

I don't pretend to finish this PR right now, we will finish it once this gets priority in our roadmap, but I did some tests in our codebase while reviewing the changes of `react-easy-state` that I didn't want to lose.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fixes

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- 🚧 Work in progress
