### PR TITLE
The babel cache identifier now requires a string

### DIFF
--- a/.changeset/tough-peas-sell.md
+++ b/.changeset/tough-peas-sell.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+`babel-loader` throws an error if the cache identifier is not a string.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "dev:inspect": "node --inspect-brk -r ts-node/register src/scripts/dev.ts",
     "serve:inspect": "node --inspect-brk -r ts-node/register src/scripts/serve.ts",
     "build": "../../node_modules/.bin/tsc --project ./tsconfig.build.json",
+    "build:watch": "../../node_modules/.bin/tsc --project ./tsconfig.build.json --watch",
     "prepublish": "npm run build"
   },
   "dependencies": {

--- a/packages/core/src/config/webpack/modules.ts
+++ b/packages/core/src/config/webpack/modules.ts
@@ -28,11 +28,11 @@ export default ({
           cacheDirectory: true,
           // A unique hash using @babel/core's version, the babel-loader's version,
           // and the contents of babel.
-          cacheIdentifier: hash({
+          cacheIdentifier: `${hash({
             babelCoreVersion: babelCore.version,
             babelLoaderVersion: babelLoader.version,
             babel: babel
-          }),
+          })}`,
           // Instead, use the babel options directly from our babel object.
           ...babel[target]
         }


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

The babel cache identifier now requires a string. Before he had a number and it worked fine, but now it throws an error.


#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
