### PR TITLE
github-actions: Add `actions-comment-run` workflow

### DIFF
--- a/.github/workflows/comment-run.yml
+++ b/.github/workflows/comment-run.yml
@@ -1,0 +1,18 @@
+# .github/workflows/comment-run.yml
+name: "Comment run"
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  comment-run:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # 0 indicates all history
+          fetch-depth: 0
+      - uses: nwtgck/actions-comment-run@v1.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allowed-associations: '["OWNER"]'


### PR DESCRIPTION
**What**:

Add a workflow that allows the owners of the frontity repo to post comments that will trigger github actions.

**Why**:

I noticed that the preview on now.sh has not been deployed and I did some digging and found that because we use github secrets to store the $NOW_TOKEN which is used for deployments, any PR by an external contributor will not be able to create a preview deploy!

But there is a workaround: We can use a bot that runs workflows triggered by comments in the PR: https://github.com/nwtgck/actions-comment-run. Then, if a comment is posted by a member of the team who has a collaborator access, the action triggered by that comment would have access to github secrets! It even has an example of the action that we can which could use to trigger a deploy: https://github.com/nwtgck/actions-comment-run#pr-merge-preview

And even better, we can put that comment in “saved replies” so that it’s literally one click! :sweat_smile:  #lazy

**How**:

Add https://github.com/nwtgck/actions-comment-run to workflows
