### PR TITLE
Fix package names that start with a number

### DIFF
--- a/.changeset/tasty-zebras-breathe.md
+++ b/.changeset/tasty-zebras-breathe.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Fix for package names that start with a number, like `@123/package`.

--- a/packages/core/src/utils/__tests__/get-variable.tests.ts
+++ b/packages/core/src/utils/__tests__/get-variable.tests.ts
@@ -11,8 +11,13 @@ describe("getVariable", () => {
     expect(getVariable("org-package", "mode")).not.toBe(
       getVariable("org.package", "mode")
     );
-    expect(getVariable("@org/package", "html")).not.toBe(
+    expect(getVariable("@org/package", "default")).not.toBe(
       getVariable("@org/package", "amp")
     );
+  });
+  it("should allow scopes starting with numbers", () => {
+    expect(() =>
+      eval("var " + getVariable("@123/package", "mode"))
+    ).not.toThrow();
   });
 });

--- a/packages/core/src/utils/get-variable.ts
+++ b/packages/core/src/utils/get-variable.ts
@@ -1,9 +1,18 @@
-// Remove some characters present in the npm package name to
-// turn it into a variable name.
+/**
+ * Create a valid variable name out of a package name and a mode.
+ *
+ * @param pkg - The package name, like for example `@frontity/mars-theme`.
+ * @param mode - The mode, like for example `default` or `amp`.
+ *
+ * @returns A valid variable name that can be used to create the entry point
+ * files.
+ */
 export default (pkg: string, mode: string) => {
   return (
+    // "_" +
     pkg
       .replace(/^@/, "")
+      .replace(/^(\d)/, "_$1")
       .replace(/-/g, "_")
       .replace(/\//g, "__")
       .replace(/\./g, "___") + `_${mode}`

--- a/packages/core/src/utils/get-variable.ts
+++ b/packages/core/src/utils/get-variable.ts
@@ -9,7 +9,6 @@
  */
 export default (pkg: string, mode: string) => {
   return (
-    // "_" +
     pkg
       .replace(/^@/, "")
       .replace(/^(\d)/, "_$1")


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Packages that start with a number, like `@123/package` didn't work.

**Why**:

<!-- Why are these changes necessary? -->

Because we generate variables out of those names in our entry point files and we were not contemplating that case.

**How**:

<!-- How were these changes implemented? -->

Fixing the function that turns package names into variable names.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] TSDocs
- [x] Unit tests
- [x] Add a changeset

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- End to end tests
- TypeScript
- TypeScript tests
- Update starter themes
- Update other packages
- Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- Update community discussions
<!-- ignore-task-list-end -->