### PR TITLE
Add --ci arg to all tests run in the CI

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -17,7 +17,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest --passWithNoTests",
+    "test:ci": "../../node_modules/.bin/jest --ci --passWithNoTests",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"
   },

--- a/packages/babel-plugin-frontity/package.json
+++ b/packages/babel-plugin-frontity/package.json
@@ -17,7 +17,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand",
     "build": "tsc --project ./tsconfig.build.json",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,7 +15,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"
   },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -19,6 +19,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand",
     "dev:inspect": "node --inspect-brk -r ts-node/register src/scripts/dev.ts",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -15,6 +15,7 @@
     "url": "git+https://github.com/frontity/frontity.git"
   },
   "scripts": {
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"
   }

--- a/packages/file-settings/package.json
+++ b/packages/file-settings/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/frontity/frontity/issues"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand",
     "build": "tsc --project ./tsconfig.build.json",

--- a/packages/frontity/package.json
+++ b/packages/frontity/package.json
@@ -25,7 +25,7 @@
     "dev": "ts-node src/cli/index.ts",
     "ts": "ts-node",
     "test": "../../node_modules/.bin/jest --watch",
-    "test:ci": "../../node_modules/.bin/jest --colors",
+    "test:ci": "../../node_modules/.bin/jest --ci --colors",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand",
     "build": "tsc --project ./tsconfig.build.json && cp -a templates dist/templates",
     "prepublish": "npm run build"

--- a/packages/google-analytics/package.json
+++ b/packages/google-analytics/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"
   },

--- a/packages/google-tag-manager/package.json
+++ b/packages/google-tag-manager/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"
   },

--- a/packages/head-tags/package.json
+++ b/packages/head-tags/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -16,7 +16,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest --passWithNoTests",
+    "test:ci": "../../node_modules/.bin/jest --ci --passWithNoTests",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ./node_modules/jest/bin/jest.js --watch --no-cache --runInBand"
   },

--- a/packages/html2react/package.json
+++ b/packages/html2react/package.json
@@ -16,7 +16,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -16,7 +16,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --clearCache && ../../node_modules/.bin/jest"
   },
   "dependencies": {

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -17,6 +17,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --clearCache && ../../node_modules/.bin/jest"
   },
   "dependencies": {

--- a/packages/tiny-router/package.json
+++ b/packages/tiny-router/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,7 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --clearCache && ../../node_modules/.bin/jest"
   },
   "dependencies": {

--- a/packages/wp-source/package.json
+++ b/packages/wp-source/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "test:ci": "../../node_modules/.bin/jest",
+    "test:ci": "../../node_modules/.bin/jest --ci",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"
   },


### PR DESCRIPTION
**What**:

I added `--ci` to all the tests run in the CI, as suggested by @michalczaplinski czaplinski.

**Why**:

If we forget to add an snapshot, the tests will fail instead of create the snapshot.

https://jestjs.io/docs/en/cli.html#--ci

**How**:

I just updated all the `test:ci` scripts.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation"
Strikethrough each line that's irrelevant to your changes using ~, for example: "- [x] ~Code~"
If needed, add the reason: "- [x] ~Documentation~: Internal code, not documented." -->

- [x] Code
- [ ] ~TypeScript~
- [ ] ~Unit tests~
- [ ] ~End to end tests~
- [ ] ~TypeScript tests~
- [ ] ~Update starter themes~
- [ ] ~Update other packages~
- [ ] ~Documentation~
- [ ] ~Community discussions~
- [ ] ~Changeset~
<!-- Changesets are necessary if your changes should release any packages.Run
`npx changeset` to create a changeset. If there is a Feature Discussion for
this, please add a link: https://community.frontity.org/c/33 -->

<!-- Feel free to add any additional comments. -->
