### PR TITLE
Disable Codecov patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,11 +4,9 @@ coverage:
   precision: 2
   round: up
 
-  # The `patch` target of 100% means that all new code must be fully tested (100%)
+  # Patch is currently disable until cypress coverage is implemented.
   status:
-    patch:
-      default:
-        target: 100%
+    patch: off
 
 # Make the layout of the comment posted on the PR by the codecov bot a bit nicer
 comment:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,12 @@ coverage:
   precision: 2
   round: up
 
-  # Patch is currently disable until cypress coverage is implemented.
+  # Patch is set to 0% so it doesn't prevent PRs to be merged but the value
+  # is reported anyways
   status:
-    patch: off
+    patch:
+      default:
+        target: 0%
 
 # Make the layout of the comment posted on the PR by the codecov bot a bit nicer
 comment:


### PR DESCRIPTION
**What**:

Disables [patch status](https://docs.codecov.io/docs/commit-status#patch-status) from Codecov reports.

**Why**:

It might be a good idea to try to get a 100% code coverage, but right now we are only getting reports from unit tests (`jest`), and not from e2e tests (`cypress`) so we don't have an accurate coverage value yet.

It doesn't make sense to implement redundant tests either, I mean, trying to get a 100% coverage just with unit tests when the same code it's tested using e2e tests.

Also, I don't think setting an arbitrary value here would be worth it, so for me it's better to disable that metric util we add coverage support for Cypress.

The project status is still there so we would know if our overall code coverage drops anyways.

**How**:

Changing configuration in `codecov.yml`.

**Tasks**:

- [x] Code

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

- TSDocs
- TypeScript
- Unit tests
- End to end tests
- TypeScript tests
- Update starter themes
- Update other packages
- Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- Community discussions
- Changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Additional Comments**

I leave here some resources in order to implement Cypress tests coverage:

- [Code Coverage - Cypress Documentation](https://docs.cypress.io/guides/tooling/code-coverage.html#Introduction)
- [code-coverage/examples/ts-example at master · cypress-io/code-coverage](https://github.com/cypress-io/code-coverage/tree/master/examples/ts-example)
- [Combining Storybook, Cypress and Jest Code Coverage - DEV Community 👩‍💻👨‍💻](https://dev.to/penx/combining-storybook-cypress-and-jest-code-coverage-4pa5)