### PR TITLE
Analytics: Remove beta version from e2e tests

### DIFF
--- a/e2e/packages/analytics/package.json
+++ b/e2e/packages/analytics/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Package to do e2e testing of Frontity's analytics library",
   "dependencies": {
-    "@frontity/analytics": "^1.0.0-beta.0",
+    "@frontity/analytics": "^1.2.0",
     "@frontity/source": "^1.2.0",
     "@frontity/router": "^1.0.19",
     "frontity": "^1.4.3"


### PR DESCRIPTION
**What**:

Update `@frontity/analytics` version used in the `e2e-analytics` package from `1.0.0-beta.0` to `1.2.0`.

**Why**:

To install the correct package while running e2e tests.

**How**:

Just updating the `package.json` file.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- ignore-task-list-end -->

**Additional Comments**

I guess this happened because we changed the way changeset bumps package versions, preventing e2e packages to release new versions. :shrug: