### PR TITLE
Add publicPath option to CLI

### DIFF
--- a/.changeset/odd-students-look.md
+++ b/.changeset/odd-students-look.md
@@ -1,0 +1,6 @@
+---
+"@frontity/core": minor
+"frontity": minor
+---
+
+Add a `--publicPath` option to `build` and `dev` commands and pass it to webpack builds.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "test": "lerna run test:ci --stream",
     "test:ci": "jest --clearCache && lerna run test:ci --stream",
     "e2e:prod:all": "cd e2e/project/ && npx frontity build && npx frontity serve --port 3001",
-    "e2e:prod:module": "cd e2e/project/ && npx frontity build --target module && npx frontity serve --port 3001",
-    "e2e:prod:es5": "cd e2e/project/ && npx frontity build --target es5 && npx frontity serve --port 3001",
+    "e2e:prod:module": "cd e2e/project/ && npx frontity build --publicPath /custom/path --target module && npx frontity serve --port 3001",
+    "e2e:prod:es5": "cd e2e/project/ && npx frontity build --publicPath /custom/path/ --target es5 && npx frontity serve --port 3001",
     "prepare": "lerna bootstrap --hoist",
     "reinstall": "lerna clean --yes && npm run prepare"
   },

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -8,13 +8,21 @@ import getFrontity from "./frontity";
 export default ({
   mode,
   entryPoints,
+  publicPath,
 }: {
   mode: Mode;
   entryPoints: EntryPoints[];
+  publicPath: string;
 }): Config => {
   const frontity = getFrontity();
   const babel = getBabel({ mode });
-  const webpack = getWebpack({ mode, babel, frontity, entryPoints });
+  const webpack = getWebpack({
+    mode,
+    babel,
+    frontity,
+    entryPoints,
+    publicPath,
+  });
   return {
     babel,
     webpack,

--- a/packages/core/src/config/webpack/__tests__/index.ts
+++ b/packages/core/src/config/webpack/__tests__/index.ts
@@ -63,3 +63,19 @@ test("Webpack returns for production", () => {
     })
   ).toMatchSnapshot();
 });
+
+test("Webpack changes the public path if specified", () => {
+  const publicPath = "/custom-public-path/";
+
+  const { es5, module, server } = getWebpack({
+    mode: "production",
+    babel: babel["production"],
+    frontity,
+    entryPoints,
+    publicPath,
+  });
+
+  expect(es5.output.publicPath).toBe(publicPath);
+  expect(module.output.publicPath).toBe(publicPath);
+  expect(server.output.publicPath).toBe(publicPath);
+});

--- a/packages/core/src/config/webpack/index.ts
+++ b/packages/core/src/config/webpack/index.ts
@@ -23,13 +23,13 @@ export default ({
   babel,
   frontity,
   entryPoints,
-  publicPath,
+  publicPath = "/static/",
 }: {
   mode: Mode;
   babel: BabelConfigs;
   frontity: FrontityConfig;
   entryPoints: EntryPoints[];
-  publicPath: string;
+  publicPath?: string;
 }): WebpackConfigs => {
   const getConfig = (target: Target): Configuration => ({
     mode,

--- a/packages/core/src/config/webpack/index.ts
+++ b/packages/core/src/config/webpack/index.ts
@@ -23,11 +23,13 @@ export default ({
   babel,
   frontity,
   entryPoints,
+  publicPath,
 }: {
   mode: Mode;
   babel: BabelConfigs;
   frontity: FrontityConfig;
   entryPoints: EntryPoints[];
+  publicPath: string;
 }): WebpackConfigs => {
   const getConfig = (target: Target): Configuration => ({
     mode,
@@ -35,7 +37,7 @@ export default ({
     target: targets({ target }),
     devtool: devtool({ mode }),
     entry: entry({ target, mode, entryPoints }),
-    output: output({ target, mode, outDir: frontity.outDir }),
+    output: output({ target, mode, outDir: frontity.outDir, publicPath }),
     module: modules({ target, babel, mode }),
     resolve: resolve(),
     externals: externals({ target }),

--- a/packages/core/src/config/webpack/output.ts
+++ b/packages/core/src/config/webpack/output.ts
@@ -66,7 +66,8 @@ export default ({
 }): Configuration["output"] => ({
   filename: filenames[target][mode],
   path: resolve(rootPath, outDir, paths[target]),
-  publicPath,
+  // Ensure there is a trailing slash in the public path.
+  publicPath: publicPath.replace(/\/?$/, "/"),
   ...(target !== "server" && { chunkFilename: chunkFilenames[target][mode] }),
   // Node still needs CJS.
   ...(target === "server" && { libraryTarget: "commonjs2" }),

--- a/packages/core/src/config/webpack/output.ts
+++ b/packages/core/src/config/webpack/output.ts
@@ -57,14 +57,16 @@ export default ({
   target,
   mode,
   outDir,
+  publicPath,
 }: {
   target: Target;
   mode: Mode;
   outDir: string;
+  publicPath: string;
 }): Configuration["output"] => ({
   filename: filenames[target][mode],
   path: resolve(rootPath, outDir, paths[target]),
-  publicPath: "/static/",
+  publicPath,
   ...(target !== "server" && { chunkFilename: chunkFilenames[target][mode] }),
   // Node still needs CJS.
   ...(target === "server" && { libraryTarget: "commonjs2" }),

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -12,9 +12,11 @@ import { webpackAsync } from "./utils/webpack";
 export default async ({
   mode,
   target,
+  publicPath,
 }: {
   mode: Mode;
   target: "both" | "es5" | "module";
+  publicPath: string;
 }): Promise<void> => {
   console.log(`mode: ${mode}\n`);
 
@@ -32,7 +34,7 @@ export default async ({
   const entryPoints = await generateEntryPoints({ sites, outDir, mode });
 
   // Get FrontityConfig for Webpack.
-  const config = getConfig({ mode, entryPoints });
+  const config = getConfig({ mode, entryPoints, publicPath });
 
   // Build and wait until webpack finished the clients first.
   // We need to do this because the server bundle needs to import

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -20,12 +20,14 @@ export default async ({
   port,
   target,
   openBrowser = true,
+  publicPath,
 }: {
   port: number;
   isHttps: boolean;
   mode: Mode;
   target: "es5" | "module";
   openBrowser?: boolean;
+  publicPath: string;
 }): Promise<void> => {
   // Get config from frontity.config.js files.
   const frontityConfig = getFrontity();
@@ -53,7 +55,7 @@ export default async ({
   });
 
   // Get config for webpack, babel and frontity.
-  const config = getConfig({ mode, entryPoints });
+  const config = getConfig({ mode, entryPoints, publicPath });
 
   // Build and wait until webpack finished the client first.
   // We need to do this because the server bundle needs to import

--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -27,7 +27,12 @@ export default ({ packages }): ReturnType<Koa["callback"]> => {
   const app = new Koa();
 
   // Serve static files.
-  app.use(mount("/static", serve("./build/static")));
+  app.use(async (ctx, next) => {
+    const moduleStats = await getStats({ target: "module" });
+    const es5Stats = await getStats({ target: "es5" });
+    const stats = moduleStats || es5Stats;
+    if (stats) mount(stats.publicPath, serve("build/static"))(ctx, next);
+  });
 
   // Default robots.txt.
   app.use(

--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -31,7 +31,8 @@ export default ({ packages }): ReturnType<Koa["callback"]> => {
     const moduleStats = await getStats({ target: "module" });
     const es5Stats = await getStats({ target: "es5" });
     const stats = moduleStats || es5Stats;
-    if (stats) mount(stats.publicPath, serve("build/static"))(ctx, next);
+    const publicPath = stats ? stats.publicPath : "/static";
+    return mount(publicPath, serve("build/static"))(ctx, next);
   });
 
   // Default robots.txt.

--- a/packages/core/src/server/utils/stats.ts
+++ b/packages/core/src/server/utils/stats.ts
@@ -1,3 +1,5 @@
+import { join } from "path";
+
 export interface Stats {
   assetsByChunkName: { [key: string]: string };
   publicPath?: string;
@@ -51,11 +53,17 @@ export const getBothScriptTags = ({
 
   const moduleTags = chunkNames.map(
     (chunk) =>
-      `<script async type="module" data-chunk="${chunk}" src="${publicPath}${moduleStats.assetsByChunkName[chunk]}"></script>`
+      `<script async type="module" data-chunk="${chunk}" src="${join(
+        publicPath,
+        moduleStats.assetsByChunkName[chunk]
+      )}"></script>`
   );
   const es5Tags = chunkNames.map(
     (chunk) =>
-      `<script async nomodule data-chunk="${chunk}" src="${publicPath}${es5Stats.assetsByChunkName[chunk]}"></script>`
+      `<script async nomodule data-chunk="${chunk}" src="${join(
+        publicPath,
+        es5Stats.assetsByChunkName[chunk]
+      )}"></script>`
   );
 
   const requiredChunksTag = extractor.getRequiredChunksScriptTag({});

--- a/packages/core/src/server/utils/stats.ts
+++ b/packages/core/src/server/utils/stats.ts
@@ -1,6 +1,6 @@
 export interface Stats {
   assetsByChunkName: { [key: string]: string };
-  publicPath: string;
+  publicPath?: string;
 }
 
 export interface Extractor {

--- a/packages/core/src/server/utils/stats.ts
+++ b/packages/core/src/server/utils/stats.ts
@@ -1,5 +1,6 @@
 export interface Stats {
   assetsByChunkName: { [key: string]: string };
+  publicPath: string;
 }
 
 export interface Extractor {

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -74,6 +74,11 @@ program
     "--target <target>",
     'create bundles with "es5" or "module". Default target is "module".'
   )
+
+  .option(
+    "--publicPath <path>",
+    'set the public path for static assests. Default path is "/static/".'
+  )
   .description("Starts a server in development mode.")
   .action(dev);
 
@@ -86,7 +91,7 @@ program
   )
   .option(
     "--publicPath <path>",
-    'set the public path for static assests. Default path is "/static".'
+    'set the public path for static assests. Default path is "/static/".'
   )
   .description("Builds the project for production.")
   .action(build);

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -77,7 +77,7 @@ program
 
   .option(
     "--publicPath <path>",
-    'set the public path for static assests. Default path is "/static/".'
+    'set the public path for static assets. Default path is "/static/".'
   )
   .description("Starts a server in development mode.")
   .action(dev);
@@ -91,7 +91,7 @@ program
   )
   .option(
     "--publicPath <path>",
-    'set the public path for static assests. Default path is "/static/".'
+    'set the public path for static assets. Default path is "/static/".'
   )
   .description("Builds the project for production.")
   .action(build);

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -84,6 +84,10 @@ program
     "--target <target>",
     'create bundles with "es5" or "module". Default target is "module".'
   )
+  .option(
+    "--publicPath <path>",
+    'set the public path for static assests. Default path is "/static".'
+  )
   .description("Builds the project for production.")
   .action(build);
 

--- a/packages/frontity/src/commands/build.ts
+++ b/packages/frontity/src/commands/build.ts
@@ -7,7 +7,7 @@ export default async ({ development, target, publicPath }) => {
   const options = {
     mode: development ? "development" : "production",
     target: target || "both",
-    publicPath: publicPath || "/static",
+    publicPath: publicPath || "/static/",
   };
 
   try {

--- a/packages/frontity/src/commands/build.ts
+++ b/packages/frontity/src/commands/build.ts
@@ -1,12 +1,13 @@
 import chalk from "chalk";
 import { errorLogger } from "../utils";
 
-export default async ({ development, target }) => {
+export default async ({ development, target, publicPath }) => {
   let build: Function;
 
   const options = {
     mode: development ? "development" : "production",
     target: target || "both",
+    publicPath: publicPath || "/static",
   };
 
   try {

--- a/packages/frontity/src/commands/dev.ts
+++ b/packages/frontity/src/commands/dev.ts
@@ -4,7 +4,14 @@ import choosePort from "../utils/choosePort";
 
 const HOST = process.env.HOST || "0.0.0.0";
 
-export default async ({ production, port, https, target, dontOpenBrowser }) => {
+export default async ({
+  production,
+  port,
+  https,
+  target,
+  dontOpenBrowser,
+  publicPath,
+}) => {
   let dev: Function;
 
   const options = {
@@ -13,6 +20,7 @@ export default async ({ production, port, https, target, dontOpenBrowser }) => {
     isHttps: !!https,
     target: target || "module",
     openBrowser: !dontOpenBrowser,
+    publicPath: publicPath || "/static/",
   };
 
   try {


### PR DESCRIPTION
**What**:

Add a `--publicPath` option to `build` and `dev` commands that is passed to webpack builds.

Closes #393 

**Why**:

To allow frontity users to change the public path option used by Webpack: https://webpack.js.org/guides/public-path/

**How**:

Following the implementation proposal: https://community.frontity.org/t/change-publicpath/1461/5

**Tasks**:

- [x] Code
- [x] Unit tests
- [x] Documentation: https://github.com/frontity/gitbook-docs/pull/60
- [x] Community discussions: https://community.frontity.org/t/change-publicpath/1461/7?u=david
- [x] Changeset

**Unrelated tasks**:
- ~TypeScript~ No new types created.
- ~End to end tests~ There are no e2e tests for the CLI yet.
- ~TypeScript tests~ No new types created.
- ~Update starter themes~ Not needed.
- ~Update other packages~ Not needed.



<!-- Feel free to add any additional comments. -->
