### PR TITLE
Fix public path arg camelcase

### DIFF
--- a/.changeset/eleven-glasses-give.md
+++ b/.changeset/eleven-glasses-give.md
@@ -1,0 +1,8 @@
+---
+"@frontity/core": patch
+"frontity": patch
+---
+
+Deprecate the `--publicPath` CLI arg of the `npx frontity dev` and `npx frontity build` commands in favor of `--public-path` to be consistent with the rest of the arguments.
+
+It also adds a log to those commands, along with the already existing `mode` and `target` logs.

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -1,21 +1,22 @@
 import * as tsNode from "ts-node";
 
 /**
- * This file gets transpiled to JS anyway, but if the users's frontity.settings.(js|ts)
- * is an ES Module, we cannot require an ES Module from a commonjs module!
+ * This file gets transpiled to JS anyway, but if the users's
+ * frontity.settings.(js|ts) is an ES Module, we cannot require an ES Module
+ * from a commonjs module.
  *
- * This is why we use ts-node here as well as in the `dev` script. It's ONLY
- * because we want the user to be able to use ES Modules syntax in the
- * frontity.settings.(js|ts) file like:
+ * This is why we use ts-node here as well as in the `dev` script.
+ * It's only because we want the user to be able to use ES Modules syntax in
+ * the frontity.settings.(js|ts) file like this.
  *
- * ```
+ * @example
+ * ```js
  * export default {
  *   name: 'my-theme',
  *   state: {},
  *   packages: {},
  * }
  * ```
- *
  */
 tsNode.register({
   transpileOnly: true,
@@ -52,16 +53,50 @@ import { Mode } from "../../types";
 import cleanBuildFolders from "./utils/clean-build-folders";
 import { webpackAsync } from "./utils/webpack";
 
-export default async ({
-  mode,
-  target,
-  publicPath,
-}: {
+/**
+ * The options of the build command.
+ */
+interface BuildOptions {
+  /**
+   * The Webpack mode used, either "development" or "production".
+   *
+   * @defaultValue "production"
+   */
   mode: Mode;
-  target: "both" | "es5" | "module";
+
+  /**
+   * The JavaScript transpilation target. Either "es5" or "module".
+   *
+   * @defaultValue "both"
+   */
+  target: "es5" | "module" | "both";
+
+  /**
+   * The publicPath used in Webpack.
+   *
+   * @defaultValue "/static/"
+   */
   publicPath: string;
-}): Promise<void> => {
-  console.log(`mode: ${mode}\n`);
+}
+
+/**
+ * The Frontity build command that creates all the bundles and assets necessary
+ * to run the Frontity server.
+ *
+ * @param options - Defined in {@link BuildOptions}.
+ *
+ * @returns A promise that resolves when the build has finished.
+ */
+export default async ({
+  mode = "production",
+  target = "both",
+  publicPath = "/static/",
+}: BuildOptions): Promise<void> => {
+  console.log();
+  console.log(`  - mode: ${mode}`);
+  console.log(`  - target: ${target}`);
+  console.log(`  - public-path: ${publicPath}`);
+  console.log();
 
   // Get config from frontity.config.js files.
   const frontityConfig = getFrontity();

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -1,21 +1,22 @@
 import * as tsNode from "ts-node";
 
 /**
- * This file gets transpiled to JS anyway, but if the users's frontity.settings.(js|ts)
- * is an ES Module, we cannot require an ES Module from a commonjs module!
+ * This file gets transpiled to JS anyway, but if the users's
+ * frontity.settings.(js|ts) is an ES Module, we cannot require an ES Module
+ * from a commonjs module.
  *
- * This is why we use ts-node here as well as in the `build` script. It's ONLY
- * because we want the user to be able to use ES Modules syntax in the
- * frontity.settings.(js|ts) file like:
+ * This is why we use ts-node here as well as in the `build` script.
+ * It's only because we want the user to be able to use ES Modules syntax in
+ * the frontity.settings.(js|ts) file like this.
  *
- * ```
+ * @example
+ * ```js
  * export default {
  *   name: 'my-theme',
  *   state: {},
  *   packages: {},
  * }
  * ```
- *
  */
 tsNode.register({
   transpileOnly: true,
@@ -56,7 +57,62 @@ import cleanBuildFolders from "./utils/clean-build-folders";
 import { webpackAsync } from "./utils/webpack";
 import createSymlinks from "./utils/create-symlinks";
 
-// Start Frontity development environment.
+/**
+ * The options of the dev command.
+ */
+export interface DevOptions {
+  /**
+   * The Webpack mode used, either "development" or "production".
+   *
+   * @defaultValue "development"
+   */
+  mode: Mode;
+
+  /**
+   * The port used to start the server.
+   *
+   * @defaultValue 3000
+   */
+  port: number;
+
+  /**
+   * Indicate if the server should be started using HTTPS. The certs used
+   * are in the /certs folder of this package. They are valid only for local
+   * usage.
+   *
+   * @defaultValue false
+   */
+  isHttps: boolean;
+
+  /**
+   * The JavaScript transpilation target. Either "es5" or "module".
+   *
+   * @defaultValue "module"
+   */
+  target: "es5" | "module";
+
+  /**
+   * If this command should open a browser or not.
+   *
+   * @defaultValue true
+   */
+  openBrowser?: boolean;
+
+  /**
+   * The publicPath used in Webpack.
+   *
+   * @defaultValue "/static/"
+   */
+  publicPath: string;
+}
+
+/**
+ * The Frontity dev command that starts a development Frontity server.
+ *
+ * @param options - Defined in {@link DevOptions}.
+ *
+ * @returns A promise that resolves when the server has started.
+ */
 export default async ({
   isHttps,
   mode,
@@ -64,14 +120,7 @@ export default async ({
   target,
   openBrowser = true,
   publicPath,
-}: {
-  port: number;
-  isHttps: boolean;
-  mode: Mode;
-  target: "es5" | "module";
-  openBrowser?: boolean;
-  publicPath: string;
-}): Promise<void> => {
+}: DevOptions): Promise<void> => {
   // Get config from frontity.config.js files.
   const frontityConfig = getFrontity();
   const { outDir } = frontityConfig;
@@ -95,6 +144,7 @@ export default async ({
     isHttps,
     target,
     openBrowser,
+    publicPath,
   });
 
   // Get config for webpack, babel and frontity.

--- a/packages/core/src/scripts/utils/create-app.ts
+++ b/packages/core/src/scripts/utils/create-app.ts
@@ -2,23 +2,33 @@ import { MultiCompiler } from "webpack";
 import express from "express";
 import createServer from "./create-server";
 import { openBrowserTab } from "./open-browser";
-import { Mode } from "../../../types";
+import { DevOptions } from "../dev";
 
-// Create an express app ready to be used with webpack-dev-middleware.
+/**
+ * Create an express app ready to be used with webpack-dev-middleware.
+ *
+ * @param options - Defined in {@link DevOptions}.
+ *
+ * @returns - An object with the app and a callback function that starts the
+ * server when Webpack has finished.
+ */
 export default async ({
   mode,
   port,
   isHttps,
   target,
   openBrowser = true,
-}: {
-  mode: Mode;
-  port: number;
-  isHttps: boolean;
-  target: "es5" | "module";
-  openBrowser?: boolean;
-}): Promise<{
+  publicPath = "/static",
+}: DevOptions): Promise<{
+  /**
+   * The app created by Express, ready to be used by webpack-dev-middleware.
+   */
   app: express.Express;
+
+  /**
+   * A function that accepts a {@link MultiCompiler} and starts the server
+   * once Webpack has finished the bundles.
+   */
   done: (compiler: MultiCompiler) => void;
 }> => {
   // Create the app.
@@ -50,14 +60,19 @@ export default async ({
   // Start listening.
   server.listen(port, () => {
     console.log(
-      `\n\nSERVER STARTED -- Listening @ ${url}\n  - mode: ${mode}\n  - target: ${target}\n\n`
+      `\n\nSERVER STARTED -- Listening @ ${url}\n  - mode: ${mode}\n  - target: ${target}\n  - public-path: ${publicPath}\n\n`
     );
   });
 
   // Open localhost on the local browser.
   if (openBrowser) openBrowserTab(url);
 
-  // Check if webpack has finished (both the client and server bundles).
+  //
+  /**
+   * Check if webpack has finished (both the client and server bundles).
+   *
+   * @param compiler - A {@link MultiCompiler} from Webpack.
+   */
   const done = (compiler: MultiCompiler) => {
     compiler.compilers[0].hooks.done.tapAsync(
       "frontity-dev-server",

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -51,9 +51,9 @@ program
     "--target <target>",
     'create bundles with "es5" or "module". Default target is "module".'
   )
-
+  .option("--publicPath <path>", "DEPRECATED, use --public-path instead.")
   .option(
-    "--publicPath <path>",
+    "--public-path <path>",
     'set the public path for static assets. Default path is "/static/".'
   )
   .description("Starts a server in development mode.")
@@ -66,8 +66,9 @@ program
     "--target <target>",
     'create bundles with "es5", "module" or "both". Default target is "both".'
   )
+  .option("--publicPath <path>", "DEPRECATED, use --public-path instead.")
   .option(
-    "--publicPath <path>",
+    "--public-path <path>",
     'set the public path for static assets. Default path is "/static/".'
   )
   .description("Builds the project for production.")


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Deprecate the `--publicPath` CLI arg of the `npx frontity dev` and `npx frontity build` commands in favor of `--public-path`.

It also adds a log to those commands, along with the already existing `mode` and `target` logs.

**Why**:

<!-- Why are these changes necessary? -->

To be consistent with the rest of the CLI arguments.

**How**:

<!-- How were these changes implemented? -->

`commander` supports this very well, so I just added the new `--public-path` argument and left the older `--publicPath` with a deprecation notice. Both arguments end up being the same variable: `publicPath`.

It's not yet possible to hide an argument from the help. It seems like the commander mainteiners will add this soon (https://github.com/tj/commander.js/pull/1331) so we can use that in the future to omit this from the help.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] TSDocs
- [x] TypeScript
- [x] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases): https://github.com/frontity/docs/issues/202
- [x] Update community discussions: https://community.frontity.org/t/change-publicpath/1461/14
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
<!-- ignore-task-list-end -->