### PR TITLE
Get rid of short flags in the CLI

### DIFF
--- a/.changeset/small-islands-reply.md
+++ b/.changeset/small-islands-reply.md
@@ -1,0 +1,5 @@
+---
+"frontity": minor
+---
+
+Remove all the short flags from the CLI commands.

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -40,7 +40,7 @@ program
 
 program
   .command("dev")
-  .option("-p, --production", "Builds the project for production.")
+  .option("--prod, --production", "Builds the project for production.")
   .option("--port <port>", "Runs the server on a custom port. Default is 3000.")
   .option("--https", "Runs the server using https.")
   .option(
@@ -61,7 +61,7 @@ program
 
 program
   .command("build")
-  .option("-d, --development", "Builds the project for development.")
+  .option("--dev, --development", "Builds the project for development.")
   .option(
     "--target <target>",
     'create bundles with "es5", "module" or "both". Default target is "both".'

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -24,16 +24,16 @@ program
 // options: --typescript, --use-cwd.
 program
   .command("create [name]")
-  .option("-h, --theme <theme>", "The theme to use")
-  .option("-t, --typescript", "Adds support for TypeScript")
-  .option("-c, --use-cwd", "Generates the project in the current directory.")
-  .option("-n, --no-prompt", "Skips prompting the user for options")
+  .option("--theme <theme>", "The theme to use")
+  .option("--typescript", "Adds support for TypeScript")
+  .option("--use-cwd", "Generates the project in the current directory.")
+  .option("--no-prompt", "Skips prompting the user for options")
   .description("Creates a new Frontity project.")
   .action((name, { ...args }) => create({ name, ...args }));
 
 program
   .command("create-package [name]")
-  .option("-n, --namespace <value>", "Sets the namespace for this package")
+  .option("--namespace <value>", "Sets the namespace for this package")
   .option("--no-prompt", "Skips prompting the user for options")
   .description("Creates a new Frontity package in a project.")
   .action((name, { ...args }) => createPackage({ name, ...args }));
@@ -42,7 +42,7 @@ program
   .command("dev")
   .option("-p, --production", "Builds the project for production.")
   .option("--port <port>", "Runs the server on a custom port. Default is 3000.")
-  .option("-s, --https", "Runs the server using https.")
+  .option("--https", "Runs the server using https.")
   .option(
     "--dont-open-browser",
     "Don't open a browser window with the localhost."
@@ -76,7 +76,7 @@ program
 program
   .command("serve")
   .option("--port <port>", "Runs the server on a custom port. Default is 3000.")
-  .option("-s, --https", "Runs the server using https.")
+  .option("--https", "Runs the server using https.")
   .description("Starts a server in production mode.")
   .action(serve);
 


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

This PR gets rid of all the short flags, like `-h` or `-s`.

**Why**:

<!-- Why are these changes necessary? -->

They were not consistent. For example, in a command, `-n` meant `--namespace` and `--no-prompt` didn't have any short flag, but in another command `-n` meant `--no-prompt`.

Some of them are not even valid, like `-h` for the `--theme`, because `-h` is also used for help:

```bash
-h, --help  output usage information
```

I don't think it makes sense to expose these types of args just for the shake of using them. I think we should get rid of them now, and then maybe introduce them in the future after agreeing on a standardize way to create them.

**How**:

<!-- How were these changes implemented? -->

I just got rid of them in the `commander` configuration.

I also added the alias `--prod` for `--production` and `--dev` for `--development`.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
- [x] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases): https://github.com/frontity/docs/issues/199

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->