### PR TITLE
Use an options object on the `error` function

### DIFF
--- a/.changeset/sweet-papayas-cough.md
+++ b/.changeset/sweet-papayas-cough.md
@@ -1,0 +1,5 @@
+---
+"@frontity/error": minor
+---
+
+Use an options object as the second parameter of the `error` function to keep consistency with the rest of the Frontity APIs.

--- a/packages/error/__tests__/index.test.ts
+++ b/packages/error/__tests__/index.test.ts
@@ -20,11 +20,19 @@ describe("error", () => {
 
   test("In development, console.error the full message", () => {
     console.error = jest.fn();
-    error("This is wrong", false);
+    expect(() => error("This is wrong", { throw: false })).not.toThrow();
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenLastCalledWith(
       "This is wrong\nVisit https://community.frontity.org for help! 🙂\n"
     );
+  });
+
+  test("In production, console.error the short message", () => {
+    process.env.NODE_ENV = "production";
+    console.error = jest.fn();
+    expect(() => error("This is wrong", { throw: false })).not.toThrow();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenLastCalledWith("This is wrong");
   });
 });
 

--- a/packages/error/index.ts
+++ b/packages/error/index.ts
@@ -1,6 +1,16 @@
 const suffix = "\nVisit https://community.frontity.org for help! 🙂\n";
 
-export const error = (message: string, doThrow = true) => {
+interface FrontityError {
+  (
+    message: string,
+    options?: {
+      throw?: boolean;
+    }
+  ): void;
+}
+
+export const error: FrontityError = (message, options = {}) => {
+  const doThrow = typeof options.throw !== "undefined" ? options.throw : true;
   if (process.env.NODE_ENV !== "production") {
     if (doThrow) throw new Error(message + suffix);
     console.error(message + suffix);


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed
-->

#### Description of what you did:

Switch to an options object for the second parameter of the `error` function to keep consistency with the rest of the Frontity APIs.

Now, if users don't want to throw, they have to use:

```js
import { error } from "frontity";

error("My message", { throw: false });
```

This function was not documented yet, so we can safely do the change.

#### My PR is a:

<!-- Delete the ones that don't apply -->

- 🔝 Improvement

#### Is the PR ready to be merged?

<!-- Delete the one that don't apply -->

- ✅ Yes!
