### PR TITLE
Change urls to point to test.frontity.org

### DIFF
--- a/.changeset/quick-otters-juggle.md
+++ b/.changeset/quick-otters-juggle.md
@@ -1,0 +1,8 @@
+---
+"frontity": patch
+"@frontity/head-tags": patch
+"@frontity/source": patch
+"@frontity/wp-source": patch
+---
+
+Change urls to point to test.frontity.org instead of test.frontity.io.

--- a/e2e/packages/wp-source-errors/src/index.tsx
+++ b/e2e/packages/wp-source-errors/src/index.tsx
@@ -25,15 +25,15 @@ const wpSourceErrors: WpSourceErrors = {
         if (path !== "/") {
           state.source.api = `https://httpstat.us/${path}?rest_route=/`;
         } else {
-          state.source.api = "https://test.frontity.io/wp-json";
+          state.source.api = "https://test.frontity.org/wp-json";
         }
-      }
-    }
+      },
+    },
   },
   roots: {
-    wpSourceErrors: Root
+    wpSourceErrors: Root,
   },
-  libraries: {}
+  libraries: {},
 };
 
 export default wpSourceErrors;

--- a/e2e/project/frontity.settings.ts
+++ b/e2e/project/frontity.settings.ts
@@ -63,13 +63,13 @@ const settings: Settings = [
       "e2e-tiny-router",
       {
         name: "@frontity/tiny-router",
-        state: { router: { autoFetch: false } }
+        state: { router: { autoFetch: false } },
       },
       {
         name: "@frontity/wp-source",
-        state: { source: { api: "https://test.frontity.io/wp-json" } }
-      }
-    ]
+        state: { source: { api: "https://test.frontity.org/wp-json" } },
+      },
+    ],
   },
   {
     name: "google-tag-manager",

--- a/examples/mars-theme-example/frontity.settings.js
+++ b/examples/mars-theme-example/frontity.settings.js
@@ -4,8 +4,8 @@ export default {
     frontity: {
       url: "https://mars.frontity.org",
       title: "Test Frontity Blog",
-      description: "Useful content for Frontity development"
-    }
+      description: "Useful content for Frontity development",
+    },
   },
   packages: [
     "@frontity/tiny-router",
@@ -19,22 +19,22 @@ export default {
             ["Nature", "/category/nature/"],
             ["Travel", "/category/travel/"],
             ["Japan", "/tag/japan/"],
-            ["About Us", "/about-us/"]
+            ["About Us", "/about-us/"],
           ],
           featured: {
             showOnList: true,
-            showOnPost: true
-          }
-        }
-      }
+            showOnPost: true,
+          },
+        },
+      },
     },
     {
       name: "@frontity/wp-source",
       state: {
         source: {
-          api: "https://test.frontity.io/wp-json"
-        }
-      }
-    }
-  ]
+          api: "https://test.frontity.org/wp-json",
+        },
+      },
+    },
+  ],
 };

--- a/examples/twentytwenty-theme-example/frontity.settings.js
+++ b/examples/twentytwenty-theme-example/frontity.settings.js
@@ -52,7 +52,7 @@ export default {
       name: "@frontity/wp-source",
       state: {
         source: {
-          api: "https://test.frontity.io/wp-json",
+          api: "https://test.frontity.org/wp-json",
         },
       },
     },

--- a/packages/frontity/src/__tests__/__snapshots__/steps.test.ts.snap
+++ b/packages/frontity/src/__tests__/__snapshots__/steps.test.ts.snap
@@ -75,7 +75,7 @@ Array [
   \\"name\\": \\"random-name\\",
   \\"state\\": {
     \\"frontity\\": {
-      \\"url\\": \\"https://test.frontity.io\\",
+      \\"url\\": \\"https://test.frontity.org\\",
       \\"title\\": \\"Test Frontity Blog\\",
       \\"description\\": \\"WordPress installation for Frontity development\\"
     }
@@ -118,7 +118,7 @@ Array [
       \\"name\\": \\"@frontity/wp-source\\",
       \\"state\\": {
         \\"source\\": {
-          \\"api\\": \\"https://test.frontity.io/wp-json\\"
+          \\"api\\": \\"https://test.frontity.org/wp-json\\"
         }
       }
     },
@@ -138,7 +138,7 @@ Array [
   \\"name\\": \\"random-name\\",
   \\"state\\": {
     \\"frontity\\": {
-      \\"url\\": \\"https://test.frontity.io\\",
+      \\"url\\": \\"https://test.frontity.org\\",
       \\"title\\": \\"Test Frontity Blog\\",
       \\"description\\": \\"WordPress installation for Frontity development\\"
     }
@@ -181,7 +181,7 @@ Array [
       \\"name\\": \\"@frontity/wp-source\\",
       \\"state\\": {
         \\"source\\": {
-          \\"api\\": \\"https://test.frontity.io/wp-json\\"
+          \\"api\\": \\"https://test.frontity.org/wp-json\\"
         }
       }
     },

--- a/packages/frontity/src/steps/index.ts
+++ b/packages/frontity/src/steps/index.ts
@@ -143,7 +143,7 @@ export const createFrontitySettings = async (
     name,
     state: {
       frontity: {
-        url: "https://test.frontity.io",
+        url: "https://test.frontity.org",
         title: "Test Frontity Blog",
         description: "WordPress installation for Frontity development",
       },
@@ -171,7 +171,7 @@ export const createFrontitySettings = async (
         name: "@frontity/wp-source",
         state: {
           source: {
-            api: "https://test.frontity.io/wp-json",
+            api: "https://test.frontity.org/wp-json",
           },
         },
       },

--- a/packages/head-tags/src/__tests__/__snapshots__/state.tests.ts.snap
+++ b/packages/head-tags/src/__tests__/__snapshots__/state.tests.ts.snap
@@ -18,7 +18,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/",
+      "href": "https://test.frontity.org/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
@@ -39,14 +39,14 @@ exports[`state.headTags.get() (post entity) doesn't change links that don't poin
 Array [
   Object {
     "attributes": Object {
-      "content": "https://test.frontity.io/wp-content/uploads/2019/12/img.jpg",
+      "content": "https://test.frontity.org/wp-content/uploads/2019/12/img.jpg",
       "property": "og:image",
     },
     "tag": "meta",
   },
   Object {
     "attributes": Object {
-      "content": "https://test.frontity.io/wp-content/uploads/2019/12/img.jpg",
+      "content": "https://test.frontity.org/wp-content/uploads/2019/12/img.jpg",
       "name": "twitter:image",
     },
     "tag": "meta",
@@ -60,7 +60,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/feed/",
+      "href": "https://test.frontity.org/feed/",
       "rel": "alternate",
       "title": "frontity » Feed",
       "type": "application/rss+xml",
@@ -69,7 +69,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/comments/feed/",
+      "href": "https://test.frontity.org/comments/feed/",
       "rel": "alternate",
       "title": "frontity » Comments Feed",
       "type": "application/rss+xml",
@@ -78,7 +78,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/post-1/feed/",
+      "href": "https://test.frontity.org/post-1/feed/",
       "rel": "alternate",
       "title": "frontity » Post 1 Comments Feed",
       "type": "application/rss+xml",
@@ -87,14 +87,14 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/",
+      "href": "https://test.frontity.org/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/xmlrpc.php?rsd",
+      "href": "https://test.frontity.org/xmlrpc.php?rsd",
       "rel": "EditURI",
       "title": "RSD",
       "type": "application/rsd+xml",
@@ -103,7 +103,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-includes/wlwmanifest.xml",
+      "href": "https://test.frontity.org/wp-includes/wlwmanifest.xml",
       "rel": "wlwmanifest",
       "type": "application/wlwmanifest+xml",
     },
@@ -111,7 +111,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.io%2Fpost-1%2F",
+      "href": "https://test.frontity.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.org%2Fpost-1%2F",
       "rel": "alternate",
       "type": "application/json+oembed",
     },
@@ -119,7 +119,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.io%2Fpost-1%2F&format=xml",
+      "href": "https://test.frontity.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.org%2Fpost-1%2F&format=xml",
       "rel": "alternate",
       "type": "text/xml+oembed",
     },
@@ -127,7 +127,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/xmlrpc.php",
+      "href": "https://test.frontity.org/xmlrpc.php",
       "rel": "pingback",
     },
     "tag": "link",
@@ -139,14 +139,14 @@ exports[`state.headTags.get() (post entity) doesn't transform links if \`source.
 Array [
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/post-1/",
+      "href": "https://test.frontity.org/post-1/",
       "rel": "canonical",
     },
     "tag": "link",
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/",
+      "href": "https://test.frontity.org/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
@@ -155,7 +155,7 @@ Array [
     "attributes": Object {
       "type": "application/ld+json",
     },
-    "content": "{\\"@context\\":\\"https://schema.org\\",\\"@graph\\":[{\\"@type\\":\\"WebSite\\",\\"@id\\":\\"https://test.frontity.io/#website\\",\\"url\\":\\"https://test.frontity.io/\\"}]}",
+    "content": "{\\"@context\\":\\"https://schema.org\\",\\"@graph\\":[{\\"@type\\":\\"WebSite\\",\\"@id\\":\\"https://test.frontity.org/#website\\",\\"url\\":\\"https://test.frontity.org/\\"}]}",
     "tag": "script",
   },
 ]
@@ -165,14 +165,14 @@ exports[`state.headTags.get() (post entity) doesn't transform links if \`state.h
 Array [
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/post-1/",
+      "href": "https://test.frontity.org/post-1/",
       "rel": "canonical",
     },
     "tag": "link",
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/",
+      "href": "https://test.frontity.org/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
@@ -181,7 +181,7 @@ Array [
     "attributes": Object {
       "type": "application/ld+json",
     },
-    "content": "{\\"@context\\":\\"https://schema.org\\",\\"@graph\\":[{\\"@type\\":\\"WebSite\\",\\"@id\\":\\"https://test.frontity.io/#website\\",\\"url\\":\\"https://test.frontity.io/\\"}]}",
+    "content": "{\\"@context\\":\\"https://schema.org\\",\\"@graph\\":[{\\"@type\\":\\"WebSite\\",\\"@id\\":\\"https://test.frontity.org/#website\\",\\"url\\":\\"https://test.frontity.org/\\"}]}",
     "tag": "script",
   },
 ]
@@ -229,12 +229,12 @@ Array [
   \\"@graph\\": [
     {
       \\"@type\\": \\"WebPage\\",
-      \\"@id\\": \\"https://test.frontity.io/wrong-title/#webpage\\",
-      \\"url\\": \\"https://test.frontity.io/wrong-title/\\",
+      \\"@id\\": \\"https://test.frontity.org/wrong-title/#webpage\\",
+      \\"url\\": \\"https://test.frontity.org/wrong-title/\\",
       \\"inLanguage\\": \\"en-US\\",
       \\"name\\": \\"Wrong title with \\"quotes\\" - frontity\\",
       \\"isPartOf\\": {
-        \\"@id\\": \\"https://test.frontity.io/#website\\"
+        \\"@id\\": \\"https://test.frontity.org/#website\\"
       }
     }
   ]
@@ -253,7 +253,7 @@ Array [
       "class": "yoast-schema-graph yoast-schema-graph--main",
       "type": "application/ld+json",
     },
-    "content": "{\\"@context\\":\\"https://schema.org\\",\\"@graph\\":[{\\"@type\\":\\"WebSite\\",\\"@id\\":\\"https://mars.frontity.org/#website\\",\\"url\\":\\"https://mars.frontity.org/\\",\\"potentialAction\\":{\\"@type\\":\\"SearchAction\\",\\"target\\":\\"https://mars.frontity.org/?s={search_term_string}\\"}},{\\"@type\\":\\"ImageObject\\",\\"@id\\":\\"https://mars.frontity.org/post-1/#primaryimage\\",\\"url\\":\\"https://test.frontity.io/wp-content/uploads/2019/12/img.jpg\\"}]}",
+    "content": "{\\"@context\\":\\"https://schema.org\\",\\"@graph\\":[{\\"@type\\":\\"WebSite\\",\\"@id\\":\\"https://mars.frontity.org/#website\\",\\"url\\":\\"https://mars.frontity.org/\\",\\"potentialAction\\":{\\"@type\\":\\"SearchAction\\",\\"target\\":\\"https://mars.frontity.org/?s={search_term_string}\\"}},{\\"@type\\":\\"ImageObject\\",\\"@id\\":\\"https://mars.frontity.org/post-1/#primaryimage\\",\\"url\\":\\"https://test.frontity.org/wp-content/uploads/2019/12/img.jpg\\"}]}",
     "tag": "script",
   },
 ]
@@ -270,7 +270,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/",
+      "href": "https://test.frontity.org/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
@@ -296,7 +296,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/do-not-change/me/",
+      "href": "https://test.frontity.org/do-not-change/me/",
       "rel": "alternate",
       "title": "frontity » Feed",
       "type": "application/rss+xml",
@@ -317,7 +317,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/subdir/wp-json/",
+      "href": "https://test.frontity.org/subdir/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
@@ -343,7 +343,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/subdir/wp-json/",
+      "href": "https://test.frontity.org/subdir/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
@@ -402,7 +402,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/",
+      "href": "https://test.frontity.org/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",
@@ -435,7 +435,7 @@ Array [
   },
   Object {
     "attributes": Object {
-      "href": "https://test.frontity.io/wp-json/",
+      "href": "https://test.frontity.org/wp-json/",
       "rel": "https://api.w.org/",
     },
     "tag": "link",

--- a/packages/head-tags/src/__tests__/mocks/utils.ts
+++ b/packages/head-tags/src/__tests__/mocks/utils.ts
@@ -13,7 +13,7 @@ export const mockPostEntity = (
         id: 1,
         slug: "post-1",
         type: "post",
-        link: "https://test.frontity.io/post-1/",
+        link: "https://test.frontity.org/post-1/",
         author: 1,
         featured_media: 1,
         categories: [],
@@ -74,7 +74,7 @@ export const mockTaxonomy = (headTags: HeadTags) => {
       1: {
         id: 1,
         count: 5,
-        link: "https://test.frontity.io/category/cat-1/",
+        link: "https://test.frontity.org/category/cat-1/",
         slug: "cat-1",
         taxonomy: "category",
         parent: 0,
@@ -102,7 +102,7 @@ export const mockAuthor = (headTags: HeadTags) => {
       1: {
         id: 1,
         name: "Author 1",
-        link: "https://test.frontity.io/author/author-1/",
+        link: "https://test.frontity.org/author/author-1/",
         slug: "author-1",
         head_tags: headTags,
       },

--- a/packages/head-tags/src/__tests__/state.tests.ts
+++ b/packages/head-tags/src/__tests__/state.tests.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 
   // Mock wp-source state.
   config.state.source = clone(wpSource()).state.source;
-  config.state.source.api = "https://test.frontity.io/wp-json";
+  config.state.source.api = "https://test.frontity.org/wp-json";
   // Mock router state.
   config.state.router = { link: "/", state: {} };
   // Mock site url.
@@ -83,21 +83,21 @@ describe("state.headTags.get() (post entity)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/post-1/",
+          href: "https://test.frontity.org/post-1/",
         },
       },
       {
         tag: "meta",
         attributes: {
           property: "og:url",
-          content: "https://test.frontity.io/post-1/",
+          content: "https://test.frontity.org/post-1/",
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "shortlink",
-          href: "https://test.frontity.io/?p=1",
+          href: "https://test.frontity.org/?p=1",
         },
       },
     ];
@@ -114,7 +114,7 @@ describe("state.headTags.get() (post entity)", () => {
         attributes: {
           property: "og:image",
           content:
-            "https://test.frontity.io/wp-content/uploads/2019/12/img.jpg",
+            "https://test.frontity.org/wp-content/uploads/2019/12/img.jpg",
         },
       },
       {
@@ -122,7 +122,7 @@ describe("state.headTags.get() (post entity)", () => {
         attributes: {
           name: "twitter:image",
           content:
-            "https://test.frontity.io/wp-content/uploads/2019/12/img.jpg",
+            "https://test.frontity.org/wp-content/uploads/2019/12/img.jpg",
         },
       },
       {
@@ -138,7 +138,7 @@ describe("state.headTags.get() (post entity)", () => {
           rel: "alternate",
           type: "application/rss+xml",
           title: "frontity » Feed",
-          href: "https://test.frontity.io/feed/",
+          href: "https://test.frontity.org/feed/",
         },
       },
       {
@@ -147,7 +147,7 @@ describe("state.headTags.get() (post entity)", () => {
           rel: "alternate",
           type: "application/rss+xml",
           title: "frontity » Comments Feed",
-          href: "https://test.frontity.io/comments/feed/",
+          href: "https://test.frontity.org/comments/feed/",
         },
       },
       {
@@ -156,14 +156,14 @@ describe("state.headTags.get() (post entity)", () => {
           rel: "alternate",
           type: "application/rss+xml",
           title: "frontity » Post 1 Comments Feed",
-          href: "https://test.frontity.io/post-1/feed/",
+          href: "https://test.frontity.org/post-1/feed/",
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/wp-json/",
+          href: "https://test.frontity.org/wp-json/",
         },
       },
       {
@@ -172,7 +172,7 @@ describe("state.headTags.get() (post entity)", () => {
           rel: "EditURI",
           type: "application/rsd+xml",
           title: "RSD",
-          href: "https://test.frontity.io/xmlrpc.php?rsd",
+          href: "https://test.frontity.org/xmlrpc.php?rsd",
         },
       },
       {
@@ -180,7 +180,7 @@ describe("state.headTags.get() (post entity)", () => {
         attributes: {
           rel: "wlwmanifest",
           type: "application/wlwmanifest+xml",
-          href: "https://test.frontity.io/wp-includes/wlwmanifest.xml",
+          href: "https://test.frontity.org/wp-includes/wlwmanifest.xml",
         },
       },
       {
@@ -189,7 +189,7 @@ describe("state.headTags.get() (post entity)", () => {
           rel: "alternate",
           type: "application/json+oembed",
           href:
-            "https://test.frontity.io/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.io%2Fpost-1%2F",
+            "https://test.frontity.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.org%2Fpost-1%2F",
         },
       },
       {
@@ -198,14 +198,14 @@ describe("state.headTags.get() (post entity)", () => {
           rel: "alternate",
           type: "text/xml+oembed",
           href:
-            "https://test.frontity.io/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.io%2Fpost-1%2F&format=xml",
+            "https://test.frontity.org/wp-json/oembed/1.0/embed?url=http%3A%2F%2Ftest.frontity.org%2Fpost-1%2F&format=xml",
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "pingback",
-          href: "https://test.frontity.io/xmlrpc.php",
+          href: "https://test.frontity.org/xmlrpc.php",
         },
       },
     ];
@@ -229,19 +229,19 @@ describe("state.headTags.get() (post entity)", () => {
             {
               // All these links should change...
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/#website",
-              url: "https://test.frontity.io/",
+              "@id": "https://test.frontity.org/#website",
+              url: "https://test.frontity.org/",
               potentialAction: {
                 "@type": "SearchAction",
-                target: "https://test.frontity.io/?s={search_term_string}",
+                target: "https://test.frontity.org/?s={search_term_string}",
               },
             },
             {
               "@type": "ImageObject",
-              "@id": "https://test.frontity.io/post-1/#primaryimage",
+              "@id": "https://test.frontity.org/post-1/#primaryimage",
               // ...except this one.
               url:
-                "https://test.frontity.io/wp-content/uploads/2019/12/img.jpg",
+                "https://test.frontity.org/wp-content/uploads/2019/12/img.jpg",
             },
           ],
         }),
@@ -259,14 +259,14 @@ describe("state.headTags.get() (post entity)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/subdir/post-1/", // should change
+          href: "https://test.frontity.org/subdir/post-1/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/subdir/wp-json/", // should not change
+          href: "https://test.frontity.org/subdir/wp-json/", // should not change
         },
       },
       {
@@ -280,8 +280,8 @@ describe("state.headTags.get() (post entity)", () => {
             {
               // All these links should change
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/subdir/#website",
-              url: "https://test.frontity.io/subdir/",
+              "@id": "https://test.frontity.org/subdir/#website",
+              url: "https://test.frontity.org/subdir/",
             },
           ],
         }),
@@ -291,7 +291,7 @@ describe("state.headTags.get() (post entity)", () => {
     setUpState(store.state, headTags);
 
     // Change API prop
-    store.state.source.api = "https://test.frontity.io/subdir/wp-json/";
+    store.state.source.api = "https://test.frontity.org/subdir/wp-json/";
 
     // Test current head tags.
     expect(store.state.headTags.get(store.state.router.link)).toMatchSnapshot();
@@ -303,14 +303,14 @@ describe("state.headTags.get() (post entity)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/subdir/post-1/", // should change
+          href: "https://test.frontity.org/subdir/post-1/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/subdir/wp-json/", // should not change
+          href: "https://test.frontity.org/subdir/wp-json/", // should not change
         },
       },
       {
@@ -324,8 +324,8 @@ describe("state.headTags.get() (post entity)", () => {
             {
               // All these links should change
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/subdir/#website",
-              url: "https://test.frontity.io/subdir/",
+              "@id": "https://test.frontity.org/subdir/#website",
+              url: "https://test.frontity.org/subdir/",
             },
           ],
         }),
@@ -336,7 +336,7 @@ describe("state.headTags.get() (post entity)", () => {
 
     // Change API and Frontity URL prop
     store.state.frontity.url = "https://frontity.org/mars/";
-    store.state.source.api = "https://test.frontity.io/subdir/wp-json/";
+    store.state.source.api = "https://test.frontity.org/subdir/wp-json/";
 
     // Test current head tags.
     expect(store.state.headTags.get(store.state.router.link)).toMatchSnapshot();
@@ -348,7 +348,7 @@ describe("state.headTags.get() (post entity)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/subdir/post-1/", // should change
+          href: "https://test.frontity.org/subdir/post-1/", // should change
         },
       },
     ];
@@ -379,12 +379,12 @@ describe("state.headTags.get() (post entity)", () => {
   "@graph": [
     {
       "@type": "WebPage",
-      "@id": "https://test.frontity.io/wrong-title/#webpage",
-      "url": "https://test.frontity.io/wrong-title/",
+      "@id": "https://test.frontity.org/wrong-title/#webpage",
+      "url": "https://test.frontity.org/wrong-title/",
       "inLanguage": "en-US",
       "name": "Wrong title with "quotes" - frontity",
       "isPartOf": {
-        "@id": "https://test.frontity.io/#website"
+        "@id": "https://test.frontity.org/#website"
       }
     }
   ]
@@ -407,14 +407,14 @@ describe("state.headTags.get() (post entity)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/post-1/", // should not change
+          href: "https://test.frontity.org/post-1/", // should not change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/wp-json/", // should not change
+          href: "https://test.frontity.org/wp-json/", // should not change
         },
       },
       {
@@ -428,8 +428,8 @@ describe("state.headTags.get() (post entity)", () => {
             {
               // All these links should not change
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/#website",
-              url: "https://test.frontity.io/",
+              "@id": "https://test.frontity.org/#website",
+              url: "https://test.frontity.org/",
             },
           ],
         }),
@@ -451,14 +451,14 @@ describe("state.headTags.get() (post entity)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/post-1/", // should not change
+          href: "https://test.frontity.org/post-1/", // should not change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/wp-json/", // should not change
+          href: "https://test.frontity.org/wp-json/", // should not change
         },
       },
       {
@@ -472,8 +472,8 @@ describe("state.headTags.get() (post entity)", () => {
             {
               // All these links should not change
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/#website",
-              url: "https://test.frontity.io/",
+              "@id": "https://test.frontity.org/#website",
+              url: "https://test.frontity.org/",
             },
           ],
         }),
@@ -483,7 +483,7 @@ describe("state.headTags.get() (post entity)", () => {
     setUpState(store.state, headTags);
 
     // Set `frontity.url` to the same site.
-    store.state.frontity.url = "https://test.frontity.io/";
+    store.state.frontity.url = "https://test.frontity.org/";
 
     // Test current head tags.
     expect(store.state.headTags.get(store.state.router.link)).toMatchSnapshot();
@@ -495,14 +495,14 @@ describe("state.headTags.get() (post entity)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://different.frontity.io/blog/post-1/", // should change
+          href: "https://different.frontity.org/blog/post-1/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/wp-json/", // should not change
+          href: "https://test.frontity.org/wp-json/", // should not change
         },
       },
       {
@@ -516,8 +516,8 @@ describe("state.headTags.get() (post entity)", () => {
             {
               // All these links should change
               "@type": "WebSite",
-              "@id": "https://different.frontity.io/blog/#website",
-              url: "https://different.frontity.io/blog/",
+              "@id": "https://different.frontity.org/blog/#website",
+              url: "https://different.frontity.org/blog/",
             },
           ],
         }),
@@ -529,7 +529,7 @@ describe("state.headTags.get() (post entity)", () => {
     // Set `transformLinks` to false.
     const { transformLinks } = store.state.headTags;
     if (transformLinks)
-      transformLinks.base = "https://different.frontity.io/blog/";
+      transformLinks.base = "https://different.frontity.org/blog/";
 
     // Test current head tags.
     expect(store.state.headTags.get(store.state.router.link)).toMatchSnapshot();
@@ -543,7 +543,7 @@ describe("state.headTags.get() (post entity)", () => {
           name: "twitter:image",
           // should change
           content:
-            "https://test.frontity.io/wp-content/uploads/2019/12/img.jpg",
+            "https://test.frontity.org/wp-content/uploads/2019/12/img.jpg",
         },
       },
       {
@@ -553,7 +553,7 @@ describe("state.headTags.get() (post entity)", () => {
           type: "application/rss+xml",
           title: "frontity » Feed",
           // SHOULD NOT CHANGE
-          href: "https://test.frontity.io/do-not-change/me/",
+          href: "https://test.frontity.org/do-not-change/me/",
         },
       },
     ];
@@ -563,7 +563,7 @@ describe("state.headTags.get() (post entity)", () => {
     // Set `transformLinks` to false.
     const { transformLinks } = store.state.headTags;
     if (transformLinks) {
-      transformLinks.base = "https://test.frontity.io/";
+      transformLinks.base = "https://test.frontity.org/";
       transformLinks.ignore = "do\\-not\\-change";
     }
 
@@ -589,21 +589,21 @@ describe("state.headTags.get() (post type)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/", // should change
+          href: "https://test.frontity.org/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "next",
-          href: "https://test.frontity.io/page/2/", // should change
+          href: "https://test.frontity.org/page/2/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/wp-json/", // should not change
+          href: "https://test.frontity.org/wp-json/", // should not change
         },
       },
       {
@@ -617,8 +617,8 @@ describe("state.headTags.get() (post type)", () => {
             {
               // All these links should change
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/#website",
-              url: "https://test.frontity.io/",
+              "@id": "https://test.frontity.org/#website",
+              url: "https://test.frontity.org/",
             },
           ],
         }),
@@ -648,21 +648,21 @@ describe("state.headTags.get() (taxonomy)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/category/cat-1/", // should change
+          href: "https://test.frontity.org/category/cat-1/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "next",
-          href: "https://test.frontity.io/category/cat-1/page/2/", // should change
+          href: "https://test.frontity.org/category/cat-1/page/2/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/wp-json/", // should not change
+          href: "https://test.frontity.org/wp-json/", // should not change
         },
       },
       {
@@ -676,8 +676,8 @@ describe("state.headTags.get() (taxonomy)", () => {
             {
               // All these links should change
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/#website",
-              url: "https://test.frontity.io/",
+              "@id": "https://test.frontity.org/#website",
+              url: "https://test.frontity.org/",
             },
           ],
         }),
@@ -707,21 +707,21 @@ describe("state.headTags.get() (author)", () => {
         tag: "link",
         attributes: {
           rel: "canonical",
-          href: "https://test.frontity.io/author/author-1/", // should change
+          href: "https://test.frontity.org/author/author-1/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "next",
-          href: "https://test.frontity.io/author/author-1/page/2/", // should change
+          href: "https://test.frontity.org/author/author-1/page/2/", // should change
         },
       },
       {
         tag: "link",
         attributes: {
           rel: "https://api.w.org/",
-          href: "https://test.frontity.io/wp-json/", // should not change
+          href: "https://test.frontity.org/wp-json/", // should not change
         },
       },
       {
@@ -735,8 +735,8 @@ describe("state.headTags.get() (author)", () => {
             {
               // All these links should change
               "@type": "WebSite",
-              "@id": "https://test.frontity.io/#website",
-              url: "https://test.frontity.io/",
+              "@id": "https://test.frontity.org/#website",
+              url: "https://test.frontity.org/",
             },
           ],
         }),

--- a/packages/source/types/__tests__/data.tests.ts
+++ b/packages/source/types/__tests__/data.tests.ts
@@ -44,12 +44,12 @@ data.taxonomy = {
     {
       id: 60,
       type: "post",
-      link: "https://test.frontity.io/2016/the-beauties-of-gullfoss",
+      link: "https://test.frontity.org/2016/the-beauties-of-gullfoss",
     },
     {
       id: 57,
       type: "post",
-      link: "https://test.frontity.io/2016/shinjuku-gyoen-national-garden/",
+      link: "https://test.frontity.org/2016/shinjuku-gyoen-national-garden/",
     },
   ],
   isReady: true,
@@ -69,12 +69,12 @@ data.taxonomyWithSearchData = {
     {
       id: 60,
       type: "post",
-      link: "https://test.frontity.io/2016/the-beauties-of-gullfoss",
+      link: "https://test.frontity.org/2016/the-beauties-of-gullfoss",
     },
     {
       id: 57,
       type: "post",
-      link: "https://test.frontity.io/2016/shinjuku-gyoen-national-garden/",
+      link: "https://test.frontity.org/2016/shinjuku-gyoen-national-garden/",
     },
   ],
   isReady: true,

--- a/packages/source/types/__tests__/entity.tests.ts
+++ b/packages/source/types/__tests__/entity.tests.ts
@@ -13,7 +13,7 @@ const author: AuthorEntity = {
   name: "luisherranz",
   url: "",
   description: "",
-  link: "https://test.frontity.io/author/luisherranz/",
+  link: "https://test.frontity.org/author/luisherranz/",
   slug: "luisherranz",
   avatar_urls: {
     "24": "https://secure.gravatar.com/avatar/?s=24&d=mm&r=g",
@@ -24,12 +24,12 @@ const author: AuthorEntity = {
   _links: {
     self: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/users/1",
+        href: "https://test.frontity.org/wp-json/wp/v2/users/1",
       },
     ],
     collection: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/users",
+        href: "https://test.frontity.org/wp-json/wp/v2/users",
       },
     ],
   },
@@ -39,7 +39,7 @@ const taxonomy: TaxonomyEntity = {
   id: 7,
   count: 10,
   description: "",
-  link: "https://test.frontity.io/category/nature/",
+  link: "https://test.frontity.org/category/nature/",
   name: "Nature",
   slug: "nature",
   taxonomy: "category",
@@ -48,22 +48,22 @@ const taxonomy: TaxonomyEntity = {
   _links: {
     self: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/categories/7",
+        href: "https://test.frontity.org/wp-json/wp/v2/categories/7",
       },
     ],
     collection: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/categories",
+        href: "https://test.frontity.org/wp-json/wp/v2/categories",
       },
     ],
     about: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/taxonomies/category",
+        href: "https://test.frontity.org/wp-json/wp/v2/taxonomies/category",
       },
     ],
     "wp:post_type": [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/posts?categories=7",
+        href: "https://test.frontity.org/wp-json/wp/v2/posts?categories=7",
       },
     ],
     curies: [
@@ -88,7 +88,7 @@ const post: PostEntity = {
   slug: "block-button",
   status: "publish",
   type: "post",
-  link: "https://test.frontity.io/2018/block-button/",
+  link: "https://test.frontity.org/2018/block-button/",
   title: {
     rendered: "Block: Button",
   },
@@ -99,7 +99,7 @@ const post: PostEntity = {
   },
   excerpt: {
     rendered:
-      '<p>Button blocks are not semantically buttons, but links inside a styled div.&nbsp; If you do not add a link, a link tag without an anchor will be used. Left aligned Check to make sure that the text wraps correctly when the button has more than one line of text, and when it is extra long. &hellip; </p>\n<p class="link-more"><a href="https://test.frontity.io/2018/block-button/" class="more-link">Continue reading<span class="screen-reader-text"> &#8220;Block: Button&#8221;</span></a></p>\n',
+      '<p>Button blocks are not semantically buttons, but links inside a styled div.&nbsp; If you do not add a link, a link tag without an anchor will be used. Left aligned Check to make sure that the text wraps correctly when the button has more than one line of text, and when it is extra long. &hellip; </p>\n<p class="link-more"><a href="https://test.frontity.org/2018/block-button/" class="more-link">Continue reading<span class="screen-reader-text"> &#8220;Block: Button&#8221;</span></a></p>\n',
     protected: false,
   },
   author: 6,
@@ -116,57 +116,57 @@ const post: PostEntity = {
   _links: {
     self: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/posts/1798",
+        href: "https://test.frontity.org/wp-json/wp/v2/posts/1798",
       },
     ],
     collection: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/posts",
+        href: "https://test.frontity.org/wp-json/wp/v2/posts",
       },
     ],
     about: [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/types/post",
+        href: "https://test.frontity.org/wp-json/wp/v2/types/post",
       },
     ],
     author: [
       {
         embeddable: true,
-        href: "https://test.frontity.io/wp-json/wp/v2/users/6",
+        href: "https://test.frontity.org/wp-json/wp/v2/users/6",
       },
     ],
     replies: [
       {
         embeddable: true,
-        href: "https://test.frontity.io/wp-json/wp/v2/comments?post=1798",
+        href: "https://test.frontity.org/wp-json/wp/v2/comments?post=1798",
       },
     ],
     "version-history": [
       {
         count: 0,
-        href: "https://test.frontity.io/wp-json/wp/v2/posts/1798/revisions",
+        href: "https://test.frontity.org/wp-json/wp/v2/posts/1798/revisions",
       },
     ],
     "wp:attachment": [
       {
-        href: "https://test.frontity.io/wp-json/wp/v2/media?parent=1798",
+        href: "https://test.frontity.org/wp-json/wp/v2/media?parent=1798",
       },
     ],
     "wp:term": [
       {
         taxonomy: "category",
         embeddable: true,
-        href: "https://test.frontity.io/wp-json/wp/v2/categories?post=1798",
+        href: "https://test.frontity.org/wp-json/wp/v2/categories?post=1798",
       },
       {
         taxonomy: "post_tag",
         embeddable: true,
-        href: "https://test.frontity.io/wp-json/wp/v2/tags?post=1798",
+        href: "https://test.frontity.org/wp-json/wp/v2/tags?post=1798",
       },
       {
         taxonomy: "latest",
         embeddable: true,
-        href: "https://test.frontity.io/wp-json/wp/v2/latest?post=1798",
+        href: "https://test.frontity.org/wp-json/wp/v2/latest?post=1798",
       },
     ],
     curies: [
@@ -186,7 +186,7 @@ const attachment: AttachmentEntity = {
   date_gmt: "2018-11-23T12:27:38",
   guid: {
     rendered:
-      "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg",
+      "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg",
   },
   modified: "2018-11-23T14:27:38",
   modified_gmt: "2018-11-23T12:27:38",
@@ -194,7 +194,7 @@ const attachment: AttachmentEntity = {
   status: "inherit",
   type: "attachment",
   link:
-    "https://test.frontity.io/web3_baby_boy_smile_hat_shutterstock_476144548/",
+    "https://test.frontity.org/web3_baby_boy_smile_hat_shutterstock_476144548/",
   title: {
     rendered: "web3_baby_boy_smile_hat_shutterstock_476144548",
   },
@@ -205,7 +205,7 @@ const attachment: AttachmentEntity = {
   meta: [],
   description: {
     rendered:
-      '<p class="attachment"><a href=\'https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg\'><img data-attachment-id="0" data-attachment-id-source="attachment-link-hook"width="300" height="150" src="https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-300x150.jpg" class="attachment-medium size-medium" alt="" srcset="https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-300x150.jpg 300w, https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-768x384.jpg 768w, https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-1024x512.jpg 1024w, https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg 1200w" sizes="100vw" data-attachment-id="437" data-attachment-id-source="image-attributes-hook" /></a></p>\n',
+      '<p class="attachment"><a href=\'https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg\'><img data-attachment-id="0" data-attachment-id-source="attachment-link-hook"width="300" height="150" src="https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-300x150.jpg" class="attachment-medium size-medium" alt="" srcset="https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-300x150.jpg 300w, https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-768x384.jpg 768w, https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-1024x512.jpg 1024w, https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg 1200w" sizes="100vw" data-attachment-id="437" data-attachment-id-source="image-attributes-hook" /></a></p>\n',
   },
   caption: {
     rendered: "",
@@ -224,7 +224,7 @@ const attachment: AttachmentEntity = {
         height: 150,
         mime_type: "image/jpeg",
         source_url:
-          "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-150x150.jpg",
+          "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-150x150.jpg",
       },
       medium: {
         file: "web3_baby_boy_smile_hat_shutterstock_476144548-300x150.jpg",
@@ -232,7 +232,7 @@ const attachment: AttachmentEntity = {
         height: 150,
         mime_type: "image/jpeg",
         source_url:
-          "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-300x150.jpg",
+          "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-300x150.jpg",
       },
       medium_large: {
         file: "web3_baby_boy_smile_hat_shutterstock_476144548-768x384.jpg",
@@ -240,7 +240,7 @@ const attachment: AttachmentEntity = {
         height: 384,
         mime_type: "image/jpeg",
         source_url:
-          "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-768x384.jpg",
+          "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-768x384.jpg",
       },
       large: {
         file: "web3_baby_boy_smile_hat_shutterstock_476144548-1024x512.jpg",
@@ -248,7 +248,7 @@ const attachment: AttachmentEntity = {
         height: 512,
         mime_type: "image/jpeg",
         source_url:
-          "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-1024x512.jpg",
+          "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-1024x512.jpg",
       },
       "twentyseventeen-thumbnail-avatar": {
         file: "web3_baby_boy_smile_hat_shutterstock_476144548-100x100.jpg",
@@ -256,7 +256,7 @@ const attachment: AttachmentEntity = {
         height: 100,
         mime_type: "image/jpeg",
         source_url:
-          "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-100x100.jpg",
+          "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548-100x100.jpg",
       },
       full: {
         file: "web3_baby_boy_smile_hat_shutterstock_476144548.jpg",
@@ -264,7 +264,7 @@ const attachment: AttachmentEntity = {
         height: 600,
         mime_type: "image/jpeg",
         source_url:
-          "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg",
+          "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg",
       },
     },
     image_meta: {
@@ -284,24 +284,24 @@ const attachment: AttachmentEntity = {
   },
   post: null,
   source_url:
-    "https://test.frontity.io/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg",
+    "https://test.frontity.org/wp-content/uploads/2018/11/web3_baby_boy_smile_hat_shutterstock_476144548.jpg",
   _links: {
     self: [
       {
         attributes: [],
-        href: "https://test.frontity.io/wp-json/wp/v2/media/437",
+        href: "https://test.frontity.org/wp-json/wp/v2/media/437",
       },
     ],
     collection: [
       {
         attributes: [],
-        href: "https://test.frontity.io/wp-json/wp/v2/media",
+        href: "https://test.frontity.org/wp-json/wp/v2/media",
       },
     ],
     about: [
       {
         attributes: [],
-        href: "https://test.frontity.io/wp-json/wp/v2/types/attachment",
+        href: "https://test.frontity.org/wp-json/wp/v2/types/attachment",
       },
     ],
     author: [
@@ -309,7 +309,7 @@ const attachment: AttachmentEntity = {
         attributes: {
           embeddable: true,
         },
-        href: "https://test.frontity.io/wp-json/wp/v2/users/2",
+        href: "https://test.frontity.org/wp-json/wp/v2/users/2",
       },
     ],
     replies: [
@@ -317,7 +317,7 @@ const attachment: AttachmentEntity = {
         attributes: {
           embeddable: true,
         },
-        href: "https://test.frontity.io/wp-json/wp/v2/comments?post=437",
+        href: "https://test.frontity.org/wp-json/wp/v2/comments?post=437",
       },
     ],
     "wp:term": [
@@ -326,12 +326,12 @@ const attachment: AttachmentEntity = {
           taxonomy: "latest",
           embeddable: true,
         },
-        href: "https://test.frontity.io/wp-json/wp/v2/latest?attachment=437",
+        href: "https://test.frontity.org/wp-json/wp/v2/latest?attachment=437",
       },
       {
         taxonomy: "latest",
         embeddable: true,
-        href: "https://test.frontity.io/wp-json/wp/v2/latest?attachment=437",
+        href: "https://test.frontity.org/wp-json/wp/v2/latest?attachment=437",
       },
     ],
     curies: [
@@ -354,12 +354,12 @@ const taxonomyType: TaxonomyType = {
   _links: {
     collection: [
       {
-        href: "http://test.frontity.io/wp-json/wp/v2/types",
+        href: "http://test.frontity.org/wp-json/wp/v2/types",
       },
     ],
     "wp:items": [
       {
-        href: "http://test.frontity.io/wp-json/wp/v2/posts",
+        href: "http://test.frontity.org/wp-json/wp/v2/posts",
       },
     ],
     curies: [
@@ -382,12 +382,12 @@ const postType: PostType = {
   _links: {
     collection: [
       {
-        href: "http://test.frontity.io/wp-json/wp/v2/types",
+        href: "http://test.frontity.org/wp-json/wp/v2/types",
       },
     ],
     "wp:items": [
       {
-        href: "http://test.frontity.io/wp-json/wp/v2/posts",
+        href: "http://test.frontity.org/wp-json/wp/v2/posts",
       },
     ],
     curies: [

--- a/packages/wp-source/src/__tests__/actions.tests.ts
+++ b/packages/wp-source/src/__tests__/actions.tests.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
 
   // Initialize the store
   store = createStore(clone(wpSource()));
-  store.state.source.api = "https://test.frontity.io/wp-json";
+  store.state.source.api = "https://test.frontity.org/wp-json";
 
   // Add mock handler to the store
   store.libraries.source.handlers.push(handler);

--- a/packages/wp-source/src/libraries/__tests__/__snapshots__/populate.tests.ts.snap
+++ b/packages/wp-source/src/libraries/__tests__/__snapshots__/populate.tests.ts.snap
@@ -404,7 +404,7 @@ Array [
 
 exports[`populate removes WP API path from links 2`] = `
 Object {
-  "api": "https://test.frontity.io/subdirectory/wp-json",
+  "api": "https://test.frontity.org/subdirectory/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -613,7 +613,7 @@ Array [
 
 exports[`populate transforms links if subdirectory is specified 2`] = `
 Object {
-  "api": "https://test.frontity.io/subdirectory/wp-json",
+  "api": "https://test.frontity.org/subdirectory/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,

--- a/packages/wp-source/src/libraries/__tests__/populate.tests.ts
+++ b/packages/wp-source/src/libraries/__tests__/populate.tests.ts
@@ -38,7 +38,7 @@ describe("populate", () => {
         {
           id: 1,
           count: 5,
-          link: "https://test.frontity.io/category/cat-1/",
+          link: "https://test.frontity.org/category/cat-1/",
           slug: "cat-1",
           taxonomy: "category",
           description: "This is the Category 1",
@@ -52,7 +52,7 @@ describe("populate", () => {
       state,
       response: mockResponse({
         id: 1,
-        link: "https://test.frontity.io/category/cat-1/",
+        link: "https://test.frontity.org/category/cat-1/",
         slug: "cat-1",
         taxonomy: "category",
       }),
@@ -71,7 +71,7 @@ describe("populate", () => {
       response: mockResponse([
         {
           id: 1,
-          link: "https://test.frontity.io/category/cat-1/",
+          link: "https://test.frontity.org/category/cat-1/",
           slug: "cat-1",
           taxonomy: "category",
         },
@@ -84,7 +84,7 @@ describe("populate", () => {
       response: mockResponse({
         id: 1,
         count: 5,
-        link: "https://test.frontity.io/category/cat-1/",
+        link: "https://test.frontity.org/category/cat-1/",
         slug: "cat-1",
         taxonomy: "category",
         description: "This is the Category 1",
@@ -99,7 +99,7 @@ describe("populate", () => {
 
   test("removes WP API path from links", async () => {
     const { state } = initStore();
-    state.source.api = "https://test.frontity.io/subdirectory/wp-json";
+    state.source.api = "https://test.frontity.org/subdirectory/wp-json";
 
     const response = mockResponse(postsSubdir);
     const result = await populate({ state, response });
@@ -110,7 +110,7 @@ describe("populate", () => {
 
   test("transforms links if subdirectory is specified", async () => {
     const { state } = initStore();
-    state.source.api = "https://test.frontity.io/subdirectory/wp-json";
+    state.source.api = "https://test.frontity.org/subdirectory/wp-json";
 
     const response = mockResponse(postsSubdir);
     const subdirectory = "/blog/";

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/author.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/author.tests.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`author doesn't exist in source.author 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -181,7 +181,7 @@ Object {
 
 exports[`author doesn't return 404 if the first page is empty (no headers) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {
     "1": Object {
@@ -230,7 +230,7 @@ Object {
 
 exports[`author doesn't return 404 if the first page is empty 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {
     "1": Object {
@@ -307,7 +307,7 @@ Array [
 
 exports[`author fetchs from a different endpoint with extra params 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -493,7 +493,7 @@ Object {
 
 exports[`author is requested with a search param 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -681,7 +681,7 @@ Object {
 
 exports[`author is requested with any query param 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -867,7 +867,7 @@ Object {
 
 exports[`author returns 404 if author doesn't exist in WP 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -903,7 +903,7 @@ Object {
 
 exports[`author returns 404 if the page fetched is out of range 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {
     "1": Object {
@@ -951,7 +951,7 @@ Object {
 
 exports[`author was populated but not accessed 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "4": Object {
       "author": 1,

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/category.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/category.tests.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`category doesn't exist in source.category 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -218,7 +218,7 @@ Object {
 
 exports[`category doesn't return 404 if the first page is empty (no headers) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -271,7 +271,7 @@ Object {
 
 exports[`category doesn't return 404 if the first page is empty 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -352,7 +352,7 @@ Array [
 
 exports[`category fetchs from a different endpoint with extra params 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -575,7 +575,7 @@ Object {
 
 exports[`category is requested with any query param 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -799,7 +799,7 @@ Object {
 
 exports[`category returns 404 if category doesn't exist in WP 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -835,7 +835,7 @@ Object {
 
 exports[`category returns 404 if the page fetched is out of range 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -886,7 +886,7 @@ Object {
 
 exports[`category was populated but not accessed 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "4": Object {
       "author": 1,

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/date.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/date.tests.ts.snap
@@ -23,7 +23,7 @@ Array [
 
 exports[`date fetchs from a different endpoint with extra params 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -219,7 +219,7 @@ Array [
 
 exports[`date get January 1, 2019 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -359,7 +359,7 @@ Array [
 
 exports[`date get January, 2019 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -559,7 +559,7 @@ Array [
 
 exports[`date get two pages of year 2019 (with query params) 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -926,7 +926,7 @@ Array [
 
 exports[`date get two pages of year 2019 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -1277,7 +1277,7 @@ Array [
 
 exports[`date returns 404 if the page fetched is empty 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-archive.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-archive.tests.ts.snap
@@ -21,7 +21,7 @@ Array [
 
 exports[`post archive fetchs from a different endpoint with extra params 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -250,7 +250,7 @@ Object {
 
 exports[`post archive works with first page 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -472,7 +472,7 @@ Object {
 
 exports[`post archive works with pagination 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "4": Object {
       "author": 1,
@@ -645,7 +645,7 @@ Object {
 
 exports[`post archive works with query params 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -869,7 +869,7 @@ Object {
 
 exports[`post archive works with query params and pagination 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "4": Object {
       "author": 1,

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`attachment doesn't exist in source.attachment 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -50,7 +50,7 @@ Object {
 
 exports[`attachment exists in source.attachment 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -96,7 +96,7 @@ Object {
 
 exports[`attachment works with query params (doesn't exist in source.attachment) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -152,7 +152,7 @@ Object {
 
 exports[`attachment works with query params (exists in source.attachment) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -208,7 +208,7 @@ Object {
 
 exports[`page doesn't exist in source.page 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {
     "1": Object {
@@ -274,7 +274,7 @@ Object {
 
 exports[`page exists in source.page 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {
     "1": Object {
@@ -338,7 +338,7 @@ Object {
 
 exports[`page works with query params (doesn't exist in source.page) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {
     "1": Object {
@@ -412,7 +412,7 @@ Object {
 
 exports[`page works with query params (exists in source.page) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {
     "1": Object {
@@ -486,7 +486,7 @@ Object {
 
 exports[`post doesn't exist in source.post 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -598,7 +598,7 @@ Object {
 
 exports[`post exists in source.post 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -726,7 +726,7 @@ Array [
 
 exports[`post fetchs from a different endpoint with extra params 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "12": Object {
       "author": 1,
@@ -844,7 +844,7 @@ Object {
 
 exports[`post works with query params (doesn't exist in source.post) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -964,7 +964,7 @@ Object {
 
 exports[`post works with query params (exists in source.post) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -1084,7 +1084,7 @@ Object {
 
 exports[`post works with types embedded 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -1214,7 +1214,7 @@ Object {
 
 exports[`postType returns 404 if not found 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -1250,7 +1250,7 @@ Object {
 
 exports[`postType should contain the correct error code on error 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/tag.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/tag.tests.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`tag doesn't exist in source.tag 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -218,7 +218,7 @@ Object {
 
 exports[`tag doesn't return 404 if the first page is empty (no headers) 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -271,7 +271,7 @@ Object {
 
 exports[`tag doesn't return 404 if the first page is empty 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -352,7 +352,7 @@ Array [
 
 exports[`tag fetchs from a different endpoint with extra params 2`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -575,7 +575,7 @@ Object {
 
 exports[`tag is requested with any query param 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "1": Object {
       "author": 1,
@@ -799,7 +799,7 @@ Object {
 
 exports[`tag returns 404 if tag doesn't exist in WP 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -835,7 +835,7 @@ Object {
 
 exports[`tag returns 404 if the page fetched is out of range 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {},
   "author": Object {},
   "authorBase": "",
@@ -886,7 +886,7 @@ Object {
 
 exports[`tag was populated but not accessed 1`] = `
 Object {
-  "api": "https://test.frontity.io/wp-json",
+  "api": "https://test.frontity.org/wp-json",
   "attachment": Object {
     "4": Object {
       "author": 1,

--- a/packages/wp-source/src/libraries/handlers/__tests__/author.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/author.tests.ts
@@ -14,7 +14,7 @@ let store: InitializedStore<WpSource>;
 let api: jest.Mocked<Api>;
 beforeEach(() => {
   store = createStore(clone(wpSource()));
-  store.state.source.api = "https://test.frontity.io/wp-json";
+  store.state.source.api = "https://test.frontity.org/wp-json";
   store.actions.source.init();
   api = store.libraries.source.api as jest.Mocked<Api>;
 });

--- a/packages/wp-source/src/libraries/handlers/__tests__/category.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/category.tests.ts
@@ -14,7 +14,7 @@ let store: InitializedStore<WpSource>;
 let api: jest.Mocked<Api>;
 beforeEach(() => {
   store = createStore(clone(wpSource()));
-  store.state.source.api = "https://test.frontity.io/wp-json";
+  store.state.source.api = "https://test.frontity.org/wp-json";
   store.actions.source.init();
   api = store.libraries.source.api as jest.Mocked<Api>;
 });

--- a/packages/wp-source/src/libraries/handlers/__tests__/date.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/date.tests.ts
@@ -15,7 +15,7 @@ let store: InitializedStore<WpSource>;
 let api: jest.Mocked<Api>;
 beforeEach(() => {
   store = createStore(clone(wpSource()));
-  store.state.source.api = "https://test.frontity.io/wp-json";
+  store.state.source.api = "https://test.frontity.org/wp-json";
   store.actions.source.init();
   api = store.libraries.source.api as jest.Mocked<Api>;
 });

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1-posts-cpt.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1-posts-cpt.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ]
@@ -32,7 +32,7 @@
     "id": 11,
     "slug": "cpt-11",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-11/",
+    "link": "https://test.frontity.org/cpt/cpt-11/",
     "author": 1,
     "featured_media": 12,
     "categories": [],
@@ -42,7 +42,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -51,7 +51,7 @@
           "id": 12,
           "slug": "attachment-cpt-11",
           "type": "attachment",
-          "link": "https://test.frontity.io/cpt/cpt-11/attachment-cpt-11/",
+          "link": "https://test.frontity.org/cpt/cpt-11/attachment-cpt-11/",
           "author": 1
         }
       ]
@@ -61,7 +61,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [],
@@ -71,7 +71,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -80,7 +80,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ]

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1-posts-page-2.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1-posts-page-2.json
@@ -3,7 +3,7 @@
     "id": 4,
     "slug": "post-4",
     "type": "post",
-    "link": "https://test.frontity.io/post-4/",
+    "link": "https://test.frontity.org/post-4/",
     "author": 1,
     "featured_media": 4,
     "categories": [],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 4,
           "slug": "attachment-4",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-4/attachment-4/",
+          "link": "https://test.frontity.org/post-4/attachment-4/",
           "author": 1
         }
       ]
@@ -32,7 +32,7 @@
     "id": 5,
     "slug": "post-5",
     "type": "post",
-    "link": "https://test.frontity.io/post-5/",
+    "link": "https://test.frontity.org/post-5/",
     "author": 1,
     "featured_media": 5,
     "categories": [],
@@ -42,7 +42,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -51,7 +51,7 @@
           "id": 5,
           "slug": "attachment-5",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-5/attachment-5/",
+          "link": "https://test.frontity.org/post-5/attachment-5/",
           "author": 1
         }
       ]

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1-posts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1-posts.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ]
@@ -32,7 +32,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [],
@@ -42,7 +42,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -51,7 +51,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ]
@@ -61,7 +61,7 @@
     "id": 3,
     "slug": "post-3",
     "type": "post",
-    "link": "https://test.frontity.io/post-3/",
+    "link": "https://test.frontity.org/post-3/",
     "author": 1,
     "featured_media": 3,
     "categories": [],
@@ -71,7 +71,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -80,7 +80,7 @@
           "id": 3,
           "slug": "attachment-3",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-3/attachment-3/",
+          "link": "https://test.frontity.org/post-3/attachment-3/",
           "author": 1
         }
       ]

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/author/author-1.json
@@ -1,6 +1,6 @@
 {
   "id": 1,
   "name": "Author 1",
-  "link": "https://test.frontity.io/author/author-1/",
+  "link": "https://test.frontity.org/author/author-1/",
   "slug": "author-1"
 }

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1-posts-cpt.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1-posts-cpt.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 11,
     "slug": "cpt-11",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-11/",
+    "link": "https://test.frontity.org/cpt/cpt-11/",
     "author": 1,
     "featured_media": 12,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 12,
           "slug": "attachment-cpt-11",
           "type": "attachment",
-          "link": "https://test.frontity.io/cpt/cpt-11/attachment-cpt-11/",
+          "link": "https://test.frontity.org/cpt/cpt-11/attachment-cpt-11/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [1],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1-posts-page-2.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1-posts-page-2.json
@@ -3,7 +3,7 @@
     "id": 4,
     "slug": "post-4",
     "type": "post",
-    "link": "https://test.frontity.io/post-4/",
+    "link": "https://test.frontity.org/post-4/",
     "author": 1,
     "featured_media": 4,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 4,
           "slug": "attachment-4",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-4/attachment-4/",
+          "link": "https://test.frontity.org/post-4/attachment-4/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 5,
     "slug": "post-5",
     "type": "post",
-    "link": "https://test.frontity.io/post-5/",
+    "link": "https://test.frontity.org/post-5/",
     "author": 1,
     "featured_media": 5,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 5,
           "slug": "attachment-5",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-5/attachment-5/",
+          "link": "https://test.frontity.org/post-5/attachment-5/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1-posts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1-posts.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 3,
     "slug": "post-3",
     "type": "post",
-    "link": "https://test.frontity.io/post-3/",
+    "link": "https://test.frontity.org/post-3/",
     "author": 1,
     "featured_media": 3,
     "categories": [1],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 3,
           "slug": "attachment-3",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-3/attachment-3/",
+          "link": "https://test.frontity.org/post-3/attachment-3/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/category/cat-1.json
@@ -1,7 +1,7 @@
 {
   "id": 1,
   "count": 5,
-  "link": "https://test.frontity.io/category/cat-1/",
+  "link": "https://test.frontity.org/category/cat-1/",
   "slug": "cat-1",
   "taxonomy": "category",
   "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/cpt-archive/cpts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/cpt-archive/cpts.json
@@ -3,7 +3,7 @@
     "id": 11,
     "slug": "cpt-11",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-11/",
+    "link": "https://test.frontity.org/cpt/cpt-11/",
     "author": 1,
     "featured_media": 2,
     "custom-taxonomy": [1],
@@ -14,7 +14,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -23,7 +23,7 @@
           "id": 11,
           "slug": "attachment-11",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-11/attachment-11/",
+          "link": "https://test.frontity.org/post-11/attachment-11/",
           "author": 1
         }
       ],
@@ -32,7 +32,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/custom-taxonomy/ct-1/",
+            "link": "https://test.frontity.org/custom-taxonomy/ct-1/",
             "slug": "ct-1",
             "taxonomy": "custom-taxonomy",
             "parent": 0
@@ -45,7 +45,7 @@
     "id": 12,
     "slug": "cpt-12",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-12/",
+    "link": "https://test.frontity.org/cpt/cpt-12/",
     "author": 1,
     "featured_media": 2,
     "custom-taxonomy": [1],
@@ -56,7 +56,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -65,7 +65,7 @@
           "id": 12,
           "slug": "attachment-12",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-12/attachment-12/",
+          "link": "https://test.frontity.org/post-12/attachment-12/",
           "author": 1
         }
       ],
@@ -74,7 +74,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/custom-taxonomy/ct-1/",
+            "link": "https://test.frontity.org/custom-taxonomy/ct-1/",
             "slug": "ct-1",
             "taxonomy": "custom-taxonomy",
             "parent": 0
@@ -87,7 +87,7 @@
     "id": 12,
     "slug": "cpt-12",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-12/",
+    "link": "https://test.frontity.org/cpt/cpt-12/",
     "author": 1,
     "featured_media": 2,
     "custom-taxonomy": [1],
@@ -98,7 +98,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -107,7 +107,7 @@
           "id": 12,
           "slug": "attachment-12",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-12/attachment-12/",
+          "link": "https://test.frontity.org/post-12/attachment-12/",
           "author": 1
         }
       ],
@@ -116,7 +116,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/custom-taxonomy/ct-1/",
+            "link": "https://test.frontity.org/custom-taxonomy/ct-1/",
             "slug": "ct-1",
             "taxonomy": "custom-taxonomy",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-01-01-posts-cpt.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-01-01-posts-cpt.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 11,
     "slug": "cpt-11",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-11/",
+    "link": "https://test.frontity.org/cpt/cpt-11/",
     "author": 1,
     "featured_media": 12,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 12,
           "slug": "attachment-cpt-11",
           "type": "attachment",
-          "link": "https://test.frontity.io/cpt/cpt-11/attachment-cpt-11/",
+          "link": "https://test.frontity.org/cpt/cpt-11/attachment-cpt-11/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-01-01-posts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-01-01-posts.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-01-posts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-01-posts.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-posts-page-2.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-posts-page-2.json
@@ -3,7 +3,7 @@
     "id": 4,
     "slug": "post-4",
     "type": "post",
-    "link": "https://test.frontity.io/post-4/",
+    "link": "https://test.frontity.org/post-4/",
     "author": 1,
     "featured_media": 4,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 4,
           "slug": "attachment-4",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-4/attachment-4/",
+          "link": "https://test.frontity.org/post-4/attachment-4/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 5,
     "slug": "post-5",
     "type": "post",
-    "link": "https://test.frontity.io/post-5/",
+    "link": "https://test.frontity.org/post-5/",
     "author": 1,
     "featured_media": 5,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 5,
           "slug": "attachment-5",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-5/attachment-5/",
+          "link": "https://test.frontity.org/post-5/attachment-5/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-posts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/date/2019-posts.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 3,
     "slug": "post-3",
     "type": "post",
-    "link": "https://test.frontity.io/post-3/",
+    "link": "https://test.frontity.org/post-3/",
     "author": 1,
     "featured_media": 3,
     "categories": [1],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 3,
           "slug": "attachment-3",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-3/attachment-3/",
+          "link": "https://test.frontity.org/post-3/attachment-3/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts-cpt.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts-cpt.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 11,
     "slug": "cpt-11",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-11/",
+    "link": "https://test.frontity.org/cpt/cpt-11/",
     "author": 1,
     "featured_media": 12,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 12,
           "slug": "attachment-cpt-11",
           "type": "attachment",
-          "link": "https://test.frontity.io/cpt/cpt-11/attachment-cpt-11/",
+          "link": "https://test.frontity.org/cpt/cpt-11/attachment-cpt-11/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [1],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts-page-2.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts-page-2.json
@@ -3,7 +3,7 @@
     "id": 4,
     "slug": "post-4",
     "type": "post",
-    "link": "https://test.frontity.io/post-4/",
+    "link": "https://test.frontity.org/post-4/",
     "author": 1,
     "featured_media": 4,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 4,
           "slug": "attachment-4",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-4/attachment-4/",
+          "link": "https://test.frontity.org/post-4/attachment-4/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 5,
     "slug": "post-5",
     "type": "post",
-    "link": "https://test.frontity.io/post-5/",
+    "link": "https://test.frontity.org/post-5/",
     "author": 1,
     "featured_media": 5,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 5,
           "slug": "attachment-5",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-5/attachment-5/",
+          "link": "https://test.frontity.org/post-5/attachment-5/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts-subdir.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts-subdir.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/subdirectory/post-1/",
+    "link": "https://test.frontity.org/subdirectory/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/subdirectory/author/author-1/",
+          "link": "https://test.frontity.org/subdirectory/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/subdirectory/post-1/attachment-1/",
+          "link": "https://test.frontity.org/subdirectory/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/subdirectory/category/cat-1/",
+            "link": "https://test.frontity.org/subdirectory/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/subdirectory/post-2/",
+    "link": "https://test.frontity.org/subdirectory/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/subdirectory/author/author-1/",
+          "link": "https://test.frontity.org/subdirectory/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/subdirectory/post-2/attachment-2/",
+          "link": "https://test.frontity.org/subdirectory/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/subdirectory/category/cat-1/",
+            "link": "https://test.frontity.org/subdirectory/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 3,
     "slug": "post-3",
     "type": "post",
-    "link": "https://test.frontity.io/subdirectory/post-3/",
+    "link": "https://test.frontity.org/subdirectory/post-3/",
     "author": 1,
     "featured_media": 3,
     "categories": [1],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/subdirectory/author/author-1/",
+          "link": "https://test.frontity.org/subdirectory/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 3,
           "slug": "attachment-3",
           "type": "attachment",
-          "link": "https://test.frontity.io/subdirectory/post-3/attachment-3/",
+          "link": "https://test.frontity.org/subdirectory/post-3/attachment-3/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/subdirectory/category/cat-1/",
+            "link": "https://test.frontity.org/subdirectory/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-archive/posts.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [1],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [1],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 3,
     "slug": "post-3",
     "type": "post",
-    "link": "https://test.frontity.io/post-3/",
+    "link": "https://test.frontity.org/post-3/",
     "author": 1,
     "featured_media": 3,
     "categories": [1],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 3,
           "slug": "attachment-3",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-3/attachment-3/",
+          "link": "https://test.frontity.org/post-3/attachment-3/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/category/cat-1/",
+            "link": "https://test.frontity.org/category/cat-1/",
             "slug": "cat-1",
             "taxonomy": "category",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/attachment-1.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/attachment-1.json
@@ -2,6 +2,6 @@
   "id": 1,
   "slug": "attachment-1",
   "type": "attachment",
-  "link": "https://test.frontity.io/post-1/attachment-1/",
+  "link": "https://test.frontity.org/post-1/attachment-1/",
   "author": 1
 }

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/cpt-11.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/cpt-11.json
@@ -2,7 +2,7 @@
   "id": 11,
   "slug": "cpt-11",
   "type": "cpt",
-  "link": "https://test.frontity.io/cpt/cpt-11/",
+  "link": "https://test.frontity.org/cpt/cpt-11/",
   "author": 1,
   "featured_media": 12,
   "categories": [1],
@@ -12,7 +12,7 @@
       {
         "id": 1,
         "name": "Author 1",
-        "link": "https://test.frontity.io/author/author-1/",
+        "link": "https://test.frontity.org/author/author-1/",
         "slug": "author-1"
       }
     ],
@@ -21,7 +21,7 @@
         "id": 12,
         "slug": "attachment-cpt-11",
         "type": "attachment",
-        "link": "https://test.frontity.io/cpt/cpt-11/attachment-cpt-11/",
+        "link": "https://test.frontity.org/cpt/cpt-11/attachment-cpt-11/",
         "author": 1
       }
     ],
@@ -30,7 +30,7 @@
         {
           "id": 1,
           "count": 5,
-          "link": "https://test.frontity.io/category/cat-1/",
+          "link": "https://test.frontity.org/category/cat-1/",
           "slug": "cat-1",
           "taxonomy": "category",
           "parent": 0
@@ -40,7 +40,7 @@
         {
           "id": 1,
           "count": 5,
-          "link": "https://test.frontity.io/tag/tag-1/",
+          "link": "https://test.frontity.org/tag/tag-1/",
           "slug": "tag-1",
           "taxonomy": "tag",
           "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/page-1.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/page-1.json
@@ -2,7 +2,7 @@
   "id": 1,
   "slug": "page-1",
   "type": "page",
-  "link": "https://test.frontity.io/page-1/",
+  "link": "https://test.frontity.org/page-1/",
   "author": 1,
   "featured_media": 1,
   "_embedded": {
@@ -10,7 +10,7 @@
       {
         "id": 1,
         "name": "Author 1",
-        "link": "https://test.frontity.io/author/author-1/",
+        "link": "https://test.frontity.org/author/author-1/",
         "slug": "author-1"
       }
     ]

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/post-1-with-type.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/post-1-with-type.json
@@ -2,7 +2,7 @@
   "id": 1,
   "slug": "post-1",
   "type": "post",
-  "link": "https://test.frontity.io/post-1/",
+  "link": "https://test.frontity.org/post-1/",
   "author": 1,
   "featured_media": 1,
   "categories": [1],
@@ -12,7 +12,7 @@
       {
         "id": 1,
         "name": "Author 1",
-        "link": "https://test.frontity.io/author/author-1/",
+        "link": "https://test.frontity.org/author/author-1/",
         "slug": "author-1"
       }
     ],
@@ -21,7 +21,7 @@
         "id": 1,
         "slug": "attachment-1",
         "type": "attachment",
-        "link": "https://test.frontity.io/post-1/attachment-1/",
+        "link": "https://test.frontity.org/post-1/attachment-1/",
         "author": 1
       }
     ],
@@ -30,7 +30,7 @@
         {
           "id": 1,
           "count": 5,
-          "link": "https://test.frontity.io/category/cat-1/",
+          "link": "https://test.frontity.org/category/cat-1/",
           "slug": "cat-1",
           "taxonomy": "category",
           "parent": 0
@@ -40,7 +40,7 @@
         {
           "id": 1,
           "count": 5,
-          "link": "https://test.frontity.io/tag/tag-1/",
+          "link": "https://test.frontity.org/tag/tag-1/",
           "slug": "tag-1",
           "taxonomy": "tag",
           "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/post-1.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/post-1.json
@@ -2,7 +2,7 @@
   "id": 1,
   "slug": "post-1",
   "type": "post",
-  "link": "https://test.frontity.io/post-1/",
+  "link": "https://test.frontity.org/post-1/",
   "author": 1,
   "featured_media": 1,
   "categories": [1],
@@ -12,7 +12,7 @@
       {
         "id": 1,
         "name": "Author 1",
-        "link": "https://test.frontity.io/author/author-1/",
+        "link": "https://test.frontity.org/author/author-1/",
         "slug": "author-1"
       }
     ],
@@ -21,7 +21,7 @@
         "id": 1,
         "slug": "attachment-1",
         "type": "attachment",
-        "link": "https://test.frontity.io/post-1/attachment-1/",
+        "link": "https://test.frontity.org/post-1/attachment-1/",
         "author": 1
       }
     ],
@@ -30,7 +30,7 @@
         {
           "id": 1,
           "count": 5,
-          "link": "https://test.frontity.io/category/cat-1/",
+          "link": "https://test.frontity.org/category/cat-1/",
           "slug": "cat-1",
           "taxonomy": "category",
           "parent": 0
@@ -40,7 +40,7 @@
         {
           "id": 1,
           "count": 5,
-          "link": "https://test.frontity.io/tag/tag-1/",
+          "link": "https://test.frontity.org/tag/tag-1/",
           "slug": "tag-1",
           "taxonomy": "tag",
           "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1-posts-cpt.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1-posts-cpt.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 11,
     "slug": "cpt-11",
     "type": "cpt",
-    "link": "https://test.frontity.io/cpt/cpt-11/",
+    "link": "https://test.frontity.org/cpt/cpt-11/",
     "author": 1,
     "featured_media": 12,
     "categories": [],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 12,
           "slug": "attachment-cpt-11",
           "type": "attachment",
-          "link": "https://test.frontity.io/cpt/cpt-11/attachment-cpt-11/",
+          "link": "https://test.frontity.org/cpt/cpt-11/attachment-cpt-11/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1-posts-page-2.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1-posts-page-2.json
@@ -3,7 +3,7 @@
     "id": 4,
     "slug": "post-4",
     "type": "post",
-    "link": "https://test.frontity.io/post-4/",
+    "link": "https://test.frontity.org/post-4/",
     "author": 1,
     "featured_media": 4,
     "categories": [],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 4,
           "slug": "attachment-4",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-4/attachment-4/",
+          "link": "https://test.frontity.org/post-4/attachment-4/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 5,
     "slug": "post-5",
     "type": "post",
-    "link": "https://test.frontity.io/post-5/",
+    "link": "https://test.frontity.org/post-5/",
     "author": 1,
     "featured_media": 5,
     "categories": [],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 5,
           "slug": "attachment-5",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-5/attachment-5/",
+          "link": "https://test.frontity.org/post-5/attachment-5/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1-posts.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1-posts.json
@@ -3,7 +3,7 @@
     "id": 1,
     "slug": "post-1",
     "type": "post",
-    "link": "https://test.frontity.io/post-1/",
+    "link": "https://test.frontity.org/post-1/",
     "author": 1,
     "featured_media": 1,
     "categories": [],
@@ -13,7 +13,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -22,7 +22,7 @@
           "id": 1,
           "slug": "attachment-1",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-1/attachment-1/",
+          "link": "https://test.frontity.org/post-1/attachment-1/",
           "author": 1
         }
       ],
@@ -31,7 +31,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0
@@ -44,7 +44,7 @@
     "id": 2,
     "slug": "post-2",
     "type": "post",
-    "link": "https://test.frontity.io/post-2/",
+    "link": "https://test.frontity.org/post-2/",
     "author": 1,
     "featured_media": 2,
     "categories": [],
@@ -54,7 +54,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -63,7 +63,7 @@
           "id": 2,
           "slug": "attachment-2",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-2/attachment-2/",
+          "link": "https://test.frontity.org/post-2/attachment-2/",
           "author": 1
         }
       ],
@@ -72,7 +72,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0
@@ -85,7 +85,7 @@
     "id": 3,
     "slug": "post-3",
     "type": "post",
-    "link": "https://test.frontity.io/post-3/",
+    "link": "https://test.frontity.org/post-3/",
     "author": 1,
     "featured_media": 3,
     "categories": [],
@@ -95,7 +95,7 @@
         {
           "id": 1,
           "name": "Author 1",
-          "link": "https://test.frontity.io/author/author-1/",
+          "link": "https://test.frontity.org/author/author-1/",
           "slug": "author-1"
         }
       ],
@@ -104,7 +104,7 @@
           "id": 3,
           "slug": "attachment-3",
           "type": "attachment",
-          "link": "https://test.frontity.io/post-3/attachment-3/",
+          "link": "https://test.frontity.org/post-3/attachment-3/",
           "author": 1
         }
       ],
@@ -113,7 +113,7 @@
           {
             "id": 1,
             "count": 5,
-            "link": "https://test.frontity.io/tag/tag-1/",
+            "link": "https://test.frontity.org/tag/tag-1/",
             "slug": "tag-1",
             "taxonomy": "post_tag",
             "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/tag/tag-1.json
@@ -1,7 +1,7 @@
 {
   "id": 1,
   "count": 5,
-  "link": "https://test.frontity.io/tag/tag-1/",
+  "link": "https://test.frontity.org/tag/tag-1/",
   "slug": "tag-1",
   "taxonomy": "post_tag",
   "parent": 0

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-archive.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-archive.tests.ts
@@ -13,7 +13,7 @@ let store: InitializedStore<WpSource>;
 let api: jest.Mocked<Api>;
 beforeEach(() => {
   store = createStore(clone(wpSource()));
-  store.state.source.api = "https://test.frontity.io/wp-json";
+  store.state.source.api = "https://test.frontity.org/wp-json";
   store.actions.source.init();
   api = store.libraries.source.api as jest.Mocked<Api>;
 });

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -16,7 +16,7 @@ let store: InitializedStore<WpSource>;
 let api: jest.Mocked<Api>;
 beforeEach(() => {
   store = createStore(clone(wpSource()));
-  store.state.source.api = "https://test.frontity.io/wp-json";
+  store.state.source.api = "https://test.frontity.org/wp-json";
   store.actions.source.init();
   api = store.libraries.source.api as jest.Mocked<Api>;
 });

--- a/packages/wp-source/src/libraries/handlers/__tests__/tag.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/tag.tests.ts
@@ -14,7 +14,7 @@ let store: InitializedStore<WpSource>;
 let api: jest.Mocked<Api>;
 beforeEach(() => {
   store = createStore(clone(wpSource()));
-  store.state.source.api = "https://test.frontity.io/wp-json";
+  store.state.source.api = "https://test.frontity.org/wp-json";
   store.actions.source.init();
   api = store.libraries.source.api as jest.Mocked<Api>;
 });

--- a/packages/wp-source/src/libraries/schemas/__tests__/__snapshots__/entity.tests.ts.snap
+++ b/packages/wp-source/src/libraries/schemas/__tests__/__snapshots__/entity.tests.ts.snap
@@ -297,7 +297,7 @@ Object {
   "_links": Object {
     "collection": Array [
       Object {
-        "href": "http://test.frontity.io/wp-json/wp/v2/types",
+        "href": "http://test.frontity.org/wp-json/wp/v2/types",
       },
     ],
     "curies": Array [
@@ -309,7 +309,7 @@ Object {
     ],
     "wp:items": Array [
       Object {
-        "href": "http://test.frontity.io/wp-json/wp/v2/posts",
+        "href": "http://test.frontity.org/wp-json/wp/v2/posts",
       },
     ],
   },

--- a/packages/wp-source/src/libraries/schemas/__tests__/mocks/post-type.json
+++ b/packages/wp-source/src/libraries/schemas/__tests__/mocks/post-type.json
@@ -8,12 +8,12 @@
   "_links": {
     "collection": [
       {
-        "href": "http://test.frontity.io/wp-json/wp/v2/types"
+        "href": "http://test.frontity.org/wp-json/wp/v2/types"
       }
     ],
     "wp:items": [
       {
-        "href": "http://test.frontity.io/wp-json/wp/v2/posts"
+        "href": "http://test.frontity.org/wp-json/wp/v2/posts"
       }
     ],
     "curies": [


### PR DESCRIPTION
**What**:

Change the urls to point to `test.frontity.org` instead of `test.frontity.io`.

**Why**:

We have moved our content from `test.frontity.io` to `test.frontity.org`, so I guess it's a good idea to modify the urls to the new domain.

**How**:

Search & Replace :slightly_smiling_face: 
