### PR TITLE
Add bin property to `create-frontity`

### DIFF
--- a/.changeset/wise-dolls-judge.md
+++ b/.changeset/wise-dolls-judge.md
@@ -1,0 +1,5 @@
+---
+"create-frontity": patch
+---
+
+Add a `"bin"` property to the `package.json` of `create-frontity`.

--- a/packages/create-frontity/package.json
+++ b/packages/create-frontity/package.json
@@ -7,6 +7,9 @@
   ],
   "homepage": "https://frontity.org",
   "license": "Apache-2.0",
+  "bin": {
+    "create-frontity": "src/index.js"
+  },
   "main": "src/index.js",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

I forgot to add a `"bin"` property to the `package.json` of `create-frontity` so it doesn't work. This PR fixes that.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🐞 Bug fix


#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
