### PR TITLE
Avoid embedding fonts in HTML as it impacts LightHouse performance score

### DIFF
--- a/.changeset/serious-brooms-exist.md
+++ b/.changeset/serious-brooms-exist.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Use `swap` in all `font-displays`. This was needed because we are not embedding fonts smaller than 25Kbs anymore.

--- a/.changeset/two-plums-greet.md
+++ b/.changeset/two-plums-greet.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Don't embed fonts so big because they have an impact on LightHouse performance score. I have reduced the limit from 25Kbs to 8Kbs, which seems to be the recommendation in Webpack.

--- a/examples/twentytwenty-theme-example/frontity.settings.js
+++ b/examples/twentytwenty-theme-example/frontity.settings.js
@@ -4,8 +4,8 @@ export default {
     frontity: {
       url: "https://twentytwenty.frontity.org",
       title: "Test Frontity Blog",
-      description: "Useful content for Frontity development"
-    }
+      description: "Useful content for Frontity development",
+    },
   },
   packages: [
     "@frontity/tiny-router",
@@ -19,13 +19,13 @@ export default {
             ["Nature", "/category/nature/"],
             ["Travel", "/category/travel/"],
             ["Japan", "/tag/japan/"],
-            ["About Us", "/about-us/"]
+            ["About Us", "/about-us/"],
           ],
           colors: {
             primary: "#E6324B",
             headerBg: "#ffffff",
             footerBg: "#ffffff",
-            bodyBg: "#f5efe0"
+            bodyBg: "#f5efe0",
           },
           // Whether to show the search button in page header
           showSearchInHeader: true,
@@ -36,7 +36,7 @@ export default {
             // Whether to show it on archive view
             showOnArchive: true,
             // Whether to show it on post
-            showOnPost: true
+            showOnPost: true,
           },
           // Whether to auto-fetch links on a page. Values can be "no" | "all" | "in-view" | "hover"
           autoPreFetch: "hover",
@@ -44,17 +44,17 @@ export default {
            * At the moment, we only include the ascii characters of Inter font.
            * Values can be "us-ascii" | "latin" | "all"
            */
-          fontSets: "us-ascii"
-        }
-      }
+          fontSets: "us-ascii",
+        },
+      },
     },
     {
       name: "@frontity/wp-source",
       state: {
         source: {
-          api: "https://test.frontity.io/wp-json"
-        }
-      }
-    }
-  ]
+          api: "https://test.frontity.io/wp-json",
+        },
+      },
+    },
+  ],
 };

--- a/packages/core/src/config/webpack/__tests__/__snapshots__/index.ts.snap
+++ b/packages/core/src/config/webpack/__tests__/__snapshots__/index.ts.snap
@@ -62,7 +62,7 @@ Object {
             "loader": "url-loader",
             "options": Object {
               "emitFile": true,
-              "limit": 25000,
+              "limit": 8192,
               "name": [Function],
               "outputPath": "fonts",
             },
@@ -208,7 +208,7 @@ Object {
             "loader": "url-loader",
             "options": Object {
               "emitFile": true,
-              "limit": 25000,
+              "limit": 8192,
               "name": [Function],
               "outputPath": "fonts",
             },
@@ -341,7 +341,7 @@ Object {
             "loader": "url-loader",
             "options": Object {
               "emitFile": false,
-              "limit": 25000,
+              "limit": 8192,
               "name": [Function],
               "outputPath": "fonts",
             },
@@ -480,7 +480,7 @@ Object {
             "loader": "url-loader",
             "options": Object {
               "emitFile": true,
-              "limit": 25000,
+              "limit": 8192,
               "name": [Function],
               "outputPath": "fonts",
             },
@@ -618,7 +618,7 @@ Object {
             "loader": "url-loader",
             "options": Object {
               "emitFile": true,
-              "limit": 25000,
+              "limit": 8192,
               "name": [Function],
               "outputPath": "fonts",
             },
@@ -745,7 +745,7 @@ Object {
             "loader": "url-loader",
             "options": Object {
               "emitFile": false,
-              "limit": 25000,
+              "limit": 8192,
               "name": [Function],
               "outputPath": "fonts",
             },

--- a/packages/core/src/config/webpack/modules.ts
+++ b/packages/core/src/config/webpack/modules.ts
@@ -77,7 +77,7 @@ export default ({
               : `${filename[1]}-[hash].[ext]`;
           },
           outputPath: "fonts",
-          limit: 25000,
+          limit: 8192,
           emitFile: target !== "server",
         },
       },

--- a/packages/twentytwenty-theme/src/components/styles/font-faces.js
+++ b/packages/twentytwenty-theme/src/components/styles/font-faces.js
@@ -10,18 +10,14 @@ import InterMediumLatin from "../../fonts/inter/Inter-Medium-LATIN.woff2";
 import InterBoldLatin from "../../fonts/inter/Inter-Bold-LATIN.woff2";
 import InterSemiBoldLatin from "../../fonts/inter/Inter-SemiBold-LATIN.woff2";
 
+const fonts = {
+  "us-ascii": [InterMediumUS, InterSemiBoldUS, InterBoldUS],
+  latin: [InterMediumLatin, InterSemiBoldLatin, InterBoldLatin],
+  all: [InterMedium, InterSemiBold, InterBold],
+};
+
 const FontFace = ({ state }) => {
-  let fonts = null;
-  switch (state.theme.fontSets) {
-    case "us-ascii":
-      fonts = [InterMediumUS, InterSemiBoldUS, InterBoldUS];
-      break;
-    case "latin":
-      fonts = [InterMediumLatin, InterSemiBoldLatin, InterBoldLatin];
-      break;
-    default:
-      fonts = [InterMedium, InterSemiBold, InterBold];
-  }
+  const font = fonts[state.theme.fontSets] || fonts["all"];
 
   return (
     <Global
@@ -31,7 +27,7 @@ const FontFace = ({ state }) => {
           font-style: normal;
           font-weight: 500;
           font-display: "swap";
-          src: url(${fonts[0]}) format("woff2");
+          src: url(${font[0]}) format("woff2");
         }
 
         @font-face {
@@ -39,7 +35,7 @@ const FontFace = ({ state }) => {
           font-style: normal;
           font-weight: 600;
           font-display: "swap";
-          src: url(${fonts[1]}) format("woff2");
+          src: url(${font[1]}) format("woff2");
         }
 
         @font-face {
@@ -47,7 +43,7 @@ const FontFace = ({ state }) => {
           font-style: normal;
           font-weight: 700;
           font-display: "swap";
-          src: url(${fonts[2]}) format("woff2");
+          src: url(${font[2]}) format("woff2");
         }
       `}
     />

--- a/packages/twentytwenty-theme/src/components/styles/font-faces.js
+++ b/packages/twentytwenty-theme/src/components/styles/font-faces.js
@@ -12,11 +12,9 @@ import InterSemiBoldLatin from "../../fonts/inter/Inter-SemiBold-LATIN.woff2";
 
 const FontFace = ({ state }) => {
   let fonts = null;
-  let fontDisplay = "swap";
   switch (state.theme.fontSets) {
     case "us-ascii":
       fonts = [InterMediumUS, InterSemiBoldUS, InterBoldUS];
-      fontDisplay = "block";
       break;
     case "latin":
       fonts = [InterMediumLatin, InterSemiBoldLatin, InterBoldLatin];
@@ -32,24 +30,24 @@ const FontFace = ({ state }) => {
           font-family: "Inter";
           font-style: normal;
           font-weight: 500;
+          font-display: "swap";
           src: url(${fonts[0]}) format("woff2");
-          font-display: ${fontDisplay};
         }
 
         @font-face {
           font-family: "Inter";
           font-style: normal;
           font-weight: 600;
+          font-display: "swap";
           src: url(${fonts[1]}) format("woff2");
-          font-display: ${fontDisplay};
         }
 
         @font-face {
           font-family: "Inter";
           font-style: normal;
           font-weight: 700;
+          font-display: "swap";
           src: url(${fonts[2]}) format("woff2");
-          font-display: ${fontDisplay};
         }
       `}
     />


### PR DESCRIPTION
**What**:

It looks like embedding fonts in HTML is not a good technique and the performance score of LightHouse is hurt. I have discovered it after doing some tests because of a conversation that started here in this community post: https://community.frontity.org/t/psi-as-expected/1617

**Why**:

Even though I still don't like the flash that happens when loading custom fonts with `font-display: swap`, I think it's better to start recommending it because of the performance gain in LightHouse.

**How**:

I have lowered the limit for embedding fonts to only 8Kbs from the previous 25kbs. I have also refactored the font-face component of the TwentyTwenty theme.

**Tasks**:

- [x] Code
- [x] Unit tests
- [x] Update starter themes
- [x] Changeset
- [x] Community discussions

Unrelated:

- [ ] ~End to end tests~
- [ ] ~TypeScript~
- [ ] ~TypeScript tests~
- [ ] ~Update other packages~
- [ ] ~Documentation~

<!-- Feel free to add any additional comments. -->