### PR TITLE
Update the test coverage collection 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,16 @@
+# Round the coverage up, up to the 2nd decimal point. E.g
+# 89.0199 % => 89.02%
 coverage:
   precision: 2
   round: up
 
+  # The `patch` target of 100% means that all new code must be fully tested (100%)
+  status:
+    patch:
+      default:
+        target: 100%
+
+# Make the layout of the comment posted on the PR by the codecov bot a bit nicer
 comment:
   layout: "files"
   behavior: once

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,11 @@ module.exports = {
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(j|t)sx?$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   testPathIgnorePatterns: ["/mocks/"],
+  collectCoverageFrom: [
+    "**/packages/**/*.{js,jsx,ts,tsx}",
+    "!**/node_modules/**",
+    "!**/vendor/**",
+    "!**/dist/**",
+    "!**/build/**",
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   testPathIgnorePatterns: ["/mocks/"],
   collectCoverageFrom: [
-    "**/packages/**/*.{js,jsx,ts,tsx}",
+    "**/*.{js,jsx,ts,tsx}",
     "!**/node_modules/**",
     "!**/vendor/**",
     "!**/dist/**",

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,5 +9,6 @@ module.exports = {
     "!**/vendor/**",
     "!**/dist/**",
     "!**/build/**",
+    "!**/jest.config.{js,ts}",
   ],
 };


### PR DESCRIPTION
At the moment, the test coverage is only collected from the files that are required / used by our tests. The files that are not tested at all do no count towards the total number of lines covered.

This results in 2 problems:
- Our coverage is artificially inflated (the ~90% coverage was not accurate, it's actually closer to 70%, which is still not terrible actually)
- We run into a problem ([reported by @DAreRodz](https://github.com/frontity/frontity/pull/458#issuecomment-638822172)) where if we add a test case for a file that we previously untested, the code coverage actually goes down, even though logically _more_ of our code is being tested 🙂 

---

**This PR** fixes this by collecting the coverage from all JS / TS files in packages with some exceptions like jest configs. Collecting the coverage only takes place when jest is run with `--coverage` so updating the global config does not affect tests that are run locally

I've additionally updated the "patch" coverage to 100% - this means that all new code should have 100% coverage. We can adjust that in the future if it ends up not being practically feasible sometimes.