### PR TITLE
Fix analytics component

### DIFF
--- a/.changeset/great-lobsters-bow.md
+++ b/.changeset/great-lobsters-bow.md
@@ -1,0 +1,5 @@
+---
+"@frontity/analytics": patch
+---
+
+Fix a bug that was causing pageviews not to be sent if the previous page has the same title.

--- a/e2e/integration/analytics.spec.js
+++ b/e2e/integration/analytics.spec.js
@@ -9,6 +9,11 @@ describe("Analytics package", () => {
     title: "Some Post Title",
   };
 
+  const pageviewSomeOtherPost = {
+    page: "/some-other-post/",
+    title: "Some Post Title",
+  };
+
   const someEvent = {
     event: "some event",
     payload: { content: "some content" },
@@ -35,7 +40,9 @@ describe("Analytics package", () => {
     cy.get("button#change-link-post-2").click();
     cy.go("back");
     getAnalytics("pageviews").its(1).should("deep.equal", pageviewSomePost);
-    getAnalytics("pageviews").its(2).should("deep.equal", pageviewSomePost);
+    getAnalytics("pageviews")
+      .its(2)
+      .should("deep.equal", pageviewSomeOtherPost);
     getAnalytics("pageviews").its(3).should("deep.equal", pageviewSomePost);
   });
 

--- a/e2e/integration/analytics.spec.js
+++ b/e2e/integration/analytics.spec.js
@@ -1,0 +1,59 @@
+describe("Analytics package", () => {
+  const pageviewHome = {
+    page: "/?name=analytics",
+    title: "Homepage Title",
+  };
+
+  const pageviewSomePost = {
+    page: "/some-post/",
+    title: "Some Post Title",
+  };
+
+  const someEvent = {
+    event: "some event",
+    payload: { content: "some content" },
+  };
+
+  const getAnalytics = (data) =>
+    cy.window().its("frontity").its("state").its("testAnalytics").its(data);
+
+  beforeEach(() => {
+    cy.visit("http://localhost:3001?name=analytics");
+  });
+
+  it("should have sent the first pageview", () => {
+    getAnalytics("pageviews").its(0).should("deep.equal", pageviewHome);
+  });
+
+  it("should sent a pageview if the page changes", () => {
+    cy.get("button#change-link").click();
+    getAnalytics("pageviews").its(1).should("deep.equal", pageviewSomePost);
+  });
+
+  it("should sent a pageview if the page changes and title is the same", () => {
+    cy.get("button#change-link").click();
+    cy.get("button#change-link-post-2").click();
+    cy.go("back");
+    getAnalytics("pageviews").its(1).should("deep.equal", pageviewSomePost);
+    getAnalytics("pageviews").its(2).should("deep.equal", pageviewSomePost);
+    getAnalytics("pageviews").its(3).should("deep.equal", pageviewSomePost);
+  });
+
+  it("should sent pageviews when going back or forward", () => {
+    cy.get("button#change-link").click();
+    cy.go("back");
+    getAnalytics("pageviews").its(2).should("deep.equal", pageviewHome);
+
+    cy.go("forward");
+    getAnalytics("pageviews").its(3).should("deep.equal", pageviewSomePost);
+  });
+
+  it("should send events", () => {
+    cy.get("button#send-event").click();
+    cy.get("button#send-event").click();
+    cy.get("button#send-event").click();
+    getAnalytics("events").its(0).should("deep.equal", someEvent);
+    getAnalytics("events").its(1).should("deep.equal", someEvent);
+    getAnalytics("events").its(2).should("deep.equal", someEvent);
+  });
+});

--- a/e2e/packages/analytics/src/index.tsx
+++ b/e2e/packages/analytics/src/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Head, connect, URL } from "frontity";
 import { Connect } from "frontity/types";
-import Analytics from "../types";
+import Analytics, { Packages } from "../types";
 
 const Homepage = () => (
   <>
@@ -23,11 +23,12 @@ const SomePost = () => (
   </>
 );
 
-const Theme: React.FC<Connect<Analytics>> = ({ state, actions }) => {
+const Theme: React.FC<Connect<Packages>> = ({ state, actions }) => {
   // Get only the pathname (link has query).
   const { pathname } = new URL(state.router.link, "http://localhost:3001");
 
-  const changeLink = () => actions.router.set("/some-post/");
+  const changeLinkPost1 = () => actions.router.set("/some-post/");
+  const changeLinkPost2 = () => actions.router.set("/some-other-post/");
   const sendEvent = () =>
     actions.analytics.sendEvent({
       event: "some event",
@@ -38,9 +39,14 @@ const Theme: React.FC<Connect<Analytics>> = ({ state, actions }) => {
     <>
       {/* Render homepage or post */}
       {pathname === "/" && <Homepage />}
+      {/* Same component to test the case when the title doesn't change*/}
       {pathname === "/some-post/" && <SomePost />}
+      {pathname === "/some-other-post/" && <SomePost />}
       {/* Buttons */}
-      <button id="change-link" onClick={changeLink}>
+      <button id="change-link" onClick={changeLinkPost1}>
+        Some Post
+      </button>
+      <button id="change-link-post-2" onClick={changeLinkPost2}>
         Some Post
       </button>
       <button id="send-event" onClick={sendEvent}>
@@ -50,7 +56,7 @@ const Theme: React.FC<Connect<Analytics>> = ({ state, actions }) => {
   );
 };
 
-const analytics: Analytics = {
+const analytics: Analytics<Packages> = {
   name: "e2e-analytics",
   roots: {
     theme: connect(Theme),
@@ -59,6 +65,12 @@ const analytics: Analytics = {
     source: {
       data: {},
       get: ({ state }) => (link) => state.source.data[link],
+    },
+    analytics: {
+      namespaces: ["testAnalytics"],
+    },
+    testAnalytics: {
+      pageviews: [],
     },
   },
   actions: {
@@ -80,6 +92,11 @@ const analytics: Analytics = {
             isReady: true,
           };
         }
+      },
+    },
+    testAnalytics: {
+      sendPageview: ({ state }) => (pageview) => {
+        state.testAnalytics.pageviews.push(pageview);
       },
     },
   },

--- a/e2e/packages/analytics/src/index.tsx
+++ b/e2e/packages/analytics/src/index.tsx
@@ -56,7 +56,7 @@ const Theme: React.FC<Connect<Packages>> = ({ state, actions }) => {
   );
 };
 
-const analytics: Analytics<Packages> = {
+const analytics: Analytics = {
   name: "e2e-analytics",
   roots: {
     theme: connect(Theme),

--- a/e2e/packages/analytics/src/index.tsx
+++ b/e2e/packages/analytics/src/index.tsx
@@ -71,6 +71,7 @@ const analytics: Analytics<Packages> = {
     },
     testAnalytics: {
       pageviews: [],
+      events: [],
     },
   },
   actions: {
@@ -97,6 +98,9 @@ const analytics: Analytics<Packages> = {
     testAnalytics: {
       sendPageview: ({ state }) => (pageview) => {
         state.testAnalytics.pageviews.push(pageview);
+      },
+      sendEvent: ({ state }) => (event) => {
+        state.testAnalytics.events.push(event);
       },
     },
   },

--- a/e2e/packages/analytics/types.ts
+++ b/e2e/packages/analytics/types.ts
@@ -1,24 +1,38 @@
 import { Package } from "frontity/types";
-import Analytics from "@frontity/analytics/types";
+import Analytics, { Pageview } from "@frontity/analytics/types";
 import Source from "@frontity/source/types";
 import Router from "@frontity/router/types";
 
-interface TestAnalytics extends Package {
+interface TestAnalytics<Pkgs = null> extends Package {
   name: "e2e-analytics";
-  state?: {
-    router?: Router["state"]["router"];
-    source?: Partial<Source["state"]["source"]>;
+  state: {
+    source: {
+      data: Source<Pkgs>["state"]["source"]["data"];
+      get: Source<Pkgs>["state"]["source"]["get"];
+    };
+    analytics: {
+      namespaces: Analytics["state"]["analytics"]["namespaces"];
+    };
+    testAnalytics: {
+      pageviews: Pageview[];
+    };
   };
-  actions?: {
-    analytics?: Analytics["actions"]["analytics"];
-    router?: Router["actions"]["router"];
-    source?: {
-      fetch: Source["actions"]["source"]["fetch"];
+  actions: {
+    source: {
+      fetch: Source<Pkgs>["actions"]["source"]["fetch"];
+    };
+    testAnalytics: {
+      sendPageview: Analytics<Pkgs>["actions"]["analytics"]["sendPageview"];
     };
   };
   roots: {
     theme: React.ReactType;
   };
 }
+
+export type Packages = TestAnalytics<Packages> &
+  Router<Packages> &
+  Source<Packages> &
+  Analytics;
 
 export default TestAnalytics;

--- a/e2e/packages/analytics/types.ts
+++ b/e2e/packages/analytics/types.ts
@@ -1,5 +1,5 @@
-import { Package } from "frontity/types";
-import Analytics, { Pageview } from "@frontity/analytics/types";
+import { Package, Action } from "frontity/types";
+import Analytics, { Pageview, Event } from "@frontity/analytics/types";
 import Source from "@frontity/source/types";
 import Router from "@frontity/router/types";
 
@@ -15,6 +15,7 @@ interface TestAnalytics<Pkgs = null> extends Package {
     };
     testAnalytics: {
       pageviews: Pageview[];
+      events: Event[];
     };
   };
   actions: {
@@ -22,7 +23,8 @@ interface TestAnalytics<Pkgs = null> extends Package {
       fetch: Source<Pkgs>["actions"]["source"]["fetch"];
     };
     testAnalytics: {
-      sendPageview: Analytics<Pkgs>["actions"]["analytics"]["sendPageview"];
+      sendPageview: Action<Pkgs, Pageview>;
+      sendEvent: Action<Pkgs, Event>;
     };
   };
   roots: {

--- a/e2e/packages/analytics/types.ts
+++ b/e2e/packages/analytics/types.ts
@@ -3,12 +3,12 @@ import Analytics, { Pageview, Event } from "@frontity/analytics/types";
 import Source from "@frontity/source/types";
 import Router from "@frontity/router/types";
 
-interface TestAnalytics<Pkgs = null> extends Package {
+interface TestAnalytics extends Package {
   name: "e2e-analytics";
   state: {
     source: {
-      data: Source<Pkgs>["state"]["source"]["data"];
-      get: Source<Pkgs>["state"]["source"]["get"];
+      data: Source["state"]["source"]["data"];
+      get: Source["state"]["source"]["get"];
     };
     analytics: {
       namespaces: Analytics["state"]["analytics"]["namespaces"];
@@ -20,11 +20,11 @@ interface TestAnalytics<Pkgs = null> extends Package {
   };
   actions: {
     source: {
-      fetch: Source<Pkgs>["actions"]["source"]["fetch"];
+      fetch: Source["actions"]["source"]["fetch"];
     };
     testAnalytics: {
-      sendPageview: Action<Pkgs, Pageview>;
-      sendEvent: Action<Pkgs, Event>;
+      sendPageview: Action<Packages, Pageview>;
+      sendEvent: Action<Packages, Event>;
     };
   };
   roots: {
@@ -32,9 +32,6 @@ interface TestAnalytics<Pkgs = null> extends Package {
   };
 }
 
-export type Packages = TestAnalytics<Packages> &
-  Router<Packages> &
-  Source<Packages> &
-  Analytics;
+export type Packages = TestAnalytics & Router & Source & Analytics;
 
 export default TestAnalytics;

--- a/e2e/project/frontity.settings.ts
+++ b/e2e/project/frontity.settings.ts
@@ -109,6 +109,10 @@ const settings: Settings = [
     name: "slot-and-fill",
     packages: ["e2e-slot-and-fill"],
   },
+  {
+    name: "analytics",
+    packages: ["e2e-analytics", "@frontity/tiny-router", "@frontity/analytics"],
+  },
 ];
 
 export default settings;

--- a/e2e/project/package.json
+++ b/e2e/project/package.json
@@ -12,6 +12,7 @@
     "serve:inspect": "node --inspect -r ts-node/register/transpile-only ./node_modules/.bin/frontity serve"
   },
   "dependencies": {
+    "@frontity/analytics": "^1.1.0",
     "@frontity/comscore-analytics": "^0.1.0",
     "@frontity/core": "^1.5.0",
     "@frontity/google-tag-manager": "^0.2.0",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@frontity/source": "^1.0.17",
+    "@frontity/router": "^1.1.0",
     "frontity": "^1.8.0"
   }
 }

--- a/packages/analytics/src/components/index.tsx
+++ b/packages/analytics/src/components/index.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { connect, Head } from "frontity";
 import { Connect } from "frontity/types";
-import Analytics from "../../types";
+import { Packages } from "../../types";
 
 /**
  * Send a pageview anytime the title changes
  * and data.isReady === true.
  */
-const Root: React.FC<Connect<Analytics>> = ({ state, actions }) => {
+const Root: React.FC<Connect<Packages>> = ({ state, actions }) => {
   const { link } = state.router;
   const { isReady } = state.source.get(link);
 

--- a/packages/analytics/src/components/index.tsx
+++ b/packages/analytics/src/components/index.tsx
@@ -11,9 +11,6 @@ const Root: React.FC<Connect<Packages>> = ({ state, actions }) => {
   const { link } = state.router;
   const { isReady } = state.source.get(link);
 
-  // Store the previous title.
-  const [prevTitle, setPrevTitle] = React.useState("");
-
   // Store if a pageview has been sent for this link.
   const [isPageviewSent, setIsPageviewSent] = React.useState(false);
 
@@ -31,9 +28,7 @@ const Root: React.FC<Connect<Packages>> = ({ state, actions }) => {
        */
       titleTemplate={!isReady ? "%s " : ""}
       onChangeClientState={({ title }) => {
-        if (isReady && !isPageviewSent && prevTitle !== title) {
-          // Store current title.
-          setPrevTitle(title);
+        if (isReady && !isPageviewSent) {
           // Send pageview.
           actions.analytics.sendPageview({
             page: state.router.link,

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,7 +1,7 @@
 import Root from "./components";
-import Analytics, { Packages } from "../types";
+import Analytics from "../types";
 
-const analytics: Analytics<Packages> = {
+const analytics: Analytics = {
   roots: {
     analytics: Root,
   },

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,7 +1,7 @@
 import Root from "./components";
-import Analytics from "../types";
+import Analytics, { Packages } from "../types";
 
-const analytics: Analytics = {
+const analytics: Analytics<Packages> = {
   roots: {
     analytics: Root,
   },

--- a/packages/analytics/types.ts
+++ b/packages/analytics/types.ts
@@ -1,5 +1,6 @@
 import { Package, Action } from "frontity/types";
 import Source from "@frontity/source/types";
+import Router from "@frontity/router/types";
 
 export type Pageview = {
   page: string;
@@ -11,31 +12,29 @@ export type Event = {
   payload: Record<string, any>;
 };
 
-interface Analytics extends Package {
+interface Analytics<Pkgs = null> extends Package {
   roots: {
     analytics: React.FC;
   };
   actions: {
     analytics: {
-      sendPageview: Action<Analytics, Pageview>;
-      sendEvent: Action<Analytics, Event>;
+      sendPageview: Action<Pkgs, Pageview>;
+      sendEvent: Action<Pkgs, Event>;
     };
     [key: string]: {
-      sendPageview?: Action<Analytics, Pageview>;
-      sendEvent?: Action<Analytics, Event>;
+      sendPageview?: Action<Pkgs, Pageview>;
+      sendEvent?: Action<Pkgs, Event>;
     };
   };
   state: {
     analytics: {
       namespaces: string[];
     };
-    router?: {
-      link: string;
-    };
-    source?: {
-      get: Source["state"]["source"]["get"];
-    };
   };
 }
+
+export type Packages = Analytics<Packages> &
+  Router<Packages> &
+  Source<Packages>;
 
 export default Analytics;

--- a/packages/analytics/types.ts
+++ b/packages/analytics/types.ts
@@ -12,18 +12,14 @@ export type Event = {
   payload: Record<string, any>;
 };
 
-interface Analytics<Pkgs = Packages> extends Package {
+interface Analytics extends Package {
   roots: {
     analytics: React.FC;
   };
   actions: {
     analytics: {
-      sendPageview: Action<Pkgs, Pageview>;
-      sendEvent: Action<Pkgs, Event>;
-    };
-    [key: string]: {
-      sendPageview?: Action<Pkgs, Pageview>;
-      sendEvent?: Action<Pkgs, Event>;
+      sendPageview: Action<Analytics, Pageview>;
+      sendEvent: Action<Analytics, Event>;
     };
   };
   state: {

--- a/packages/analytics/types.ts
+++ b/packages/analytics/types.ts
@@ -12,7 +12,7 @@ export type Event = {
   payload: Record<string, any>;
 };
 
-interface Analytics<Pkgs = null> extends Package {
+interface Analytics<Pkgs = Packages> extends Package {
   roots: {
     analytics: React.FC;
   };
@@ -33,8 +33,6 @@ interface Analytics<Pkgs = null> extends Package {
   };
 }
 
-export type Packages = Analytics<Packages> &
-  Router<Packages> &
-  Source<Packages>;
+export type Packages = Analytics & Router & Source;
 
 export default Analytics;

--- a/packages/google-analytics/types.ts
+++ b/packages/google-analytics/types.ts
@@ -1,6 +1,6 @@
 import { ReactType } from "react";
-import { Action } from "frontity/types";
-import Analytics, { Pageview } from "@frontity/analytics/types";
+import { Action, Package } from "frontity/types";
+import Analytics, { Pageview, Event } from "@frontity/analytics/types";
 
 declare global {
   interface Window {
@@ -8,7 +8,7 @@ declare global {
   }
 }
 
-interface GoogleAnalyticsEvent {
+interface GoogleAnalyticsEvent extends Event {
   event: string;
   payload: {
     category: string;
@@ -21,7 +21,7 @@ interface GoogleAnalyticsEvent {
   };
 }
 
-interface GoogleAnalytics extends Analytics {
+interface GoogleAnalytics extends Package {
   roots: Analytics["roots"] & {
     googleAnalytics: ReactType;
   };
@@ -33,10 +33,12 @@ interface GoogleAnalytics extends Analytics {
   };
   actions: Analytics["actions"] & {
     googleAnalytics: {
-      sendPageview: Action<GoogleAnalytics, Pageview>;
-      sendEvent: Action<GoogleAnalytics, GoogleAnalyticsEvent>;
+      sendPageview: Action<Packages, Pageview>;
+      sendEvent: Action<Packages, GoogleAnalyticsEvent>;
     };
   };
 }
+
+export type Packages = GoogleAnalytics & Analytics<GoogleAnalytics>;
 
 export default GoogleAnalytics;

--- a/packages/google-analytics/types.ts
+++ b/packages/google-analytics/types.ts
@@ -39,6 +39,6 @@ interface GoogleAnalytics extends Package {
   };
 }
 
-export type Packages = GoogleAnalytics & Analytics<GoogleAnalytics>;
+export type Packages = GoogleAnalytics & Analytics;
 
 export default GoogleAnalytics;


### PR DESCRIPTION
**What**:

It fixes the `@frontity/analytics` root component that wasn't sending pageviews when navigating to a new link with the same title.

I also take the opportunity to refactor the type definitions for the `@frontity/analytics` package and match what was discussed here in the community: [TypeScript: use two different types](https://community.frontity.org/t/typescript-use-two-different-types/1681)

Fixes #460 

**Why**:

To fix a bug that's causing some pageviews not to be sent.

**How**:

Just removing some innecessary checks on a page title that we were doing in the `@frontity/analytics` root component.

**Tasks**:

- [x] Code
- [x] TypeScript
- [x] End to end tests
- [x] Changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

- TSDocs
- Unit tests
- TypeScript tests
- Update starter themes
- Update other packages
- Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- Community discussions

