### PR TITLE
Fix processor return type

### DIFF
--- a/.changeset/quiet-emus-joke.md
+++ b/.changeset/quiet-emus-joke.md
@@ -1,0 +1,5 @@
+---
+"@frontity/html2react": patch
+---
+
+Fix `Processor` type so TypeScript doesn't complain when a processor returns `null`, which is how nodes are removed.

--- a/e2e/integration/html2react.spec.js
+++ b/e2e/integration/html2react.spec.js
@@ -12,6 +12,11 @@ describe("Html2React", () => {
     cy.get("p").should("have.css", "color", "rgb(255, 0, 0)");
   });
 
+  it("should remove elements when processors return `null`", () => {
+    cy.get("button#remove-paragraphs").click();
+    cy.get("p").should("not.exist");
+  });
+
   it("should work with old processors", () => {
     cy.get("span#old-processors").should("have.text", "Yes");
   });

--- a/e2e/packages/html2react/src/index.tsx
+++ b/e2e/packages/html2react/src/index.tsx
@@ -16,6 +16,12 @@ const Root: React.FC<Connect<Html2ReactTests>> = ({ actions, libraries }) => {
       >
         Change color
       </button>
+      <button
+        id="remove-paragraphs"
+        onClick={() => actions.html2reactTests.removeParagraphs()}
+      >
+        Remove paragraphs
+      </button>
     </>
   );
 };
@@ -24,24 +30,28 @@ const html2reactTests: Html2ReactTests = {
   name: "e2e-html2react",
   state: {
     html2reactTests: {
-      color: "blue"
-    }
+      color: "blue",
+      removeParagraphs: false,
+    },
   },
   actions: {
     html2reactTests: {
       setColor: ({ state }) => (color: string) => {
         state.html2reactTests.color = color;
-      }
-    }
+      },
+      removeParagraphs: ({ state }) => {
+        state.html2reactTests.removeParagraphs = true;
+      },
+    },
   },
   roots: {
-    html2reactTests: connect(Root)
+    html2reactTests: connect(Root),
   },
   libraries: {
     html2react: {
-      processors
-    }
-  }
+      processors,
+    },
+  },
 };
 
 export default html2reactTests;

--- a/e2e/packages/html2react/src/processors.tsx
+++ b/e2e/packages/html2react/src/processors.tsx
@@ -1,21 +1,19 @@
-import React from "react";
 import { css } from "frontity";
-import { Processor, Node } from "@frontity/html2react/types";
+import { Processor, Node, Element } from "@frontity/html2react/types";
 import Html2ReactTests from "../types";
 
-export const testProcessor: Processor<
-  React.HTMLProps<HTMLParagraphElement>,
-  Html2ReactTests
-> = {
+export const testProcessor: Processor<Element, Html2ReactTests> = {
   test: ({ node }) => node.type === "element" && node.component === "p",
   processor: ({ node, state }) => {
-    if (node.type === "element") {
-      node.props.css = css`
-        color: ${state.html2reactTests.color};
-      `;
-    }
+    // This will remove the node.
+    if (state.html2reactTests.removeParagraphs) return null;
+
+    // This changes the element color and return the node.
+    node.props.css = css`
+      color: ${state.html2reactTests.color};
+    `;
     return node;
-  }
+  },
 };
 
 export const oldProcessor: Processor = ({
@@ -28,12 +26,12 @@ export const oldProcessor: Processor = ({
       node.children = [
         {
           type: "text",
-          content: root ? "Yes" : "No"
-        }
+          content: root ? "Yes" : "No",
+        },
       ];
     }
     return node;
-  }
+  },
 } as unknown) as Processor;
 
 export default [testProcessor, oldProcessor];

--- a/e2e/packages/html2react/types.ts
+++ b/e2e/packages/html2react/types.ts
@@ -6,11 +6,13 @@ interface Html2ReactTests extends Package {
   state: {
     html2reactTests: {
       color: string;
+      removeParagraphs: boolean;
     };
   };
   actions: {
     html2reactTests: {
       setColor: Action<Html2ReactTests, string>;
+      removeParagraphs: Action<Html2ReactTests>;
     };
   };
   roots: {

--- a/packages/html2react/__test__/types.test.ts
+++ b/packages/html2react/__test__/types.test.ts
@@ -145,4 +145,10 @@ const proc4: Processor<MyElement> = {
   },
 };
 
+// 5. Processor can return null to remove nodes.
+const proc5: Processor<Element> = {
+  test: ({ node }) => node.props.className.includes("to-remove"),
+  processor: () => null,
+};
+
 test("Types are fine!", () => {});

--- a/packages/html2react/types.ts
+++ b/packages/html2react/types.ts
@@ -68,7 +68,7 @@ type Test<NodeDef extends Node, Pkg extends Package> = (
 
 type Process<NodeDef extends Node, Pkg extends Package> = (
   params: Params<NodeDef, Pkg>
-) => Partial<Node> | boolean;
+) => Partial<Node> | null;
 
 export interface Processor<
   NodeDef extends Node = Node,


### PR DESCRIPTION
**What**:

Fix `Processor` return type.

**Why**:

Right now, TypeScript complains when a processor returns `null`, which is how nodes are removed.

There is an example in the [`@frontity/html2react` docs](https://github.com/frontity/frontity/pull/448), but I think we could explain this better.

**How**:

Just replacing `boolean` by `null` in the `Process` type here:

https://github.com/frontity/frontity/blob/f5fc7e42e1208dedf97ffec40170bfcc9fdffc71/packages/html2react/types.ts#L69L71

**Tasks**:

- [ ] TSDocs
- [x] TypeScript
- [x] End to end tests
- [x] TypeScript tests
- [ ] Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- [x] Changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)


**Unrelated Tasks**

- Code
- Unit tests
- Update starter themes
- Update other packages
- Community discussions
