### PR TITLE
Fix publicPath if it's a URL

### DIFF
--- a/.changeset/shaggy-hats-accept.md
+++ b/.changeset/shaggy-hats-accept.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Fix --publicPath option when its value is a URL with domain specified.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  precision: 2
+  round: up
+
+comment:
+  layout: "files"
+  behavior: once

--- a/e2e/packages/use-in-view/package.json
+++ b/e2e/packages/use-in-view/package.json
@@ -5,6 +5,6 @@
   "description": "Package to do e2e testing of Frontity's useInView hook",
   "dependencies": {
     "frontity": "^1.4.3",
-    "@frontity/hooks": "^1.2.0"
+    "@frontity/hooks": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "codecov": "curl -s https://codecov.io/bash | bash -s",
     "e2e:prod:all": "cd e2e/project/ && npx frontity build && npx frontity serve --port 3001",
     "e2e:prod:module": "cd e2e/project/ && npx frontity build --publicPath /custom/path --target module && npx frontity serve --port 3001",
-    "e2e:prod:es5": "cd e2e/project/ && npx frontity build --publicPath /custom/path/ --target es5 && npx frontity serve --port 3001",
+    "e2e:prod:es5": "cd e2e/project/ && npx frontity build --publicPath http://localhost:3001/custom/path/ --target es5 && npx frontity serve --port 3001",
     "prepare": "lerna bootstrap --hoist",
     "reinstall": "lerna clean --yes && npm run prepare"
   },

--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -38,8 +38,6 @@ export default ({ packages }): ReturnType<Koa["callback"]> => {
       : // Use the value by default.
         "/static";
 
-    console.log(publicPath);
-
     // Serve the static files.
     return mount(publicPath, serve("build/static"))(ctx, next);
   });

--- a/packages/core/src/server/index.tsx
+++ b/packages/core/src/server/index.tsx
@@ -31,7 +31,16 @@ export default ({ packages }): ReturnType<Koa["callback"]> => {
     const moduleStats = await getStats({ target: "module" });
     const es5Stats = await getStats({ target: "es5" });
     const stats = moduleStats || es5Stats;
-    const publicPath = stats ? stats.publicPath : "/static";
+
+    const publicPath = stats
+      ? // Remove domain from publicPath.
+        stats.publicPath.replace(/^(?:https?:)?\/\/([^/])+/, "")
+      : // Use the value by default.
+        "/static";
+
+    console.log(publicPath);
+
+    // Serve the static files.
     return mount(publicPath, serve("build/static"))(ctx, next);
   });
 

--- a/packages/core/src/server/utils/__tests__/__snapshots__/stats.tests.ts.snap
+++ b/packages/core/src/server/utils/__tests__/__snapshots__/stats.tests.ts.snap
@@ -35,3 +35,19 @@ exports[`getBothScriptTags should work with secondary chunks in production 1`] =
         <script async nomodule data-chunk=\\"chunk-2\\" src=\\"/public-path/chunk-2.es5.456.js\\"></script>
         <script async nomodule data-chunk=\\"chunk-1~chunk-2\\" src=\\"/public-path/chunk-1~chunk-2.es5.456.js\\"></script>"
 `;
+
+exports[`should return correct chunk URLs in development (publicPath has a specified domain) 1`] = `
+"<script>REQ-CHUNK-SCRIPT-TAG</script>
+        <script async type=\\"module\\" data-chunk=\\"chunk-1\\" src=\\"http://localhost:3000/public-path/chunk-1.module.js\\"></script>
+        <script async type=\\"module\\" data-chunk=\\"chunk-2\\" src=\\"http://localhost:3000/public-path/chunk-2.module.js\\"></script>
+        <script async nomodule data-chunk=\\"chunk-1\\" src=\\"http://localhost:3000/public-path/chunk-1.es5.js\\"></script>
+        <script async nomodule data-chunk=\\"chunk-2\\" src=\\"http://localhost:3000/public-path/chunk-2.es5.js\\"></script>"
+`;
+
+exports[`should return correct chunk URLs in production (publicPath has a specified domain) 1`] = `
+"<script>REQ-CHUNK-SCRIPT-TAG</script>
+        <script async type=\\"module\\" data-chunk=\\"chunk-1\\" src=\\"http://localhost:3000/public-path/chunk-1.module.123.js\\"></script>
+        <script async type=\\"module\\" data-chunk=\\"chunk-2\\" src=\\"http://localhost:3000/public-path/chunk-2.module.123.js\\"></script>
+        <script async nomodule data-chunk=\\"chunk-1\\" src=\\"http://localhost:3000/public-path/chunk-1.es5.456.js\\"></script>
+        <script async nomodule data-chunk=\\"chunk-2\\" src=\\"http://localhost:3000/public-path/chunk-2.es5.456.js\\"></script>"
+`;

--- a/packages/core/src/server/utils/__tests__/stats.tests.ts
+++ b/packages/core/src/server/utils/__tests__/stats.tests.ts
@@ -126,3 +126,57 @@ describe("getBothScriptTags", () => {
     ).toMatchSnapshot();
   });
 });
+
+test("should return correct chunk URLs in development (publicPath has a specified domain)", () => {
+  const moduleStats = {
+    assetsByChunkName: {
+      "chunk-1": "chunk-1.module.js",
+      "chunk-2": "chunk-2.module.js",
+    },
+  };
+  const es5Stats = {
+    assetsByChunkName: {
+      "chunk-1": "chunk-1.es5.js",
+      "chunk-2": "chunk-2.es5.js",
+    },
+  };
+  const extractor = {
+    publicPath: "http://localhost:3000/public-path/",
+    getMainAssets: () => [
+      { filename: "chunk-1.module.js" },
+      { filename: "chunk-2.module.js" },
+    ],
+    getRequiredChunksScriptTag: (arg: {}) =>
+      !!arg && "<script>REQ-CHUNK-SCRIPT-TAG</script>",
+  };
+  expect(
+    getBothScriptTags({ moduleStats, es5Stats, extractor })
+  ).toMatchSnapshot();
+});
+
+test("should return correct chunk URLs in production (publicPath has a specified domain)", () => {
+  const moduleStats = {
+    assetsByChunkName: {
+      "chunk-1": "chunk-1.module.123.js",
+      "chunk-2": "chunk-2.module.123.js",
+    },
+  };
+  const es5Stats = {
+    assetsByChunkName: {
+      "chunk-1": "chunk-1.es5.456.js",
+      "chunk-2": "chunk-2.es5.456.js",
+    },
+  };
+  const extractor = {
+    publicPath: "http://localhost:3000/public-path/",
+    getMainAssets: () => [
+      { filename: "chunk-1.module.123.js" },
+      { filename: "chunk-2.module.123.js" },
+    ],
+    getRequiredChunksScriptTag: (arg: {}) =>
+      !!arg && "<script>REQ-CHUNK-SCRIPT-TAG</script>",
+  };
+  expect(
+    getBothScriptTags({ moduleStats, es5Stats, extractor })
+  ).toMatchSnapshot();
+});

--- a/packages/core/src/server/utils/stats.ts
+++ b/packages/core/src/server/utils/stats.ts
@@ -1,5 +1,3 @@
-import { join } from "path";
-
 export interface Stats {
   assetsByChunkName: { [key: string]: string };
   publicPath?: string;
@@ -45,7 +43,8 @@ export const getBothScriptTags = ({
   moduleStats: Stats;
   es5Stats: Stats;
 }): string => {
-  const publicPath = extractor.publicPath;
+  // Ensure publicPath ends with a slash.
+  const publicPath = extractor.publicPath.replace(/\/?$/, "/");
 
   const chunkNames = extractor
     .getMainAssets("script")
@@ -53,17 +52,11 @@ export const getBothScriptTags = ({
 
   const moduleTags = chunkNames.map(
     (chunk) =>
-      `<script async type="module" data-chunk="${chunk}" src="${join(
-        publicPath,
-        moduleStats.assetsByChunkName[chunk]
-      )}"></script>`
+      `<script async type="module" data-chunk="${chunk}" src="${publicPath}${moduleStats.assetsByChunkName[chunk]}"></script>`
   );
   const es5Tags = chunkNames.map(
     (chunk) =>
-      `<script async nomodule data-chunk="${chunk}" src="${join(
-        publicPath,
-        es5Stats.assetsByChunkName[chunk]
-      )}"></script>`
+      `<script async nomodule data-chunk="${chunk}" src="${publicPath}${es5Stats.assetsByChunkName[chunk]}"></script>`
   );
 
   const requiredChunksTag = extractor.getRequiredChunksScriptTag({});


### PR DESCRIPTION
**What**:

Fixes #445 

**Why**:

Critical bug

**How**:

The next line was trying to mount the static files using an invalid path (with a domain).

https://github.com/frontity/frontity/blob/ba6591581140c91d455ac01c78961da60a0f2566/packages/core/src/server/index.tsx#L35

Now it removes the domain and serves the static files from the resulting path.

There was an aditional problem generating  the source URL for chunks when using a URL as public path here ([`join`](https://nodejs.org/api/path.html#path_path_join_paths) doesn't work with URLs). It's solved too.

https://github.com/frontity/frontity/blob/de555246f630110edb1ab40ff5895e0341baba5e/packages/core/src/server/utils/stats.ts#L54-L67

**Tasks**:

- [x] Code
- [x] Unit tests
- [x] End to end tests
- [x] Changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

- TSDocs
- TypeScript
- TypeScript tests
- Update starter themes
- Update other packages
- Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- Community discussions

