### PR TITLE
Make isHome present when isReady is true

### DIFF
--- a/.changeset/chilled-trees-grow.md
+++ b/.changeset/chilled-trees-grow.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+`data.isHome` is now available when `data.isReady` turns true.

--- a/packages/wp-source/src/__tests__/actions.tests.ts
+++ b/packages/wp-source/src/__tests__/actions.tests.ts
@@ -79,6 +79,52 @@ describe("fetch", () => {
     expect(store.state.source.get("/some/route").isReady).toBe(true);
   });
 
+  test('should set isHome in "/"', (done) => {
+    observe(() => {
+      const data = store.state.source.get("/");
+      if (data.isReady) {
+        expect(data.isHome).toBe(true);
+        done();
+      }
+    });
+    store.actions.source.fetch("/");
+  });
+
+  test('should set isHome in "/page/x"', (done) => {
+    observe(() => {
+      const data = store.state.source.get("/page/123");
+      if (data.isReady) {
+        expect(data.isHome).toBe(true);
+        done();
+      }
+    });
+    store.actions.source.fetch("/page/123");
+  });
+
+  test('should set isHome in "/blog" when using a subdirectory', (done) => {
+    store.state.source.subdirectory = "/blog";
+    observe(() => {
+      const data = store.state.source.get("/blog");
+      if (data.isReady) {
+        expect(data.isHome).toBe(true);
+        done();
+      }
+    });
+    store.actions.source.fetch("/blog");
+  });
+
+  test('should set isHome in "/blog/page/x" when using a subdirectory', (done) => {
+    store.state.source.subdirectory = "/blog";
+    observe(() => {
+      const data = store.state.source.get("/blog/page/123");
+      if (data.isReady) {
+        expect(data.isHome).toBe(true);
+        done();
+      }
+    });
+    store.actions.source.fetch("/blog/page/123");
+  });
+
   test("should run again when `force` is used", async () => {
     store.state.source.data["/some/route/"] = {
       errorStatusText: "Request Timeout",

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -69,11 +69,10 @@ const actions: WpSource["actions"]["source"] = {
       // Everything OK.
       source.data[link] = {
         ...source.data[link],
+        ...(isHome && { isHome: true }),
         isFetching: false,
         isReady: true,
       };
-      // Set isHome value if it's true.
-      if (isHome) source.data[link].isHome = true;
     } catch (e) {
       // It's a server error (4xx or 5xx).
       if (e instanceof ServerError) {


### PR DESCRIPTION

**What**:

`data.isHome` was not present when `data.isReady` was true. Now it is.

**Why**:

`data.isHome` information should be available when `data.isReady` turns true.

**How**:

I moved the `isHome` set to the moment when `isReady` turns true.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- Strikethrough each line that's irrelevant to your changes and add the reason why -->

- [x] Code
- [ ] ~Documentation~
- [x] Unit tests
- [ ] ~End to end tests~
- [ ] ~TypeScript~
- [ ] ~Starter Themes~
- [ ] ~Community discussions~
- [x] Changeset 

<!-- Feel free to add additional comments. -->
