### PR TITLE
TwentyTwenty: Tag underline on hover doesn't work fine #372

### DIFF
--- a/.changeset/polite-masks-rule.md
+++ b/.changeset/polite-masks-rule.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Fix tag underlining on hover.

--- a/packages/twentytwenty-theme/src/components/post/post-meta-item.js
+++ b/packages/twentytwenty-theme/src/components/post/post-meta-item.js
@@ -29,7 +29,7 @@ const MetaText = styled.span`
     text-decoration: none;
   }
 
-  :hover {
+  a:hover {
     text-decoration: underline;
   }
 `;


### PR DESCRIPTION
https://github.com/frontity/frontity/issues/372

<!--
Thanks for your pull request 😊. Note that not following the template might result in your issue being closed

Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the https://docs.frontity.org/contributing/code-contributions.

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

TwentyTwenty: Tag underline on hover doesn't work fine #372

**Why**:

It fixes the underline style for the tags

**How**:

Change in css file to target the link instead of the span

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- Strikethrough each line that's irrelevant to your changes using "~" -->
<!-- Add the reason: ~Documentation~: Internal code, not documented. -->

- [x] Code
- [x] Update starter themes

Unrelated:

- [ ] ~TypeScript~
- [ ] ~Unit tests~
- [ ] ~End to end tests~
- [ ] ~TypeScript tests~
- [ ] ~Update other packages~
- [ ] ~Documentation~
- [ ] ~Community discussions~
- [ ] ~Changeset~

<!-- Feel free to add additional comments. -->