### PR TITLE
Get rid of getSnapshot in the store

### DIFF
--- a/.changeset/brave-kids-rest.md
+++ b/.changeset/brave-kids-rest.md
@@ -1,0 +1,6 @@
+---
+"@frontity/connect": patch
+"@frontity/core": patch
+---
+
+Move `getSnapshot` from a store property to an import of `"@frontity/connect"`.

--- a/packages/connect/src/__tests__/create-store.tests.js
+++ b/packages/connect/src/__tests__/create-store.tests.js
@@ -1,5 +1,5 @@
 /* eslint-disable require-atomic-updates */
-import { createStore, isObservable } from "..";
+import { createStore, isObservable, getSnapshot } from "..";
 
 let config = {};
 
@@ -181,8 +181,8 @@ describe("createStore actions", () => {
 describe("createStore getSnapshot", () => {
   it("should be able retrieve a serializable snapshot", () => {
     const store = createStore(config);
-    expect(store.getSnapshot()).toMatchSnapshot();
+    expect(getSnapshot(store.state)).toMatchSnapshot();
     store.actions.nested2.nested3.action5(3);
-    expect(store.getSnapshot()).toMatchSnapshot();
+    expect(getSnapshot(store.state)).toMatchSnapshot();
   });
 });

--- a/packages/connect/src/create-store.js
+++ b/packages/connect/src/create-store.js
@@ -1,6 +1,7 @@
-import { observable } from "./observable";
+import { observable, raw } from "./observable";
 
-const getSnapshot = (obj) => {
+export const getSnapshot = (obj) => {
+  obj = raw(obj);
   if (typeof obj === "function") return;
   if (typeof obj !== "object" || obj === null) return obj;
   if (obj instanceof Date) return new Date(obj.getTime());
@@ -52,7 +53,6 @@ export const createStore = (store) => {
     ...store,
     state: observableState,
     actions: {},
-    getSnapshot: () => getSnapshot(store.state),
   };
   const newActions = convertedActions(store.actions, instance);
   Object.assign(instance.actions, newActions);

--- a/packages/connect/src/index.d.ts
+++ b/packages/connect/src/index.d.ts
@@ -102,8 +102,9 @@ export type InitializedStore<St extends Store = Store> = Omit<
 > & {
   state: ResolveState<St["state"]>;
   actions: ResolveActions<St["actions"]>;
-  getSnapshot: () => St["state"];
 };
+
+export function getSnapshot(state: object): object;
 
 export function createStore<St extends Store>(store: St): InitializedStore<St>;
 

--- a/packages/connect/src/index.js
+++ b/packages/connect/src/index.js
@@ -1,5 +1,5 @@
 export { observe, unobserve } from "./observer";
 export { observable, isObservable, raw } from "./observable";
-export { createStore } from "./create-store";
+export { createStore, getSnapshot } from "./create-store";
 export { connect as default, Provider } from "./connect";
 export { batch } from "./scheduler";

--- a/packages/core/src/client/index.tsx
+++ b/packages/core/src/client/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { hydrate } from "react-dom";
 import { loadableReady } from "@loadable/component";
+import { getSnapshot } from "@frontity/connect";
 import App from "../app";
 import createStore from "./store";
 
@@ -17,7 +18,7 @@ export default async ({ packages }) => {
       const store = createStore({
         // Use initial state from server only if we are not in a HMR reload.
         state: window["frontity"]
-          ? window["frontity"].getSnapshot()
+          ? getSnapshot(window["frontity"].state)
           : JSON.parse(stateElement.innerHTML),
         packages,
       });

--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -9,6 +9,7 @@ import { renderToString, renderToStaticMarkup } from "react-dom/server";
 import { FilledContext } from "react-helmet-async";
 import { getSettings } from "@frontity/file-settings";
 import { Context } from "@frontity/types";
+import { getSnapshot } from "@frontity/connect";
 import { ChunkExtractor } from "@loadable/server";
 import getTemplate from "./templates";
 import {
@@ -120,7 +121,7 @@ export default ({ packages }): ReturnType<Koa["callback"]> => {
 
       // Add mutations to our scripts.
       frontity.script = `<script id="__FRONTITY_CONNECT_STATE__" type="application/json">${htmlescape(
-        store.getSnapshot()
+        getSnapshot(store.state)
       )}</script>\n${frontity.script}`;
     } else {
       // No client chunks: no scripts. Just do SSR. Use renderToStaticMarkup

--- a/packages/types/src/connect.ts
+++ b/packages/types/src/connect.ts
@@ -23,7 +23,6 @@ export interface CreateStore {
   <Pkg extends Package>(pkg: Pkg): Omit<Pkg, "state" | "actions"> & {
     state: ResolveState<Pkg["state"]>;
     actions: ResolveActions<Pkg["actions"]>;
-    getSnapshot: () => Pkg["state"];
   };
 }
 


### PR DESCRIPTION
**What**:

Move `getSnapshot` to an import instead of a store prop.

**Why**:

When people do this:

```js
const MyComp = ({ state, ...props }) => (
  <OtherComp {...props} />
);
```

they get error warnings about `getSnapshot` being there.

**How**:

Now `getSnapshot` can be imported from `"@frontity/connect"`.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- Delete each line that's irrelevant to your changes -->
<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Code
- [ ] ~Documentation~: `getSnapshot` is internal and not documented.
- [x] Unit tests
- [x] End to end tests
- [x] TypeScript
- [ ] ~Starter Themes~: themes don't use `getSnapshot`.
- [ ] ~Community discussions~: `getSnapshot` doesn't appear in any discussion.
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `npx changeset` to create a changeset. -->

<!-- Feel free to add additional comments. -->
