### PR TITLE
Fix twentytwenty-theme 404s

### DIFF
--- a/.changeset/twenty-squids-flow.md
+++ b/.changeset/twenty-squids-flow.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Fix 404 pages of twentytwenty-theme

--- a/packages/twentytwenty-theme/src/components/page-error.js
+++ b/packages/twentytwenty-theme/src/components/page-error.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { styled } from "frontity";
+import { styled, connect } from "frontity";
 import SearchForm from "./search/search-form";
 import SectionContainer from "./styles/section-container";
 
@@ -34,7 +34,7 @@ const ErrorPage = ({ state }) => {
   );
 };
 
-export default ErrorPage;
+export default connect(ErrorPage);
 
 export const EntryTitle = styled.h1`
   margin: 0;


### PR DESCRIPTION
**What**:
This is a PR to solve 404 pages in the twentytwenty-theme.

**Why**:
It seems that the 404 pages in the twentytwenty-theme are returning an `Internal Server Error` right now -> https://twentytwenty.frontity.org/error

**How**:
I've seen that we are not using `connect` inside the `page-error.js`, and adding it seems to solve the problem -> https://github.com/frontity/frontity/blob/dev/packages/twentytwenty-theme/src/components/page-error.js#L37
