### PR TITLE
Create README.md on `npx frontity create`

### DIFF
--- a/.changeset/curvy-pillows-fetch.md
+++ b/.changeset/curvy-pillows-fetch.md
@@ -1,0 +1,5 @@
+---
+"frontity": minor
+---
+
+Create a `README.md` file on `npx frontity create` with a brief explanation of how to work with Frontity and links to the community and documentation.

--- a/packages/frontity/src/commands/create.ts
+++ b/packages/frontity/src/commands/create.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptions,
   ensureProjectDir,
   createPackageJson,
+  createReadme,
   createFrontitySettings,
   cloneStarterTheme,
   installDependencies,
@@ -47,6 +48,11 @@ const create = async (
     step = ensureProjectDir(path);
     emitMessage(`Ensuring ${chalk.yellow(path)} directory.`, step);
     dirExisted = await step;
+
+    // 3. Creates `README.md`
+    step = createReadme(name, path);
+    emitMessage(`Creating ${chalk.yellow("README.md")}.`, step);
+    await step;
 
     // 3. Creates `package.json`.
     step = createPackageJson(name, theme, path);

--- a/packages/frontity/src/steps/index.ts
+++ b/packages/frontity/src/steps/index.ts
@@ -116,6 +116,22 @@ export const createPackageJson = async (
   await writeFile(filePath, fileData);
 };
 
+// This function create a `README.md` file.
+export const createReadme = async (
+  name: string,
+  path: string
+): Promise<void> => {
+  const fileTemplate = await readFile(
+    resolvePath(__dirname, "../../templates/README.md"),
+    {
+      encoding: "utf8",
+    }
+  );
+  const filePath = resolvePath(path, "README.md");
+  const fileData = fileTemplate.replace(/\$name\$/g, name);
+  await writeFile(filePath, fileData);
+};
+
 // This function creates a `frontity.settings` file.
 export const createFrontitySettings = async (
   extension: string,

--- a/packages/frontity/templates/README.md
+++ b/packages/frontity/templates/README.md
@@ -26,3 +26,9 @@ $ npm run build
 $ npx now login
 $ npx now --prod
 ```
+
+
+## Additional information
+
+Documentation: https://docs.frontity.org/
+Community forum: https://community.frontity.org/

--- a/packages/frontity/templates/README.md
+++ b/packages/frontity/templates/README.md
@@ -68,9 +68,9 @@ Upload your `static` folder to a CDN and your `server.js` file to a serverless s
 We have different channels at your disposal where you can find information about the project, discuss about it and get involved:
 
 - 📖 **[Docs](https://docs.frontity.org)**: this is the place to learn how to build amazing sites with Frontity.
-- 👨‍👩‍👧‍👦 **[Community](https://community.frontity.org/)**: use our forum to [share any doubts](https://community.frontity.org/c/dev-talk-questions), feedback and meet great people. This is your place too to share [what are you building with Frontity](https://community.frontity.org/c/showcases)!
-- 🐞 **[GitHub](https://github.com/frontity/frontity)**: we use GitHub for bugs and pull requests. Doubts are solved at the [community forum](https://community.frontity.org/).!
-- 🗣 **Social media**: a more informal place to interact with Frontity users, reach out to us on [Twitter](https://twitter.com/frontity)
+- 👨‍👩‍👧‍👦 **[Community](https://community.frontity.org/)**: use our forum to [ask any questions](https://community.frontity.org/c/dev-talk-questions), feedback and meet great people. This is your place too to share [what are you building with Frontity](https://community.frontity.org/c/showcases)!
+- 🐞 **[GitHub](https://github.com/frontity/frontity)**: we use GitHub for bugs and pull requests. Questions are solved at the [community forum](https://community.frontity.org/)!
+- 🗣 **Social media**: a more informal place to interact with Frontity users, reach out to us on [Twitter](https://twitter.com/frontity).
 - 💌 **Newsletter**: do you want to receive the latest framework updates and news? Subscribe [here](https://frontity.org/)
 
 ### » Get involved 🤗

--- a/packages/frontity/templates/README.md
+++ b/packages/frontity/templates/README.md
@@ -1,34 +1,80 @@
-## $name$
+# $name$
 
 This project was bootstrapped with [Frontity](https://frontity.org/).
-## Getting started
 
-```bash
-$ npm install
-$ npm run dev
+#### Table of Contents 
 
-SERVER STARTED -- Listening @ http://localhost:3000
-  - mode: development
-  - target: module
+- [Launch a development server](#launch-a-development-server)
+- [Create your custom theme](#create-your-custom-theme)
+- [Create a production-ready build](#create-a-production-ready-build)
+- [Deploy](#deploy)
+
+### Launch a development server
 
 ```
-
-## Build
-
-```bash
-$ npm run build
+npx frontity dev
 ```
 
+Runs the app in development mode. Open http://localhost:3000 to view it in the browser.
 
-## Deployment (Vercel (now.sh))
+The site will automatically reload if you make changes inside the `packages` folder. You will see the build errors in the console.
 
-```bash
-$ npx now login
-$ npx now --prod
+> Have a look at our [Quick Start Guide](https://docs.frontity.org/getting-started/quick-start-guide)
+
+### Create your custom theme
+
+```
+npx frontity create-package your-custom-theme
 ```
 
+Use the command `npx frontity create-package` to create a new package that can be set in your `frontity.settings.js` as your theme
 
-## Additional information
+> Have a look at our blog post [How to Create a React WordPress Theme in 30 Minutes](https://frontity.org/blog/how-to-create-a-react-theme-in-30-minutes/)
 
-Documentation: https://docs.frontity.org/
-Community forum: https://community.frontity.org/
+### Create a production-ready build
+
+```
+npx frontity build
+```
+
+Builds the app for production to the `build` folder. 
+
+This will create a `/build` folder with a `server.js` (a [serverless function](https://vercel.com/docs/v2/serverless-functions/introduction)) file and a `/static` folder with all your javascript files and other assets. 
+
+Your app is ready to be deployed.
+
+> Get more info about [Frontity's architecture](https://docs.frontity.org/architecture)
+
+### Deploy
+
+With the files generated in the _build_ you can deploy your project
+
+#### As a node app
+
+Use `npx frontity serve` to run it like a normal Node app. 
+
+This command generates (and runs) a small web server that uses the generated `server.js` and `/static` to serve your content
+
+#### As a serverless service
+
+Upload your `static` folder to a CDN and your `server.js` file to a serverless service, like Now or Netlify.
+
+> Get more info about [how to deploy](https://docs.frontity.org/deployment) a Frontity project 
+
+---
+
+### » Frontity Channels 🌎
+
+We have different channels at your disposal where you can find information about the project, discuss about it and get involved:
+
+- 📖 **[Docs](https://docs.frontity.org)**: this is the place to learn how to build amazing sites with Frontity.
+- 👨‍👩‍👧‍👦 **[Community](https://community.frontity.org/)**: use our forum to [share any doubts](https://community.frontity.org/c/dev-talk-questions), feedback and meet great people. This is your place too to share [what are you building with Frontity](https://community.frontity.org/c/showcases)!
+- 🐞 **[GitHub](https://github.com/frontity/frontity)**: we use GitHub for bugs and pull requests. Doubts are solved at the [community forum](https://community.frontity.org/).!
+- 🗣 **Social media**: a more informal place to interact with Frontity users, reach out to us on [Twitter](https://twitter.com/frontity)
+- 💌 **Newsletter**: do you want to receive the latest framework updates and news? Subscribe [here](https://frontity.org/)
+
+### » Get involved 🤗
+
+Got questions or feedback about Frontity? We'd love to hear from you. Use our [community forum](https://community.frontity.org) yo ! ❤️
+
+Frontity also welcomes contributions. There are many ways to support the project! If you don't know where to start, this guide might help → [How to contribute?](https://docs.frontity.org/contributing/how-to-contribute)

--- a/packages/frontity/templates/README.md
+++ b/packages/frontity/templates/README.md
@@ -1,0 +1,28 @@
+## $name$
+
+This project was bootstrapped with [Frontity](https://frontity.org/).
+## Getting started
+
+```bash
+$ npm install
+$ npm run dev
+
+SERVER STARTED -- Listening @ http://localhost:3000
+  - mode: development
+  - target: module
+
+```
+
+## Build
+
+```bash
+$ npm run build
+```
+
+
+## Deployment (Vercel (now.sh))
+
+```bash
+$ npx now login
+$ npx now --prod
+```

--- a/packages/frontity/templates/README.md
+++ b/packages/frontity/templates/README.md
@@ -2,7 +2,7 @@
 
 This project was bootstrapped with [Frontity](https://frontity.org/).
 
-#### Table of Contents 
+#### Table of Contents
 
 - [Launch a development server](#launch-a-development-server)
 - [Create your custom theme](#create-your-custom-theme)
@@ -37,9 +37,9 @@ Use the command `npx frontity create-package` to create a new package that can b
 npx frontity build
 ```
 
-Builds the app for production to the `build` folder. 
+Builds the app for production to the `build` folder.
 
-This will create a `/build` folder with a `server.js` (a [serverless function](https://vercel.com/docs/v2/serverless-functions/introduction)) file and a `/static` folder with all your javascript files and other assets. 
+This will create a `/build` folder with a `server.js` (a [serverless function](https://vercel.com/docs/v2/serverless-functions/introduction)) file and a `/static` folder with all your javascript files and other assets.
 
 Your app is ready to be deployed.
 
@@ -51,7 +51,7 @@ With the files generated in the _build_ you can deploy your project
 
 #### As a node app
 
-Use `npx frontity serve` to run it like a normal Node app. 
+Use `npx frontity serve` to run it like a normal Node app.
 
 This command generates (and runs) a small web server that uses the generated `server.js` and `/static` to serve your content
 
@@ -59,7 +59,7 @@ This command generates (and runs) a small web server that uses the generated `se
 
 Upload your `static` folder to a CDN and your `server.js` file to a serverless service, like Now or Netlify.
 
-> Get more info about [how to deploy](https://docs.frontity.org/deployment) a Frontity project 
+> Get more info about [how to deploy](https://docs.frontity.org/deployment) a Frontity project
 
 ---
 
@@ -69,7 +69,7 @@ We have different channels at your disposal where you can find information about
 
 - 📖 **[Docs](https://docs.frontity.org)**: this is the place to learn how to build amazing sites with Frontity.
 - 👨‍👩‍👧‍👦 **[Community](https://community.frontity.org/)**: use our forum to [ask any questions](https://community.frontity.org/c/dev-talk-questions), feedback and meet great people. This is your place too to share [what are you building with Frontity](https://community.frontity.org/c/showcases)!
-- 🐞 **[GitHub](https://github.com/frontity/frontity)**: we use GitHub for bugs and pull requests. Questions are solved at the [community forum](https://community.frontity.org/)!
+- 🐞 **[GitHub](https://github.com/frontity/frontity)**: we use GitHub for bugs and pull requests. Questions are answered in the [community forum](https://community.frontity.org/)!
 - 🗣 **Social media**: a more informal place to interact with Frontity users, reach out to us on [Twitter](https://twitter.com/frontity).
 - 💌 **Newsletter**: do you want to receive the latest framework updates and news? Subscribe [here](https://frontity.org/)
 


### PR DESCRIPTION
**What**:
Create README.md when run `frontity create` command.

**Why**:

When we create a new project, we can easy to understand how to develop and build it.
But now, there is no README.md file in our created project.

**How**:

Add script to put README.md on `src/commands/create.ts`

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation" -->
<!-- Strikethrough each line that's irrelevant to your changes using "~" -->
<!-- Add the reason: ~Documentation~: Internal code, not documented. -->

- [x] Code
- [x] Unit tests
- [x] Documentation
- [x] Changeset 

**Non-relevant tasks**

- ~End to end tests~ We don't have e2e tests for the cli yet.
- ~TypeScript~ There aren't new types created.
- ~TypeScript tests~ There aren't new types created.
- ~Update starter themes~ No starter themes affected.
- ~Update other packages~ No other packages affected.
- ~Community discussions~ There is no discussion in the community.


<!-- Feel free to add additional comments. -->
**Related Pull Request**

- docs: prefer to place README.md for a new project #381