### PR TITLE
Readme babel plugin frontity

### DIFF
--- a/.changeset/dirty-pets-marry.md
+++ b/.changeset/dirty-pets-marry.md
@@ -1,0 +1,5 @@
+---
+"babel-plugin-frontity": patch
+---
+
+README.md created.

--- a/packages/babel-plugin-frontity/README.md
+++ b/packages/babel-plugin-frontity/README.md
@@ -1,2 +1,64 @@
-# babel-plugin-frontity
+# `babel-plugin-frontity`
 
+[![Version](https://img.shields.io/npm/v/babel-plugin-frontity.svg)](https://www.npmjs.com/package/babel-plugin-frontity) [![npm](https://img.shields.io/npm/dw/babel-plugin-frontity)](https://www.npmjs.com/package/babel-plugin-frontity) [![License: Apache--2.0](https://img.shields.io/badge/license-Apache%202-lightgrey)](https://github.com/frontity/frontity/blob/master/LICENSE)
+
+Babel Plugin for Frontity. It contains some custom configuration for [Babel](https://babeljs.io/).
+
+## Table of contents
+
+<!-- toc -->
+
+- [Install](#install)
+- [Usage](#usage)
+- [Feature Discussions](#feature-discussions)
+- [Changelog](#changelog)
+- [Open Source Community](#open-source-community)
+  * [Channels](#channels)
+  * [Get involved](#get-involved)
+
+<!-- tocstop -->
+
+## Install
+
+This package is not meant to be installed individually. 
+
+## Usage
+
+This package is [used internally](https://www.npmjs.com/package/babel-plugin-frontity) by [`@frontity/core`](https://github.com/frontity/frontity/tree/dev/packages/core) to fix things such as source maps issues with emotion
+  
+
+## Feature Discussions
+
+[**Feature Discussions**](https://community.frontity.org/c/feature-discussions/33) about Frontity are public. You can join the discussions, vote for those you're interested in or create new ones.
+
+These are the ones related to this package: https://community.frontity.org/tags/c/feature-discussions/33/babel-plugin-frontit
+
+## Changelog
+
+Have a look at the latest updates of this package in the [CHANGELOG](https://github.com/frontity/frontity/blob/dev/packages/babel-plugin-frontity/CHANGELOG.md)
+
+***
+
+## Open Source Community
+
+### Channels
+
+[![Community Forum Topics](https://img.shields.io/discourse/topics?color=blue&label=community%20forum&server=https%3A%2F%2Fcommunity.frontity.org%2F)](https://community.frontity.org/) [![Twitter: frontity](https://img.shields.io/twitter/follow/frontity.svg?style=social)](https://twitter.com/frontity) ![Frontity Github Stars](https://img.shields.io/github/stars/frontity/frontity?style=social)
+
+Frontity has a number of different channels at your disposal where you can find out more information about the project, join in discussions about it, and also get involved:
+
+- **📖  [Docs](https://docs.frontity.org/):** Frontity's primary documentation resource - this is the place to learn how to build amazing sites with Frontity.
+* **👨‍👩‍👧‍👦  [Community forum](https://community.frontity.org/):** join Frontity's forum and ask questions, share your knowledge, give feedback and meet other cool Frontity people. We'd love to know about what you're building with Frontity, so please do swing by the [forum](https://community.frontity.org/) and tell us about your projects.
+* **🐞  Contribute:** Frontity uses [GitHub](https://github.com/frontity/frontity) for bugs and pull requests. Check out the [Contributing](../contributing/) section to find out how you can help develop Frontity, or improve this documentation.
+* **🗣  Social media**: interact with other Frontity users. Reach out to the Frontity team on [Twitter](https://twitter.com/frontity). Mention us in your tweets about Frontity and what you're building by using **`@frontity`**.
+* 💌  **Newsletter:** do you want to receive the latest news about Frontity and find out as soon as there's an update to the framework? Subscribe to our [newsletter](https://frontity.org/#newsletter).
+
+### Get involved
+
+[![GitHub issues by-label](https://img.shields.io/github/issues/frontity/frontity/good%20first%20issue)](https://github.com/frontity/frontity/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+
+Got questions or feedback about Frontity? We'd love to hear from you in our [community forum](https://community.frontity.org).
+
+Frontity also welcomes contributions. There are many ways to support the project! If you don't know where to start then this guide might help: [How to contribute?](https://docs.frontity.org/contributing/how-to-contribute).
+
+If you would like to start contributing to the code please open a pull request to address one of our [*good first issues*](https://github.com/frontity/frontity/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).


### PR DESCRIPTION
**What**:

README.md's babel plugin frontity

**Why**:

Proper info in NPM

**How**:

Creating the README.md's using on the proper folder

```
npx readme-md-generator -p ../../.github/README_TEMPLATE/package-readme.md -y
```

And then adding custom info on each README.md

Last step is adding TOC by doing...

```
npx markdown-toc -i README.md
```
**Tasks**:

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

- Changeset `patch`

**Unrelated Tasks**

- Code
- TSDocs
- TypeScript
- Unit tests
- End to end tests
- TypeScript tests
- Update starter themes
- Update other packages
- Link to PR in [Documentation](https://github.com/frontity/gitbook-docs/)
- Community discussions
