### PR TITLE
Html2react: Add support for processing script type=module

### DIFF
--- a/.changeset/lemon-pugs-retire.md
+++ b/.changeset/lemon-pugs-retire.md
@@ -1,0 +1,5 @@
+---
+"@frontity/html2react": patch
+---
+
+Add support for processing `<script>` tags with `type=module`.

--- a/packages/html2react/processors/__tests__/__snapshots__/script.test.tsx.snap
+++ b/packages/html2react/processors/__tests__/__snapshots__/script.test.tsx.snap
@@ -25,6 +25,15 @@ exports[`Script processor should process a script with src 1`] = `
 </div>
 `;
 
+exports[`Script processor should process a script with type=module  1`] = `
+<div>
+  <mocked-script
+    code="const some=\\"code\\";"
+    type="module"
+  />
+</div>
+`;
+
 exports[`Script processor should process scripts with a valid type 1`] = `
 <div>
   <mocked-script

--- a/packages/html2react/processors/__tests__/script.test.tsx
+++ b/packages/html2react/processors/__tests__/script.test.tsx
@@ -50,7 +50,7 @@ describe("Script processor", () => {
   it("should process a script with type=module ", () => {
     const { container } = render(
       <Html2React
-        html={'<script type="module">const some = "code";</script>'}
+        html={'<script type="module">const some="code";</script>'}
         {...store}
       />
     );

--- a/packages/html2react/processors/__tests__/script.test.tsx
+++ b/packages/html2react/processors/__tests__/script.test.tsx
@@ -46,4 +46,14 @@ describe("Script processor", () => {
     );
     expect(container).toMatchSnapshot();
   });
+
+  it("should process a script with type=module ", () => {
+    const { container } = render(
+      <Html2React
+        html={'<script type="module">const some = "code";</script>'}
+        {...store}
+      />
+    );
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/packages/html2react/processors/script.tsx
+++ b/packages/html2react/processors/script.tsx
@@ -15,6 +15,7 @@ const validMediaTypes = [
   "application/javascript",
   "text/javascript",
   "application/ecmascript",
+  "module",
 ];
 
 const script: Processor<ScriptElement> = {


### PR DESCRIPTION
**What**:

Add support for processing scripts that have `type=module`.

Fixes: #436 .

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Documentation"
Strikethrough each line that's irrelevant to your changes using ~, for example: "- [x] ~Code~"
If needed, add the reason: "- [x] ~Documentation~: Internal code, not documented." -->

- [x] Code
- [x] TypeScript
- [x] Unit tests
- ~~[ ] End to end tests~~
- ~~[ ] TypeScript tests~~
- ~~[ ] Update starter themes~~
- ~~[ ] Update other packages~~
- ~~[ ] Documentation~~
- ~~[ ] Community discussions~~
- ~~[ ] Changeset~~