### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - name: Setup Node.js 12.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+
+      - name: Setup npm cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CI: true
+
+      - name: Create Release Pull Request
+        uses: changesets/action@master
+        with:
+          version: npx changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**What**:

Adding a workflow to automate the releases.

**Why**:

Right now, this process is done manually.

**How**:

We are using this [GitHub action](url). These are the steps I followed, to make sure they are correct:

1. Create the `release.yml` file:
    * Change the `version` to `npx changeset publish`.
    * Change the install dependencies to `npm ci`.
    * Add the "Setup npm cache".
    * Add NPM_TOKEN.
2. Create a token in npm with our account.
3. Add secret to GitHub repo named `NPM_TOKEN`.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- Strikethrough each line that's irrelevant to your changes using "~" -->
<!-- Add the reason: ~Documentation~: Internal code, not documented. -->

- [x] Code

**Unrelated**
~~TypeScript~~
~~Unit tests~~
~~End to end tests~~
~~TypeScript tests~~
~~Update starter themes~~
~~Update other packages~~
~~Documentation~~
~~Community discussions~~
~~Changeset~~