### PR TITLE
Let `npx frontity serve` errors throw normally

### DIFF
--- a/.changeset/thirty-numbers-vanish.md
+++ b/.changeset/thirty-numbers-vanish.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Don't catch errors in `npx frontity serve`.

--- a/packages/core/src/scripts/serve.ts
+++ b/packages/core/src/scripts/serve.ts
@@ -12,14 +12,7 @@ export default async ({
   port: number;
   isHttps: boolean;
 }): Promise<void> => {
-  let app;
-  try {
-    app = require(appDir).default;
-  } catch (error) {
-    throw new Error(
-      'Something went wrong. Did you forget to run "frontity build"?'
-    );
-  }
+  const app = require(appDir).default;
   const server = await createServer({ app, isHttps });
   server.listen(port);
   console.log(


### PR DESCRIPTION
We were catching all errors before and people can't know what's going
on, like for example here https://community.frontity.org/t/error-did-you-forget-to-run-frontity-build/1426

<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

I removed the try-catch block

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🔝 Improvement

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
