### PR TITLE
docs: prefer to place README.md for a new project

### DIFF
--- a/packages/mars-theme/README.md
+++ b/packages/mars-theme/README.md
@@ -1,0 +1,27 @@
+# Marth Theme
+
+## Getting started
+
+```bash
+$ npm install
+$ npm run dev
+
+SERVER STARTED -- Listening @ http://localhost:3000
+  - mode: development
+  - target: module
+
+```
+
+## Build
+
+```bash
+$ npm run build
+```
+
+
+## Deployment (Vercel (now.sh))
+
+```bash
+$ npx now login
+$ npx now --prod
+```

--- a/packages/twentytwenty-theme/README.md
+++ b/packages/twentytwenty-theme/README.md
@@ -1,0 +1,27 @@
+# TwentyTwenty Theme
+
+## Getting started
+
+```bash
+$ npm install
+$ npm run dev
+
+SERVER STARTED -- Listening @ http://localhost:3000
+  - mode: development
+  - target: module
+
+```
+
+## Build
+
+```bash
+$ npm run build
+```
+
+
+## Deployment (Vercel (now.sh))
+
+```bash
+$ npx now login
+$ npx now --prod
+```


### PR DESCRIPTION
**What**:

Put `README.md` files into starter template packages.

**Why**:

When we create a new project, we can easy to understand how to develop and build it.
But now, there is no README.md file in our created project.

**How**:

Add a simple `README.md` file into these starter templates.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- Strikethrough each line that's irrelevant to your changes using "~" -->
<!-- Add the reason: ~Documentation~: Internal code, not documented. -->

- [ ] Code
- [ ] TypeScript

- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests

- [x] Update starter themes
- [ ] Update other packages

- [ ] Documentation
- [ ] Community discussions

<!-- This is necessary if your changes should release any packages. Run `npx changeset` to create a changeset. -->
- [ ] Changeset 

<!-- Feel free to add additional comments. -->
