### PR TITLE
Instructions to strikethrough non relevant tasks in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,8 @@ merge of your pull request!
 
 <!-- Have you done all of these things?  -->
 
-<!-- Delete each line that's irrelevant to your changes -->
 <!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
+<!-- Strikethrough each line that's irrelevant to your changes and add the reason why -->
 
 - [ ] Code
 - [ ] Documentation
@@ -37,6 +37,7 @@ merge of your pull request!
 - [ ] TypeScript
 - [ ] Starter Themes
 - [ ] Community discussions
-- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `npx changeset` to create a changeset. -->
+<!-- This is necessary if your changes should release any packages. Run `npx changeset` to create a changeset. -->
+- [ ] Changeset 
 
 <!-- Feel free to add additional comments. -->


### PR DESCRIPTION

Add instructions to strikethrough non-relevant tasks, instead of just deleting them. People should also add the reason why this is not relevant.

The reviewer needs to agree on why those tasks are not relevant. Leaving them in the description and adding a reason why they are not relevant gives him/her an opportunity to disagree.

There is an example in this PR: https://github.com/frontity/frontity/pull/360

