### PR TITLE
Lazy load Tweet script

### DIFF
--- a/packages/components/tweet.tsx
+++ b/packages/components/tweet.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Connect, Package } from "frontity/types";
+import Script from "./script";
+import { useInView } from "react-intersection-observer";
+
+type TweetType = React.FC<Connect<Package, any>>;
+
+const Tweet: TweetType = ({ children, ...props }) => {
+  const [ref, onScreen] = useInView({
+    rootMargin: "400px",
+    triggerOnce: true,
+  });
+
+  return (
+    <>
+      <blockquote ref={ref} {...props}>
+        {children}
+      </blockquote>
+      {onScreen && <Script src="https://platform.twitter.com/widgets.js" />}
+    </>
+  );
+};
+
+export default Tweet;

--- a/packages/html2react/processors/tweet.tsx
+++ b/packages/html2react/processors/tweet.tsx
@@ -1,0 +1,27 @@
+import { Processor } from "../types";
+import Tweet from "@frontity/components/tweet";
+
+const tweet: Processor = {
+  test: ({ node }) =>
+    node.type === "element" &&
+    node.component === "blockquote" &&
+    (node.props.className.split(" ").includes("twitter-tweet") ||
+      node.props.className.split(" ").includes("twitter-video")),
+  priority: 10,
+  name: "tweet",
+  processor: ({ node }) => {
+    if (node.type === "element") {
+      //Remove the <script> element next to the <blockquote>
+      const index = node.parent.children.indexOf(node);
+      if (node.parent.children[index + 1]["component"] === "script") {
+        node.parent.children.splice(index + 1, 1);
+      }
+
+      node.component = Tweet;
+    }
+
+    return node;
+  },
+};
+
+export default tweet;


### PR DESCRIPTION
**What**:
Lazy load the `<script>` included on the embedded tweets.

**Why**:
It makes the bundle-size higher and can impact the performance of the web.

**How**:
We can use a processor that deletes the `<script>` of the content, and include it with a Tweet component using `useInView`.

**Tasks**:

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- Strikethrough each line that's irrelevant to your changes and add the reason why -->

- [ ] Code
- [ ] Documentation
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript
- [ ] Starter Themes
- [ ] Community discussions
<!-- This is necessary if your changes should release any packages. Run `npx changeset` to create a changeset. -->
- [ ] Changeset 

<!-- Feel free to add additional comments. -->
