### PR TITLE
Dont debug in production

### DIFF
--- a/.changeset/wet-pumpkins-sing.md
+++ b/.changeset/wet-pumpkins-sing.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Do not allow the new `state.frontity.debug` flag to be `true` in production.

--- a/packages/core/src/utils/__tests__/__snapshots__/merge-packages.tests.tsx.snap
+++ b/packages/core/src/utils/__tests__/__snapshots__/merge-packages.tests.tsx.snap
@@ -25,7 +25,7 @@ Object {
   },
   "state": Object {
     "frontity": Object {
-      "debug": false,
+      "debug": true,
       "mode": "html",
       "packages": Array [
         "package-1",

--- a/packages/core/src/utils/__tests__/merge-packages.tests.tsx
+++ b/packages/core/src/utils/__tests__/merge-packages.tests.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable react/display-name, @typescript-eslint/camelcase */
 
 import React from "react";
@@ -11,6 +12,7 @@ class MyLib {
 
 const state = {
   frontity: {
+    debug: false,
     mode: "html",
     packages: ["package-1", "package-2", "package-3"],
   },
@@ -24,6 +26,9 @@ const packages = {
       namespace2: () => <div>namespace2</div>,
     },
     state: {
+      frontity: {
+        debug: true,
+      },
       namespace1: {
         prop1: "prop1",
         array1: ["item1"],
@@ -117,5 +122,13 @@ describe("mergePackages", () => {
     expect(packages.package_2_html.state.namespace3).not.toBe(
       merged.state.namespace3
     );
+  });
+
+  it("should not use debug mode in production", () => {
+    const nodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    const merged = mergePackages({ packages, state, overwriteArrays: true });
+    expect(merged.state.frontity.debug).toBe(false);
+    process.env.NODE_ENV = nodeEnv;
   });
 });

--- a/packages/core/src/utils/merge-packages.ts
+++ b/packages/core/src/utils/merge-packages.ts
@@ -43,9 +43,11 @@ export default ({
     clone: true,
     arrayMerge: overwriteArrays ? overwriteMerge : undefined,
   });
-  // Delete the name and restore the debug flag.
+  // Delete the name.
   delete config.name;
-  config.state.frontity.debug = debug;
+  // Restore the debug flag if we are not in production.
+  if (process.env.NODE_ENV !== "production")
+    config.state.frontity.debug = debug;
 
   return config;
 };


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

It makes sure that `state.frontity.debug` is not activated in production.

**Why**:

<!-- Why are these changes necessary? -->

People may forget to turn it false again before deploying their site in production.

**How**:

<!-- How were these changes implemented? -->

It doesn't overwrite the `state.frontity.debug` value from the default (which is `false`) if we are in production.

They can still debug production mode using the console:

```bash
> frontity.state.frontity.debug = true;
```

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests
- [x] Changeset 
<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- Remove the "[ ]" from any non related task. -->

- TSDocs
- TypeScript
- End to end tests
- TypeScript tests
- Update starter themes
- Update other packages
- Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- Community discussions
<!-- Feel free to add any additional comments. -->