### PR TITLE
WP Comments: fix typo in HTTP response code

### DIFF
--- a/.changeset/small-ants-decide.md
+++ b/.changeset/small-ants-decide.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-comments": patch
+---
+
+Fix a in the HTTP response code that WordPress returns when a comment is submitted.

--- a/packages/wp-comments/src/__tests__/actions.submit.test.ts
+++ b/packages/wp-comments/src/__tests__/actions.submit.test.ts
@@ -505,10 +505,10 @@ describe("actions.comments.submit", () => {
     // Create store from mocked packages.
     const store = createStore<Packages>(packages as Packages);
 
-    // WordPress returns 203 when a comment was successfully submitted.
+    // WordPress returns 302 when a comment was successfully submitted.
     fetch.mockResolvedValue(
       mockResponse(undefined, {
-        status: 203,
+        status: 302,
         headers: {
           Location:
             "https://test.frontity.org/2016/the-beauties-of-gullfoss/http://frontity.site/post/?unapproved=123&moderation-hash=847492149d817bf7e08d81457bf9952f#comment-123",
@@ -556,10 +556,10 @@ describe("actions.comments.submit", () => {
     // Create store from mocked packages.
     const store = createStore<Packages>(packages as Packages);
 
-    // WordPress returns 203 when a comment was successfully submitted.
+    // WordPress returns 302 when a comment was successfully submitted.
     fetch.mockResolvedValue(
       mockResponse(undefined, {
-        status: 203,
+        status: 302,
         headers: {
           Location:
             "https://test.frontity.org/2016/the-beauties-of-gullfoss/http://frontity.site/post/#comment-123",

--- a/packages/wp-comments/src/index.ts
+++ b/packages/wp-comments/src/index.ts
@@ -119,8 +119,8 @@ const wpComments: WpComments = {
           return;
         }
 
-        // 203 Found - The comment was submitted.
-        if (response.status === 203) {
+        // 302 Found - The comment was submitted.
+        if (response.status === 302) {
           // We can know if the comment was approved from the returned location.
           const location = new URL(response.headers.get("Location"));
 


### PR DESCRIPTION
**What**:

Fix a typo in the HTTP response code that WordPress returns when a comment is submitted.

**Why**:

It must be `302`, but it is being used `203`. 

**How**:

Just replacing that code.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- TSDocs
- TypeScript
- End to end tests
- TypeScript tests
- Update starter themes
- Update other packages
- Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
