### PR TITLE
Return 404 for the HMR updates that pass through

### DIFF
--- a/.changeset/sharp-dingos-search.md
+++ b/.changeset/sharp-dingos-search.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Avoid console error when an old tab is opened with localhost and the server is restarted.

--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -8,6 +8,7 @@ import htmlescape from "htmlescape";
 import { renderToString, renderToStaticMarkup } from "react-dom/server";
 import { FilledContext } from "react-helmet-async";
 import { getSettings } from "@frontity/file-settings";
+import { Context } from "@frontity/types";
 import { ChunkExtractor } from "@loadable/server";
 import getTemplate from "./templates";
 import {
@@ -36,12 +37,11 @@ export default ({ packages }): ReturnType<Koa["callback"]> => {
   );
 
   // Ignore HMR if not in dev mode or old browser open.
-  app.use(
-    get("/__webpack_hmr", ctx => {
-      ctx.status = 404;
-      ctx.body = "";
-    })
-  );
+  const return404 = (ctx: Context) => {
+    ctx.status = 404;
+  };
+  app.use(get("/__webpack_hmr", return404));
+  app.use(get("/static/([a-z0-9]+\\.hot-update\\.json)", return404));
 
   // Return Frontity favicon for favicon.ico.
   app.use(get("/favicon.ico", serve("./")));


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

Avoid throwing messages for the JSON requests of HMR that for some reason `webpack-dev-server` is not capturing and end up in the Frontity server. This happens when there are old tabs open pointing to localhost:3000 and they are trying to reconnect while you are starting the server again.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
