### PR TITLE
removed unneeded package dependency package "components"

### DIFF
--- a/.changeset/hip-comics-turn.md
+++ b/.changeset/hip-comics-turn.md
@@ -1,0 +1,5 @@
+---
+"@frontity/components": patch
+---
+
+Removed unneeded dependency.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@types/react-test-renderer": "^16.9.2",
-    "@frontity/error": "^0.1.0",
     "react-test-renderer": "^16.13.1"
   },
   "dependencies": {


### PR DESCRIPTION
**What**:

Removed unneeded dependency from "devDependencies"

**Why**:

So it is clear that any use of `error` `warn` should be done through `frontity` package
So the proper relationship between packages can be tracked in places like this: https://www.npmjs.com/browse/depended/@frontity/connect

**How**:

Removing unneeded dependency from "devDependencies"

**Tasks**:

- [X] Changeset 

**Unrelated Tasks**

- Code
- TSDocs
- TypeScript
- Unit tests
- End to end tests
- TypeScript tests
- Update starter themes
- Update other packages
- Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- Community discussions
