### PR TITLE
Add authorBase option to wp-source

### DIFF
--- a/.changeset/mean-otters-unite.md
+++ b/.changeset/mean-otters-unite.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": minor
+---
+
+Add an option called `authorBase` to change the base of author links. Useful when a custom structure for permalinks is set in the WordPress site connected with the `@frontity/wp-source` package.

--- a/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
+++ b/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
@@ -304,6 +304,23 @@ Array [
 ]
 `;
 
+exports[`init should add redirect for tags if 'authorBase' is set 1`] = `
+Array [
+  Object {
+    "func": [Function],
+    "name": "author base",
+    "pattern": "/blog/author/:subpath+/",
+    "priority": 10,
+  },
+  Object {
+    "func": [Function],
+    "name": "author base (reverse)",
+    "pattern": "/author/(.*)/",
+    "priority": 10,
+  },
+]
+`;
+
 exports[`init should add redirect for tags if 'tagBase' is set 1`] = `
 Array [
   Object {

--- a/packages/wp-source/src/__tests__/actions.tests.ts
+++ b/packages/wp-source/src/__tests__/actions.tests.ts
@@ -3,6 +3,7 @@ import clone from "clone-deep";
 import wpSource from "../";
 import WpSource, { Pattern, Handler } from "../../types";
 import * as handlers from "../libraries/handlers";
+import { getMatch } from "../libraries/get-match";
 
 // Create mock for handler generators
 jest.mock("../libraries/handlers");
@@ -189,12 +190,33 @@ describe("init", () => {
     store.state.source.categoryBase = "wp-cat";
     await store.actions.source.init();
     expect(store.libraries.source.redirections).toMatchSnapshot();
+    // Test that the redirection works.
+    const link = "/wp-cat/travel/";
+    const redirect = getMatch(link, store.libraries.source.redirections);
+    expect(redirect).toBeTruthy();
+    expect(redirect.func(redirect.params)).toBe("/category/travel/");
   });
 
   test("should add redirect for tags if 'tagBase' is set", async () => {
     store.state.source.tagBase = "wp-tag";
     await store.actions.source.init();
     expect(store.libraries.source.redirections).toMatchSnapshot();
+    // Test that the redirection works.
+    const link = "/wp-tag/paris/";
+    const redirect = getMatch(link, store.libraries.source.redirections);
+    expect(redirect).toBeTruthy();
+    expect(redirect.func(redirect.params)).toBe("/tag/paris/");
+  });
+
+  test("should add redirect for tags if 'authorBase' is set", async () => {
+    store.state.source.authorBase = "/blog/author";
+    await store.actions.source.init();
+    expect(store.libraries.source.redirections).toMatchSnapshot();
+    // Test that the redirection works.
+    const link = "/blog/author/admin/";
+    const redirect = getMatch(link, store.libraries.source.redirections);
+    expect(redirect).toBeTruthy();
+    expect(redirect.func(redirect.params)).toBe("/author/admin/");
   });
 
   test("should add redirect if 'subirectory' is present", async () => {

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -152,6 +152,7 @@ const actions: WpSource["actions"]["source"] = {
       postsPage,
       categoryBase,
       tagBase,
+      authorBase,
     } = state.source;
 
     if (homepage) {
@@ -206,6 +207,24 @@ const actions: WpSource["actions"]["source"] = {
         name: "tag base (reverse)",
         priority: 10,
         pattern: concatPath(subdirectory, "/tag/(.*)/"),
+        func: () => "",
+      });
+    }
+
+    if (authorBase) {
+      // Add new direction.
+      const pattern = concatPath(subdirectory, authorBase, "/:subpath+");
+      redirections.push({
+        name: "author base",
+        priority: 10,
+        pattern,
+        func: ({ subpath }) => `/author/${subpath}/`,
+      });
+      // Remove old direction.
+      redirections.push({
+        name: "author base (reverse)",
+        priority: 10,
+        pattern: concatPath(subdirectory, "/author/(.*)/"),
         func: () => "",
       });
     }

--- a/packages/wp-source/src/libraries/__tests__/__snapshots__/populate.tests.ts.snap
+++ b/packages/wp-source/src/libraries/__tests__/__snapshots__/populate.tests.ts.snap
@@ -47,6 +47,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "cpt": Object {
@@ -226,6 +227,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -434,6 +436,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -642,6 +645,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/author.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/author.tests.ts.snap
@@ -34,6 +34,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -190,6 +191,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -238,6 +240,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -336,6 +339,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "cpt": Object {
@@ -521,6 +525,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -708,6 +713,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -864,6 +870,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -906,6 +913,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -968,6 +976,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/category.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/category.tests.ts.snap
@@ -34,6 +34,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -220,6 +221,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -272,6 +274,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -381,6 +384,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -603,6 +607,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -797,6 +802,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -832,6 +838,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -904,6 +911,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/date.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/date.tests.ts.snap
@@ -48,6 +48,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -236,6 +237,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -382,6 +384,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -602,6 +605,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -968,6 +972,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -1275,6 +1280,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-archive.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-archive.tests.ts.snap
@@ -53,6 +53,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -281,6 +282,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -495,6 +497,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -674,6 +677,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,
@@ -890,6 +894,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {
     "1": Object {
       "count": 5,

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
@@ -13,6 +13,7 @@ Object {
     },
   },
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -60,6 +61,7 @@ Object {
     },
   },
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -105,6 +107,7 @@ Object {
     },
   },
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -160,6 +163,7 @@ Object {
     },
   },
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -214,6 +218,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -279,6 +284,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -342,6 +348,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -415,6 +422,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -496,6 +504,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -607,6 +616,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -734,6 +744,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "cpt": Object {
@@ -851,6 +862,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -970,6 +982,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -1089,6 +1102,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -1203,6 +1217,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -1238,6 +1253,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/tag.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/tag.tests.ts.snap
@@ -34,6 +34,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -220,6 +221,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -272,6 +274,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -381,6 +384,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "cpt": Object {
@@ -603,6 +607,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -797,6 +802,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -832,6 +838,7 @@ Object {
   "api": "https://test.frontity.io/wp-json",
   "attachment": Object {},
   "author": Object {},
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {
@@ -904,6 +911,7 @@ Object {
       "slug": "author-1",
     },
   },
+  "authorBase": "",
   "category": Object {},
   "categoryBase": "",
   "data": Object {

--- a/packages/wp-source/src/state.ts
+++ b/packages/wp-source/src/state.ts
@@ -38,6 +38,7 @@ const state: WpSource["state"]["source"] = {
   postsPage: "",
   categoryBase: "",
   tagBase: "",
+  authorBase: "",
   postEndpoint: "posts",
   params: {},
   postTypes: [],

--- a/packages/wp-source/types.ts
+++ b/packages/wp-source/types.ts
@@ -29,6 +29,7 @@ interface WpSource extends Source {
       subdirectory: string;
       categoryBase: string;
       tagBase: string;
+      authorBase: string;
       homepage: string;
       postsPage: string;
       postEndpoint: string;


### PR DESCRIPTION
**What**:

This PR implements this feature: [Add `authorBase` option to WP Source package](https://community.frontity.org/t/add-authorbase-option-to-wp-source-package/1607).

Closes #383.

**Why**:

To solve a critical bug in frontity.org (https://github.com/frontity/frontity.org/issues/86) that is breaking author pages.

**How**:

Adding an `authorBase option in `state.source`, here:

https://github.com/frontity/frontity/blob/c5a2e15d68a1e4c2060e32808688314725001038/packages/wp-source/src/state.ts#L39-L40

and handle that option the same way we are doing for `categoryBase` and `tagBase`:

https://github.com/frontity/frontity/blob/c5a2e15d68a1e4c2060e32808688314725001038/packages/wp-source/src/actions.ts#L177-L211

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- Strikethrough each line that's irrelevant to your changes using "~" -->
<!-- Add the reason: ~Documentation~: Internal code, not documented. -->

- [x] Code
- [x] Unit tests
- [x] Changeset 
- [x] Documentation: https://app.gitbook.com/@frontity-tech/s/frontity/~/diff/drafts/-M5aqMFLG9ELa9KCHEoi/@drafts
- [x] Community discussions: https://community.frontity.org/t/add-authorbase-option-to-wp-source-package/1607/2?u=david
- ~Update `frontity.org` package (add `authorBase: "/blog/author"` in `frontity.settings.ts`)~ To be done in a different PR.

**Unrelated tasks**

- ~TypeScript~
- ~TypeScript tests~
- ~End to end tests~
- ~Update starter themes~

<!-- Feel free to add additional comments. -->
