### PR TITLE
Fixing Warning: React.createFactory() for TwentyTwenty theme

### DIFF
--- a/.changeset/loud-gorillas-tickle.md
+++ b/.changeset/loud-gorillas-tickle.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Use a CSS-only loader to get rid of the outdated `react-spinners` package.

--- a/packages/twentytwenty-theme/package.json
+++ b/packages/twentytwenty-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontity/twentytwenty-theme",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The WordPress Twenty Twenty starter theme for Frontity",
   "keywords": [
     "frontity",
@@ -19,8 +19,7 @@
   "dependencies": {
     "@frontity/components": "^1.3.1",
     "@frontity/html2react": "^1.3.2",
-    "frontity": "^1.5.3",
-    "react-spinners": "^0.5.4",
+    "frontity": "^1.5.3",    
     "react-spring": "^8.0.27"
   }
 }

--- a/packages/twentytwenty-theme/package.json
+++ b/packages/twentytwenty-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontity/twentytwenty-theme",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "description": "The WordPress Twenty Twenty starter theme for Frontity",
   "keywords": [
     "frontity",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@frontity/components": "^1.3.1",
     "@frontity/html2react": "^1.3.2",
-    "frontity": "^1.5.3",    
+    "frontity": "^1.5.3",
     "react-spring": "^8.0.27"
   }
 }

--- a/packages/twentytwenty-theme/src/components/loading.js
+++ b/packages/twentytwenty-theme/src/components/loading.js
@@ -1,16 +1,53 @@
 import React from "react";
-import { styled, connect } from "frontity";
-import Loader from "react-spinners/BarLoader";
+import { styled, connect, keyframes, css } from "frontity";
+
+const style = (i = 1) => {
+  return css`
+    position: absolute;
+    height: 240px;
+    overflow: hidden;
+    background-color: #fff;
+    background-clip: padding-box;
+    display: block;
+    border-radius: 2px;
+    will-change: left, right;
+    animation-fill-mode: forwards;
+    animation: ${i === 1 ? long : short} 2.1s ${i === 2 ? "1.15s" : ""}
+      ${i === 1
+        ? "cubic-bezier(0.65, 0.815, 0.735, 0.395)"
+        : "cubic-bezier(0.165, 0.84, 0.44, 1)"}
+      infinite;
+  `;
+};
+
+const long = keyframes`
+  0% {left: -35%;right: 100%}
+  60% {left: 100%;right: -90%}
+  100% {left: 100%;right: -90%}
+`;
+
+const short = keyframes`
+  0% {left: -200%;right: 100%}
+  60% {left: 107%;right: -8%}
+  100% {left: 107%;right: -8%}
+`;
+
+const wrapper = (width, height, color) => {
+  return css`
+    position: relative;
+    width: ${width}px;
+    height: ${height}px;
+    overflow: hidden;
+    background-color: ${color};
+    background-clip: padding-box;
+  `;
+};
 
 const Loading = ({ state }) => (
   <Container>
-    <Loader
-      color={state.theme.colors.primary}
-      radius={0}
-      margin="3px"
-      height={4}
-      width={240}
-    />
+    <div css={[wrapper(240, 4, state.theme.colors.primary), css]}>
+      <div css={style(1)} />
+    </div>
   </Container>
 );
 

--- a/packages/twentytwenty-theme/src/components/loading.js
+++ b/packages/twentytwenty-theme/src/components/loading.js
@@ -1,23 +1,11 @@
 import React from "react";
 import { styled, connect, keyframes, css } from "frontity";
 
-const style = (i = 1) => {
-  return css`
-    position: absolute;
-    height: 240px;
-    overflow: hidden;
-    background-color: #fff;
-    background-clip: padding-box;
-    display: block;
-    border-radius: 2px;
-    will-change: left, right;
-    animation-fill-mode: forwards;
-    animation: ${i === 1 ? long : short} 2.1s ${i === 2 ? "1.15s" : ""}
-      ${i === 1
-        ? "cubic-bezier(0.65, 0.815, 0.735, 0.395)"
-        : "cubic-bezier(0.165, 0.84, 0.44, 1)"}
-      infinite;
-  `;
+const addAlpha = (hex, alpha) => {
+  const r = parseInt(hex.slice(1, 3), 16),
+    g = parseInt(hex.slice(3, 5), 16),
+    b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
 };
 
 const long = keyframes`
@@ -32,21 +20,38 @@ const short = keyframes`
   100% {left: 107%;right: -8%}
 `;
 
-const wrapper = (width, height, color) => {
-  return css`
+const style = (i = 1, color) =>
+  css`
+    position: absolute;
+    height: 240px;
+    overflow: hidden;
+    background-color: ${color};
+    background-clip: padding-box;
+    display: block;
+    border-radius: 2px;
+    will-change: left, right;
+    animation-fill-mode: forwards;
+    animation: ${i === 1 ? long : short} 2.1s ${i === 2 ? "1.15s" : ""}
+      ${i === 1
+        ? "cubic-bezier(0.65, 0.815, 0.735, 0.395)"
+        : "cubic-bezier(0.165, 0.84, 0.44, 1)"}
+      infinite;
+  `;
+
+const wrapper = (width, height, color) =>
+  css`
     position: relative;
     width: ${width}px;
     height: ${height}px;
     overflow: hidden;
-    background-color: ${color};
+    background-color: ${addAlpha(color, 0.2)};
     background-clip: padding-box;
   `;
-};
 
 const Loading = ({ state }) => (
   <Container>
     <div css={[wrapper(240, 4, state.theme.colors.primary), css]}>
-      <div css={style(1)} />
+      <div css={style(1, state.theme.colors.primary)} />
     </div>
   </Container>
 );


### PR DESCRIPTION
**What**:

Fix for issue https://github.com/frontity/frontity/issues/384 and https://github.com/frontity/frontity/issues/419 for TwentyTwenty theme

**Why**:

I see the following after cloning the TwentyTwenty starter theme and running the dev server:

Warning: React.createFactory() is deprecated and will be removed in a future major release. 
Consider using JSX or use React.createElement() directly instead.

**How**:

- Removed react-spinners dependency in package.json
- Increased version to 1.1.2
- Removed loading.js default loader and tweaked BarLoader code to fit in loader.js
- Removed Typescript from BarLoader code

**Tasks**:

- [x] Code
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [x] Update starter themes
- [ ] Update other packages
- [ ] Documentation
- [ ] Community discussions
- [ ] Changeset

**Screenshot**:

![image](https://user-images.githubusercontent.com/45217974/81030249-70f4a880-8e88-11ea-85f0-56a4486bd1f0.png)



