### PR TITLE
Update Cypress and Jest versions and remove Node 8 support

### DIFF
--- a/.changeset/five-students-joke.md
+++ b/.changeset/five-students-joke.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Deprecate the `URL` import from `"frontity"` in favor of the `new URL` global that is now present in both the browser and Node 10+.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
       - name: Checkout

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -149,7 +149,14 @@ process.chdir(__dirname);
           });
         }
       }
-      // Exit the process once Cypress ends.
+
+      // Stop all the containers and remove all the volumes that they use (the
+      // `-v` option).
+      await execa("docker-compose", ["down", "-v"], {
+        stdio: "inherit",
+      });
+
+      // Exit the process to indicate that everything went fine.
       process.exit(0);
     }
   } catch (err) {

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -73,7 +73,7 @@ process.chdir(__dirname);
       // instances for testing.
       await execa(
         "docker-compose",
-        ["run", "wp", "/bin/bash", "-c", "chmod -R 777 /var/www/html"],
+        ["run", "--rm", "wp", "/bin/bash", "-c", "chmod -R 777 /var/www/html"],
         { stdio: "inherit" }
       );
     }

--- a/e2e/integration/wordpress-01/wp-basic-tests.spec.js
+++ b/e2e/integration/wordpress-01/wp-basic-tests.spec.js
@@ -29,4 +29,10 @@ describe("WordPress plugins", () => {
       "Hello from WordPress plugin"
     );
   });
+
+  it("dummy test, otherwise the previous test doesn't run", () => {
+    // I'm not sure why, but if I remove this test, the previous one doesn't run
+    // and if it fails, Cypress does not complain. I guess it is a bug in
+    // Cypress.
+  });
 });

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -71,18 +71,6 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        }
       }
     },
     "@cypress/xvfb": {
@@ -788,13 +776,19 @@
       }
     },
     "@samverschueren/stream-to-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
+      "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/execa": {
       "version": "2.0.0",
@@ -846,12 +840,12 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -888,9 +882,9 @@
       "dev": true
     },
     "arch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
+      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
       "dev": true
     },
     "arraybuffer.slice": {
@@ -932,6 +926,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -939,9 +939,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
     "axios": {
@@ -1005,6 +1005,12 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+      "dev": true
+    },
+    "blob-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
+      "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
       "dev": true
     },
     "bluebird": {
@@ -1076,23 +1082,23 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         }
       }
@@ -1119,14 +1125,14 @@
       }
     },
     "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "requires": {
         "colors": "^1.1.2",
         "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "string-width": "^4.2.0"
       }
     },
     "cli-truncate": {
@@ -1168,18 +1174,18 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "colors": {
@@ -1199,9 +1205,9 @@
       }
     },
     "commander": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
     "common-tags": {
@@ -1270,146 +1276,56 @@
       }
     },
     "cypress": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.7.0.tgz",
-      "integrity": "sha512-Vav6wUFhPRlImIND/2lOQlUnAWzgCC/iXyJlJjX9nJOJul5LC1vUpf/m8Oiae870PFPyT0ZLLwPHKTXZNdXmHw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.0.0.tgz",
+      "integrity": "sha512-jhPd0PMO1dPSBNpx6pHVLkmnnaTfMy3wCoacHAKJ9LJG06y16zqUNSFri64N4BjuGe8y6mNMt8TdgKnmy9muCg==",
       "dev": true,
       "requires": {
-        "@cypress/listr-verbose-renderer": "0.4.1",
-        "@cypress/request": "2.88.5",
-        "@cypress/xvfb": "1.2.4",
-        "@types/sinonjs__fake-timers": "6.0.1",
-        "@types/sizzle": "2.3.2",
-        "arch": "2.1.1",
-        "bluebird": "3.7.2",
-        "cachedir": "2.3.0",
-        "chalk": "2.4.2",
-        "check-more-types": "2.24.0",
-        "cli-table3": "0.5.1",
-        "commander": "4.1.0",
-        "common-tags": "1.8.0",
-        "debug": "4.1.1",
-        "eventemitter2": "4.1.2",
-        "execa": "1.0.0",
-        "executable": "4.1.1",
-        "extract-zip": "1.7.0",
-        "fs-extra": "8.1.0",
-        "getos": "3.1.4",
-        "is-ci": "2.0.0",
-        "is-installed-globally": "0.1.0",
-        "lazy-ass": "1.6.0",
-        "listr": "0.14.3",
-        "lodash": "4.17.15",
-        "log-symbols": "3.0.0",
-        "minimist": "1.2.5",
-        "moment": "2.24.0",
-        "ospath": "1.2.2",
-        "pretty-bytes": "5.3.0",
-        "ramda": "0.26.1",
-        "request-progress": "3.0.0",
-        "supports-color": "7.1.0",
-        "tmp": "0.1.0",
-        "untildify": "4.0.0",
-        "url": "0.11.0",
-        "yauzl": "2.10.0"
+        "@cypress/listr-verbose-renderer": "^0.4.1",
+        "@cypress/request": "^2.88.5",
+        "@cypress/xvfb": "^1.2.4",
+        "@types/sinonjs__fake-timers": "^6.0.1",
+        "@types/sizzle": "^2.3.2",
+        "arch": "^2.1.2",
+        "blob-util": "2.0.2",
+        "bluebird": "^3.7.2",
+        "cachedir": "^2.3.0",
+        "chalk": "^4.1.0",
+        "check-more-types": "^2.24.0",
+        "cli-table3": "~0.6.0",
+        "commander": "^4.1.1",
+        "common-tags": "^1.8.0",
+        "debug": "^4.1.1",
+        "eventemitter2": "^6.4.2",
+        "execa": "^4.0.2",
+        "executable": "^4.1.1",
+        "extract-zip": "^1.7.0",
+        "fs-extra": "^9.0.1",
+        "getos": "^3.2.1",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.3.2",
+        "lazy-ass": "^1.6.0",
+        "listr": "^0.14.3",
+        "lodash": "^4.17.19",
+        "log-symbols": "^4.0.0",
+        "minimist": "^1.2.5",
+        "moment": "^2.27.0",
+        "ospath": "^1.2.2",
+        "pretty-bytes": "^5.3.0",
+        "ramda": "~0.26.1",
+        "request-progress": "^3.0.0",
+        "supports-color": "^7.1.0",
+        "tmp": "~0.2.1",
+        "untildify": "^4.0.0",
+        "url": "^0.11.0",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
           "dev": true
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },
@@ -1519,6 +1435,12 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1598,9 +1520,9 @@
       "dev": true
     },
     "eventemitter2": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-      "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
+      "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==",
       "dev": true
     },
     "execa": {
@@ -1685,12 +1607,6 @@
             "ms": "2.0.0"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -1715,15 +1631,15 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fd-slicer": {
@@ -1795,14 +1711,33 @@
       }
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "dev": true,
       "requires": {
+        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        }
       }
     },
     "fs.realpath": {
@@ -1821,12 +1756,12 @@
       }
     },
     "getos": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
-      "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
+      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
       "dev": true,
       "requires": {
-        "async": "^3.1.0"
+        "async": "^3.2.0"
       }
     },
     "getpass": {
@@ -1863,12 +1798,12 @@
       }
     },
     "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
+      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "^1.3.5"
       }
     },
     "graceful-fs": {
@@ -1884,12 +1819,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
@@ -1926,9 +1861,9 @@
       "dev": true
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "hogan.js": {
@@ -2014,9 +1949,9 @@
       }
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-function": {
@@ -2026,13 +1961,13 @@
       "dev": true
     },
     "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
       }
     },
     "is-observable": {
@@ -2045,13 +1980,10 @@
       }
     },
     "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "dev": true
     },
     "is-promise": {
       "version": "2.2.2",
@@ -2268,6 +2200,26 @@
         "figures": "^2.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -2277,6 +2229,21 @@
             "restore-cursor": "^2.0.0"
           }
         },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
         "figures": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2285,6 +2252,12 @@
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "mimic-fn": {
           "version": "1.2.0",
@@ -2309,6 +2282,15 @@
           "requires": {
             "onetime": "^2.0.0",
             "signal-exit": "^3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2342,12 +2324,12 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2"
+        "chalk": "^4.0.0"
       }
     },
     "log-update": {
@@ -2467,9 +2449,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
       "dev": true
     },
     "ms": {
@@ -2482,12 +2464,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-      "dev": true
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "nopt": {
@@ -2559,12 +2535,6 @@
       "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
       "dev": true
     },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
     "p-map": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
@@ -2627,12 +2597,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -2705,9 +2669,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
-      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "pump": {
@@ -2757,6 +2721,14 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "regenerator-runtime": {
@@ -2803,9 +2775,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
     "safer-buffer": {
@@ -2827,12 +2799,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "shebang-command": {
@@ -2993,28 +2959,29 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -3026,6 +2993,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "strip-ansi": {
@@ -3037,12 +3012,6 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
-    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -3050,12 +3019,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "symbol-observable": {
@@ -3083,12 +3052,23 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dev": true,
       "requires": {
-        "rimraf": "^2.6.3"
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "to-array": {
@@ -3096,6 +3076,16 @@
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -3211,9 +3201,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "verror": {
@@ -3278,6 +3268,22 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@types/execa": "^2.0.0",
     "@types/wait-on": "^4.0.0",
-    "cypress": "^4.7.0",
+    "cypress": "^5.0.0",
     "cypress-plugin-snapshots": "^1.4.3",
     "execa": "^4.0.3",
     "minimist": "^1.2.5",

--- a/e2e/packages/ads/src/index.tsx
+++ b/e2e/packages/ads/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Slot, connect, URL } from "frontity";
+import { Slot, connect } from "frontity";
 import { Connect } from "frontity/types";
 import TestAds, { Packages } from "../types";
 

--- a/e2e/packages/ads/src/index.tsx
+++ b/e2e/packages/ads/src/index.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable */
+/*
+ * TSDocs will be added in this branch:
+ * https://github.com/frontity/frontity/tree/package-name
+ */
 import React from "react";
 import { Slot, connect } from "frontity";
 import { Connect } from "frontity/types";

--- a/e2e/packages/analytics/src/index.tsx
+++ b/e2e/packages/analytics/src/index.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable */
+/*
+ * TSDocs will be added in this branch:
+ * https://github.com/frontity/frontity/tree/package-name
+ */
 import React from "react";
 import { Head, connect } from "frontity";
 import { Connect } from "frontity/types";

--- a/e2e/packages/analytics/src/index.tsx
+++ b/e2e/packages/analytics/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Head, connect, URL } from "frontity";
+import { Head, connect } from "frontity";
 import { Connect } from "frontity/types";
 import Analytics, { Packages } from "../types";
 

--- a/e2e/packages/emotion/src/index.tsx
+++ b/e2e/packages/emotion/src/index.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable */
+/*
+ * TSDocs will be added in this branch:
+ * https://github.com/frontity/frontity/tree/package-name
+ */
 import React from "react";
 import { Global, css, connect, styled } from "frontity";
 import Package from "../types";

--- a/e2e/packages/emotion/src/index.tsx
+++ b/e2e/packages/emotion/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Global, css, connect, URL, styled } from "frontity";
+import { Global, css, connect, styled } from "frontity";
 import Package from "../types";
 
 const GlobalBackgroundBlue = () => {
@@ -86,9 +86,9 @@ const EmotionPackage: Package = {
   state: {},
   actions: {},
   roots: {
-    emotion: Root
+    emotion: Root,
   },
-  libraries: {}
+  libraries: {},
 };
 
 export default EmotionPackage;

--- a/e2e/packages/fonts/src/index.tsx
+++ b/e2e/packages/fonts/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Global, css, connect, styled, URL } from "frontity";
+import { Global, css, connect, styled } from "frontity";
 import Package from "../types";
 import aclonicaEot from "./fonts/aclonica-v10-latin-regular.eot";
 import aclonicaWoff from "./fonts/aclonica-v10-latin-regular.woff";
@@ -139,9 +139,9 @@ const FontsPackage: Package = {
   state: {},
   actions: {},
   roots: {
-    fonts: Font
+    fonts: Font,
   },
-  libraries: {}
+  libraries: {},
 };
 
 export default FontsPackage;

--- a/e2e/packages/fonts/src/index.tsx
+++ b/e2e/packages/fonts/src/index.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable */
+/*
+ * TSDocs will be added in this branch:
+ * https://github.com/frontity/frontity/tree/package-name
+ */
 import React from "react";
 import { Global, css, connect, styled } from "frontity";
 import Package from "../types";

--- a/e2e/plugins/index.js
+++ b/e2e/plugins/index.js
@@ -25,7 +25,7 @@ module.exports = (on, config) => {
     installPlugin({ name, version }) {
       return (async () => {
         await execa.command(
-          `docker-compose run wpcli wp plugin install ${name}${
+          `docker-compose run --rm wpcli wp plugin install ${name}${
             version ? ` --version=${version}` : ""
           }`,
           { stdio: "inherit" }
@@ -85,9 +85,12 @@ module.exports = (on, config) => {
      */
     removeAllPlugins() {
       return (async () => {
-        await execa.command(`docker-compose run wpcli wp plugin delete --all`, {
-          stdio: "inherit",
-        });
+        await execa.command(
+          `docker-compose run --rm wpcli wp plugin delete --all`,
+          {
+            stdio: "inherit",
+          }
+        );
         return null;
       })();
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,45 +13,46 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
-			"integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+			"version": "7.11.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.4.tgz",
+			"integrity": "sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.8.4",
-				"@babel/helpers": "^7.8.4",
-				"@babel/parser": "^7.8.4",
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.4",
-				"@babel/types": "^7.8.3",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.4",
+				"@babel/helper-module-transforms": "^7.11.0",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.11.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.11.0",
+				"@babel/types": "^7.11.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
-				"json5": "^2.1.0",
-				"lodash": "^4.17.13",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.19",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.8.3"
+						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 					"dev": true,
 					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
 					}
 				},
@@ -65,13 +66,19 @@
 					}
 				},
 				"json5": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
+						"minimist": "^1.2.5"
 					}
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -82,61 +89,138 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-			"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+			"version": "7.11.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+			"integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3",
+				"@babel/types": "^7.11.0",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-			"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-get-function-arity": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.11.0"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.11.0",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
 			"dev": true
 		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+		"@babel/helper-replace-supers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
-		"@babel/helpers": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
-			"integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+		"@babel/helper-simple-access": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.4",
-				"@babel/types": "^7.8.3"
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.11.0"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"dev": true
+		},
+		"@babel/helpers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/highlight": {
@@ -151,10 +235,82 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+			"version": "7.11.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+			"integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
 			"dev": true
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
 			"version": "7.8.3",
@@ -165,73 +321,91 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
-		"@babel/template": {
+		"@babel/plugin-syntax-optional-catch-binding": {
 			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-			"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.8.3"
+						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 					"dev": true,
 					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
 					}
 				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-			"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+			"integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.8.4",
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.8.4",
-				"@babel/types": "^7.8.3",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.0",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.11.0",
+				"@babel/types": "^7.11.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.8.3"
+						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 					"dev": true,
 					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
 						"js-tokens": "^4.0.0"
 					}
 				},
@@ -244,6 +418,12 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -253,15 +433,29 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-			"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+			"integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.13",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
+		},
+		"@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true
 		},
 		"@changesets/apply-release-plan": {
 			"version": "0.3.1",
@@ -614,9 +808,9 @@
 			"dev": true
 		},
 		"@cnakazawa/watch": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
-			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+			"integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
 			"dev": true,
 			"requires": {
 				"exec-sh": "^0.3.2",
@@ -749,140 +943,751 @@
 				}
 			}
 		},
-		"@jest/console": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
-			"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+		"@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^24.9.0",
-				"chalk": "^2.0.1",
-				"slash": "^2.0.0"
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
 			},
 			"dependencies": {
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
 				}
 			}
 		},
-		"@jest/core": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
-			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+		"@istanbuljs/schema": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+			"dev": true
+		},
+		"@jest/console": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
+			"integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.9.0",
-				"jest-config": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-resolve-dependencies": "^24.9.0",
-				"jest-runner": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"jest-watcher": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"p-each-series": "^1.0.0",
-				"realpath-native": "^1.1.0",
-				"rimraf": "^2.5.4",
-				"slash": "^2.0.0",
-				"strip-ansi": "^5.0.0"
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"jest-message-util": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
 				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 					"dev": true
 				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
 		},
-		"@jest/environment": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
-			"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+		"@jest/core": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
+			"integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0"
+				"@jest/console": "^26.3.0",
+				"@jest/reporters": "^26.4.1",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-changed-files": "^26.3.0",
+				"jest-config": "^26.4.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-message-util": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-resolve-dependencies": "^26.4.2",
+				"jest-runner": "^26.4.2",
+				"jest-runtime": "^26.4.2",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
+				"jest-watcher": "^26.3.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^2.1.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.11.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"dev": true
+				}
+			}
+		},
+		"@jest/environment": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+			"integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"jest-mock": "^26.3.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
-			"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+			"integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-mock": "^24.9.0"
+				"@jest/types": "^26.3.0",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@types/node": "*",
+				"jest-message-util": "^26.3.0",
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"@jest/globals": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
+			"integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"expect": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@jest/reporters": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
-			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+			"version": "26.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
+			"integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
-				"istanbul-lib-coverage": "^2.0.2",
-				"istanbul-lib-instrument": "^3.0.1",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.2.6",
-				"jest-haste-map": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.4.2",
-				"slash": "^2.0.0",
+				"graceful-fs": "^4.2.4",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.3",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-resolve": "^26.4.0",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
+				"node-notifier": "^8.0.0",
+				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
-				"string-length": "^2.0.0"
+				"string-length": "^4.0.1",
+				"terminal-link": "^2.0.0",
+				"v8-to-istanbul": "^5.0.1"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 					"dev": true
 				},
 				"source-map": {
@@ -890,17 +1695,26 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
 		"@jest/source-map": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
-			"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
+			"integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
-				"graceful-fs": "^4.1.15",
+				"graceful-fs": "^4.2.4",
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
@@ -908,6 +1722,12 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 					"dev": true
 				},
 				"source-map": {
@@ -919,56 +1739,242 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
-			"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
+			"integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/istanbul-lib-coverage": "^2.0.0"
+				"@jest/console": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"collect-v8-coverage": "^1.0.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
-			"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
+			"integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-runner": "^24.9.0",
-				"jest-runtime": "^24.9.0"
+				"@jest/test-result": "^26.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.3.0",
+				"jest-runner": "^26.4.2",
+				"jest-runtime": "^26.4.2"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/transform": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
-			"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
+			"integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.9.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"chalk": "^2.0.1",
+				"@jest/types": "^26.3.0",
+				"babel-plugin-istanbul": "^6.0.0",
+				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.9.0",
-				"jest-regex-util": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"micromatch": "^3.1.10",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-util": "^26.3.0",
+				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
+				"slash": "^3.0.0",
 				"source-map": "^0.6.1",
-				"write-file-atomic": "2.4.1"
+				"write-file-atomic": "^3.0.0"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
 				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 					"dev": true
 				},
 				"source-map": {
@@ -977,28 +1983,100 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
-				"write-file-atomic": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
-					"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"write-file-atomic": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+					"dev": true,
+					"requires": {
 						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.2"
+						"is-typedarray": "^1.0.0",
+						"signal-exit": "^3.0.2",
+						"typedarray-to-buffer": "^3.1.5"
 					}
 				}
 			}
 		},
 		"@jest/types": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+			"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^13.0.0"
+				"@types/yargs": "^15.0.0",
+				"chalk": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@lerna/add": {
@@ -2634,10 +3712,28 @@
 				"@types/node": ">= 8"
 			}
 		},
+		"@sinonjs/commons": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/fake-timers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
+		},
 		"@types/babel__core": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
-			"integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+			"version": "7.1.9",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
+			"integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -2667,9 +3763,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.8",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
-			"integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
+			"version": "7.0.13",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
+			"integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -2704,10 +3800,19 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/graceful-fs": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/istanbul-lib-coverage": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
 			"dev": true
 		},
 		"@types/istanbul-lib-report": {
@@ -2720,9 +3825,9 @@
 			}
 		},
 		"@types/istanbul-reports": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "*",
@@ -2730,12 +3835,13 @@
 			}
 		},
 		"@types/jest": {
-			"version": "24.9.1",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
-			"integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+			"version": "26.0.10",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.10.tgz",
+			"integrity": "sha512-i2m0oyh8w/Lum7wWK/YOZJakYF8Mx08UaKA1CtbmFeDquVhAEdA7znacsVSf2hJ1OQ/OfVMGN90pw/AtzF8s/Q==",
 			"dev": true,
 			"requires": {
-				"jest-diff": "^24.3.0"
+				"jest-diff": "^25.2.1",
+				"pretty-format": "^25.2.1"
 			}
 		},
 		"@types/json-schema": {
@@ -2780,6 +3886,12 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"@types/prettier": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
+			"integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
+			"dev": true
+		},
 		"@types/semver": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.0.tgz",
@@ -2793,9 +3905,9 @@
 			"dev": true
 		},
 		"@types/yargs": {
-			"version": "13.0.8",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
-			"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+			"version": "15.0.5",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+			"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -2883,9 +3995,9 @@
 			}
 		},
 		"abab": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
+			"integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
 			"dev": true
 		},
 		"abbrev": {
@@ -2901,21 +4013,13 @@
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+			"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-					"dev": true
-				}
+				"acorn": "^7.1.1",
+				"acorn-walk": "^7.1.1"
 			}
 		},
 		"acorn-jsx": {
@@ -2925,9 +4029,9 @@
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 			"dev": true
 		},
 		"agent-base": {
@@ -3054,24 +4158,13 @@
 			"dev": true
 		},
 		"anymatch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
-			},
-			"dependencies": {
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
-				}
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
 			}
 		},
 		"aproba": {
@@ -3131,12 +4224,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
 			"integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==",
-			"dev": true
-		},
-		"array-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
 		"array-find-index": {
@@ -3227,12 +4314,6 @@
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
-		"async-limiter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-			"dev": true
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3273,102 +4354,159 @@
 			}
 		},
 		"babel-jest": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
-			"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
+			"integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/babel__core": "^7.1.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"babel-preset-jest": "^24.9.0",
-				"chalk": "^2.4.2",
-				"slash": "^2.0.0"
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/babel__core": "^7.1.7",
+				"babel-plugin-istanbul": "^6.0.0",
+				"babel-preset-jest": "^26.3.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
-			"integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+			"integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"find-up": "^3.0.0",
-				"istanbul-lib-instrument": "^3.3.0",
-				"test-exclude": "^5.2.3"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-instrument": "^4.0.0",
+				"test-exclude": "^6.0.0"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
-			"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+			"integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
 			"dev": true,
 			"requires": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
+				"@types/babel__core": "^7.0.0",
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
-		"babel-preset-jest": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
-			"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+		"babel-preset-current-node-syntax": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^24.9.0"
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.8.3",
+				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
+			"integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-jest-hoist": "^26.2.0",
+				"babel-preset-current-node-syntax": "^0.1.3"
 			}
 		},
 		"balanced-match": {
@@ -3446,16 +4584,6 @@
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
 			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
 			"dev": true
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -3617,27 +4745,10 @@
 			}
 		},
 		"browser-process-hrtime": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 			"dev": true
-		},
-		"browser-resolve": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-			"dev": true,
-			"requires": {
-				"resolve": "1.1.7"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
-				}
-			}
 		},
 		"bs-logger": {
 			"version": "0.2.6",
@@ -3823,6 +4934,12 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
+		},
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true
 		},
 		"chardet": {
 			"version": "0.7.0",
@@ -4056,6 +5173,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collect-v8-coverage": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -4436,19 +5559,40 @@
 				}
 			}
 		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
 		"cssom": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+			"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
-			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "~0.3.6"
+			},
+			"dependencies": {
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+					"dev": true
+				}
 			}
 		},
 		"csv": {
@@ -4521,14 +5665,42 @@
 			}
 		},
 		"data-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+			"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "^2.0.3",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^8.0.0"
+			},
+			"dependencies": {
+				"tr46": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+					"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.1"
+					}
+				},
+				"webidl-conversions": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.0.tgz",
+					"integrity": "sha512-Sl4svq71j4kzaFD13uxkVl2AIsbj/xwp8NTM1VMhFRyNT1ZMTWaV6+Pva0fQs7y8+cAEPrDGfCAFLvJejhT79g==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^2.0.2",
+						"webidl-conversions": "^6.1.0"
+					}
+				}
 			}
 		},
 		"dataloader": {
@@ -4582,6 +5754,12 @@
 				}
 			}
 		},
+		"decimal.js": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+			"integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+			"dev": true
+		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -4598,6 +5776,12 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
 		"defaults": {
@@ -4684,9 +5868,9 @@
 			"dev": true
 		},
 		"detect-newline": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
 		"dezalgo": {
@@ -4700,9 +5884,9 @@
 			}
 		},
 		"diff-sequences": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
 			"dev": true
 		},
 		"dir-glob": {
@@ -4724,12 +5908,20 @@
 			}
 		},
 		"domexception": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+			"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "^5.0.0"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+					"dev": true
+				}
 			}
 		},
 		"dot-prop": {
@@ -4774,6 +5966,12 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"emittery": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+			"integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -4882,9 +6080,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
@@ -5679,17 +6877,97 @@
 			}
 		},
 		"expect": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
-			"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+			"integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-styles": "^3.2.0",
-				"jest-get-type": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-regex-util": "^24.9.0"
+				"@jest/types": "^26.3.0",
+				"ansi-styles": "^4.0.0",
+				"jest-get-type": "^26.3.0",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-regex-util": "^26.0.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"extend": {
@@ -5883,13 +7161,6 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
-		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -6039,629 +7310,11 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-			"integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"bindings": "^1.5.0",
-				"nan": "^2.12.1",
-				"node-pre-gyp": "*"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-					"dev": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true,
-					"optional": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-					"dev": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true,
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-					"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
-					"dev": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true,
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true,
-					"optional": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true,
-					"optional": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-					"dev": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-					"dev": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-					"dev": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-					"dev": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-					"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-					"dev": true,
-					"optional": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-					"dev": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true,
-					"optional": true
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.9.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-					"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"debug": "^3.2.6",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-					"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4.4.2"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-					"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"npm-normalize-package-bin": "^1.0.1"
-					}
-				},
-				"npm-normalize-package-bin": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-					"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-					"dev": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.4.7",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
-					"integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"dev": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"dev": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-					"dev": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true,
-					"optional": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-					"dev": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-					"dev": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true,
-					"optional": true
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-					"dev": true,
-					"optional": true
-				}
-			}
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -6726,6 +7379,12 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
 			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+			"dev": true
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
 		"get-pkg-repo": {
@@ -7186,7 +7845,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"handlebars": {
 			"version": "4.7.6",
@@ -7305,18 +7965,18 @@
 			"dev": true
 		},
 		"html-encoding-sniffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+			"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "^1.0.5"
 			}
 		},
 		"html-escaper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-			"integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
 		"http-cache-semantics": {
@@ -7821,19 +8481,16 @@
 				}
 			}
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
 			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
+		},
+		"ip-regex": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
 			"dev": true
 		},
 		"is-accessor-descriptor": {
@@ -7934,6 +8591,13 @@
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
 			"dev": true
 		},
+		"is-docker": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+			"dev": true,
+			"optional": true
+		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -8017,6 +8681,12 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"is-potential-custom-element-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+			"dev": true
+		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -8090,10 +8760,14 @@
 			"dev": true
 		},
 		"is-wsl": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -8120,24 +8794,21 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+			"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
 			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 			"dev": true,
 			"requires": {
-				"@babel/generator": "^7.4.0",
-				"@babel/parser": "^7.4.3",
-				"@babel/template": "^7.4.0",
-				"@babel/traverse": "^7.4.3",
-				"@babel/types": "^7.4.0",
-				"istanbul-lib-coverage": "^2.0.5",
-				"semver": "^6.0.0"
+				"@babel/core": "^7.7.5",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.0.0",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -8149,53 +8820,56 @@
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"supports-color": "^6.1.0"
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^3.0.0",
+				"supports-color": "^7.1.0"
 			},
 			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 					"dev": true,
 					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
+						"semver": "^6.0.0"
 					}
 				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				},
 				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+			"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"rimraf": "^2.6.3",
+				"istanbul-lib-coverage": "^3.0.0",
 				"source-map": "^0.6.1"
 			},
 			"dependencies": {
@@ -8208,26 +8882,10 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
 				},
 				"source-map": {
@@ -8239,29 +8897,63 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-			"integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
 			"dev": true,
 			"requires": {
-				"html-escaper": "^2.0.0"
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
 			}
 		},
 		"jest": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
+			"integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
 			"dev": true,
 			"requires": {
-				"import-local": "^2.0.0",
-				"jest-cli": "^24.9.0"
+				"@jest/core": "^26.4.2",
+				"import-local": "^3.0.2",
+				"jest-cli": "^26.4.2"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
 				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
 				},
 				"camelcase": {
 					"version": "5.3.1",
@@ -8269,110 +8961,132 @@
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-					"dev": true
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
 				},
 				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
 					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
 				},
 				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
 				"import-local": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+					"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
 					"dev": true,
 					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
-					}
-				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-					"dev": true,
-					"requires": {
-						"ci-info": "^2.0.0"
+						"pkg-dir": "^4.2.0",
+						"resolve-cwd": "^3.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
 				"jest-cli": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
+					"integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^24.9.0",
-						"@jest/test-result": "^24.9.0",
-						"@jest/types": "^24.9.0",
-						"chalk": "^2.0.1",
+						"@jest/core": "^26.4.2",
+						"@jest/test-result": "^26.3.0",
+						"@jest/types": "^26.3.0",
+						"chalk": "^4.0.0",
 						"exit": "^0.1.2",
-						"import-local": "^2.0.0",
+						"graceful-fs": "^4.2.4",
+						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^24.9.0",
-						"jest-util": "^24.9.0",
-						"jest-validate": "^24.9.0",
+						"jest-config": "^26.4.2",
+						"jest-util": "^26.3.0",
+						"jest-validate": "^26.4.2",
 						"prompts": "^2.0.1",
-						"realpath-native": "^1.1.0",
-						"yargs": "^13.3.0"
+						"yargs": "^15.3.1"
 					}
 				},
 				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "^4.1.0"
 					}
 				},
 				"p-limit": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^2.2.0"
 					}
 				},
 				"p-try": {
@@ -8381,74 +9095,99 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
 				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
 					"dev": true,
 					"requires": {
-						"find-up": "^3.0.0"
+						"find-up": "^4.0.0"
 					}
 				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+				"resolve-cwd": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+					"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+					"dev": true,
+					"requires": {
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
 				},
 				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				},
 				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"yargs": {
-					"version": "13.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 					"dev": true,
 					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
 						"get-caller-file": "^2.0.1",
 						"require-directory": "^2.1.1",
 						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
+						"string-width": "^4.2.0",
 						"which-module": "^2.0.0",
 						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.1"
+						"yargs-parser": "^18.1.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "13.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -8458,403 +9197,1520 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
-			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
+			"integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"execa": "^1.0.0",
-				"throat": "^4.0.0"
+				"@jest/types": "^26.3.0",
+				"execa": "^4.0.0",
+				"throat": "^5.0.0"
 			},
 			"dependencies": {
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					},
-					"dependencies": {
-						"cross-spawn": {
-							"version": "6.0.5",
-							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-							"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-							"dev": true,
-							"requires": {
-								"nice-try": "^1.0.4",
-								"path-key": "^2.0.1",
-								"semver": "^5.5.0",
-								"shebang-command": "^1.2.0",
-								"which": "^1.2.9"
-							}
-						}
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
 		},
 		"jest-config": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
-			"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
+			"integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"babel-jest": "^24.9.0",
-				"chalk": "^2.0.1",
+				"@jest/test-sequencer": "^26.4.2",
+				"@jest/types": "^26.3.0",
+				"babel-jest": "^26.3.0",
+				"chalk": "^4.0.0",
+				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^24.9.0",
-				"jest-environment-node": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"jest-jasmine2": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"micromatch": "^3.1.10",
-				"pretty-format": "^24.9.0",
-				"realpath-native": "^1.1.0"
+				"graceful-fs": "^4.2.4",
+				"jest-environment-jsdom": "^26.3.0",
+				"jest-environment-node": "^26.3.0",
+				"jest-get-type": "^26.3.0",
+				"jest-jasmine2": "^26.4.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
+				"micromatch": "^4.0.2",
+				"pretty-format": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
 			}
 		},
 		"jest-diff": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-			"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+			"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff-sequences": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"chalk": "^3.0.0",
+				"diff-sequences": "^25.2.6",
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-docblock": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
-			"integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+			"integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "^3.0.0"
 			}
 		},
 		"jest-each": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
-			"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
+			"integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"@jest/types": "^26.3.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"pretty-format": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
-			"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
+			"integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jsdom": "^11.5.1"
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"jsdom": "^16.2.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-environment-node": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
-			"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
+			"integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-util": "^24.9.0"
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-get-type": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+			"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
-			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
+			"integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"anymatch": "^2.0.0",
+				"@jest/types": "^26.3.0",
+				"@types/graceful-fs": "^4.1.2",
+				"@types/node": "*",
+				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.7",
-				"graceful-fs": "^4.1.15",
-				"invariant": "^2.2.4",
-				"jest-serializer": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.9.0",
-				"micromatch": "^3.1.10",
+				"fsevents": "^2.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-regex-util": "^26.0.0",
+				"jest-serializer": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
+				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
 			}
 		},
 		"jest-jasmine2": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
-			"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
+			"integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
+				"@jest/environment": "^26.3.0",
+				"@jest/source-map": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"expect": "^24.9.0",
+				"expect": "^26.4.2",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"pretty-format": "^24.9.0",
-				"throat": "^4.0.0"
+				"jest-each": "^26.4.2",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-runtime": "^26.4.2",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"pretty-format": "^26.4.2",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-leak-detector": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
-			"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
+			"integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
-			"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+			"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"pretty-format": "^24.9.0"
+				"chalk": "^4.0.0",
+				"jest-diff": "^26.4.2",
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"diff-sequences": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-diff": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.0.0",
+						"diff-sequences": "^26.3.0",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
+					}
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-message-util": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
-			"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+			"integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
+				"@jest/types": "^26.3.0",
 				"@types/stack-utils": "^1.0.1",
-				"chalk": "^2.0.1",
-				"micromatch": "^3.1.10",
-				"slash": "^2.0.0",
-				"stack-utils": "^1.0.1"
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"micromatch": "^4.0.2",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.2"
 			},
 			"dependencies": {
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
 				}
 			}
 		},
 		"jest-mock": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
-			"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+			"integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0"
+				"@jest/types": "^26.3.0",
+				"@types/node": "*"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest-pnp-resolver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
 			"dev": true
 		},
 		"jest-regex-util": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
-			"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
-			"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
+			"integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"browser-resolve": "^1.11.3",
-				"chalk": "^2.0.1",
-				"jest-pnp-resolver": "^1.2.1",
-				"realpath-native": "^1.1.0"
-			}
-		},
-		"jest-resolve-dependencies": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
-			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.9.0"
-			}
-		},
-		"jest-runner": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
-			"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.4.2",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.9.0",
-				"jest-docblock": "^24.3.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-jasmine2": "^24.9.0",
-				"jest-leak-detector": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"jest-runtime": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-worker": "^24.6.0",
-				"source-map-support": "^0.5.6",
-				"throat": "^4.0.0"
-			}
-		},
-		"jest-runtime": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
-			"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
-			"dev": true,
-			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.9.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/transform": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/yargs": "^13.0.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.9.0",
-				"jest-haste-map": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-mock": "^24.9.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.9.0",
-				"jest-snapshot": "^24.9.0",
-				"jest-util": "^24.9.0",
-				"jest-validate": "^24.9.0",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
-				"strip-bom": "^3.0.0",
-				"yargs": "^13.3.0"
+				"@jest/types": "^26.3.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"jest-pnp-resolver": "^1.2.2",
+				"jest-util": "^26.3.0",
+				"read-pkg-up": "^7.0.1",
+				"resolve": "^1.17.0",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
 					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
 				},
 				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 					"dev": true
 				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
 				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "^4.1.0"
 					}
 				},
 				"p-limit": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^2.2.0"
 					}
 				},
 				"p-try": {
@@ -8863,71 +10719,542 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+				"parse-json": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-even-better-errors": "^2.3.0",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
+				"resolve": {
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true
+				}
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
+			"integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-snapshot": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-runner": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
+			"integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^26.3.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"emittery": "^0.7.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^26.4.2",
+				"jest-docblock": "^26.0.0",
+				"jest-haste-map": "^26.3.0",
+				"jest-leak-detector": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-resolve": "^26.4.0",
+				"jest-runtime": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-runtime": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
+			"integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^26.3.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/globals": "^26.4.2",
+				"@jest/source-map": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^26.4.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-message-util": "^26.3.0",
+				"jest-mock": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0",
+				"yargs": "^15.3.1"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
 				},
 				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 					"dev": true
 				},
 				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 					"dev": true,
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				},
 				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"yargs": {
-					"version": "13.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 					"dev": true,
 					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
 						"get-caller-file": "^2.0.1",
 						"require-directory": "^2.1.1",
 						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
+						"string-width": "^4.2.0",
 						"which-module": "^2.0.0",
 						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.1"
+						"yargs-parser": "^18.1.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "13.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -8937,149 +11264,569 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
-			"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
-			"dev": true
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
+			"integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"graceful-fs": "^4.2.4"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				}
+			}
 		},
 		"jest-snapshot": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
-			"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
+			"integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^24.9.0",
-				"chalk": "^2.0.1",
-				"expect": "^24.9.0",
-				"jest-diff": "^24.9.0",
-				"jest-get-type": "^24.9.0",
-				"jest-matcher-utils": "^24.9.0",
-				"jest-message-util": "^24.9.0",
-				"jest-resolve": "^24.9.0",
-				"mkdirp": "^0.5.1",
+				"@jest/types": "^26.3.0",
+				"@types/prettier": "^2.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^26.4.2",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^26.4.2",
+				"jest-get-type": "^26.3.0",
+				"jest-haste-map": "^26.3.0",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-resolve": "^26.4.0",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^24.9.0",
-				"semver": "^6.2.0"
+				"pretty-format": "^26.4.2",
+				"semver": "^7.3.2"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"diff-sequences": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-diff": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^4.0.0",
+						"diff-sequences": "^26.3.0",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
+					}
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
 		"jest-util": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
-			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+			"integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.9.0",
-				"@jest/fake-timers": "^24.9.0",
-				"@jest/source-map": "^24.9.0",
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"callsites": "^3.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.15",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
 				"is-ci": "^2.0.0",
-				"mkdirp": "^0.5.1",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.0"
+				"micromatch": "^4.0.2"
 			},
 			"dependencies": {
-				"callsites": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-					"dev": true
-				},
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-					"dev": true
-				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
-						"ci-info": "^2.0.0"
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
 					}
 				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
 				}
 			}
 		},
 		"jest-validate": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+			"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.9.0",
+				"@jest/types": "^26.3.0",
+				"camelcase": "^6.0.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^24.9.0"
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-get-type": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
 		"jest-watcher": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
-			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
+			"integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.9.0",
-				"@jest/types": "^24.9.0",
-				"@types/yargs": "^13.0.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"jest-util": "^24.9.0",
-				"string-length": "^2.0.0"
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"jest-util": "^26.3.0",
+				"string-length": "^4.0.1"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.11.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"dev": true
+				}
 			}
 		},
 		"jest-worker": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^6.1.0"
+				"supports-color": "^7.0.0"
 			},
 			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -9119,63 +11866,114 @@
 			"dev": true
 		},
 		"jsdom": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"version": "16.4.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+			"integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^5.5.3",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": "^1.0.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.9.1",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.3.0",
-				"nwsapi": "^2.0.7",
-				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.87.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.4",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^5.2.0",
+				"abab": "^2.0.3",
+				"acorn": "^7.1.1",
+				"acorn-globals": "^6.0.0",
+				"cssom": "^0.4.4",
+				"cssstyle": "^2.2.0",
+				"data-urls": "^2.0.0",
+				"decimal.js": "^10.2.0",
+				"domexception": "^2.0.1",
+				"escodegen": "^1.14.1",
+				"html-encoding-sniffer": "^2.0.1",
+				"is-potential-custom-element-name": "^1.0.0",
+				"nwsapi": "^2.2.0",
+				"parse5": "5.1.1",
+				"request": "^2.88.2",
+				"request-promise-native": "^1.0.8",
+				"saxes": "^5.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^3.0.1",
+				"w3c-hr-time": "^1.0.2",
+				"w3c-xmlserializer": "^2.0.0",
+				"webidl-conversions": "^6.1.0",
+				"whatwg-encoding": "^1.0.5",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^8.0.0",
+				"ws": "^7.2.3",
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "5.7.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+				"request": {
+					"version": "2.88.2",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+					"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+					"dev": true,
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.8.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.6",
+						"extend": "~3.0.2",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.2",
+						"har-validator": "~5.1.3",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.19",
+						"oauth-sign": "~0.9.0",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.2",
+						"safe-buffer": "^5.1.2",
+						"tough-cookie": "~2.5.0",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.3.2"
+					},
+					"dependencies": {
+						"tough-cookie": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+							"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+							"dev": true,
+							"requires": {
+								"psl": "^1.1.28",
+								"punycode": "^2.1.1"
+							}
+						}
+					}
+				},
+				"tough-cookie": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+					"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+					"dev": true,
+					"requires": {
+						"ip-regex": "^2.1.0",
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"tr46": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+					"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.1"
+					}
+				},
+				"webidl-conversions": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
 					"dev": true
 				},
 				"whatwg-url": {
-					"version": "6.5.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.0.tgz",
+					"integrity": "sha512-Sl4svq71j4kzaFD13uxkVl2AIsbj/xwp8NTM1VMhFRyNT1ZMTWaV6+Pva0fQs7y8+cAEPrDGfCAFLvJejhT79g==",
 					"dev": true,
 					"requires": {
 						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
-					}
-				},
-				"ws": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-					"dev": true,
-					"requires": {
-						"async-limiter": "~1.0.0"
+						"tr46": "^2.0.2",
+						"webidl-conversions": "^6.1.0"
 					}
 				}
 			}
@@ -9190,6 +11988,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
+			"integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==",
 			"dev": true
 		},
 		"json-schema": {
@@ -9272,12 +12076,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true
-		},
-		"left-pad": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
 			"dev": true
 		},
 		"lerna": {
@@ -9981,9 +12779,9 @@
 			}
 		},
 		"make-error": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true
 		},
 		"make-fetch-happen": {
@@ -10511,13 +13309,6 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
-		"nan": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-			"dev": true,
-			"optional": true
-		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10632,16 +13423,44 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+			"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
-				"is-wsl": "^1.1.0",
-				"semver": "^5.5.0",
+				"is-wsl": "^2.2.0",
+				"semver": "^7.3.2",
 				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"uuid": "^8.3.0",
+				"which": "^2.0.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true,
+					"optional": true
+				},
+				"uuid": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+					"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+					"dev": true,
+					"optional": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"nopt": {
@@ -11051,13 +13870,10 @@
 			"dev": true
 		},
 		"p-each-series": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-			"dev": true,
-			"requires": {
-				"p-reduce": "^1.0.0"
-			}
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+			"integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+			"dev": true
 		},
 		"p-filter": {
 			"version": "2.1.0",
@@ -11221,9 +14037,9 @@
 			}
 		},
 		"parse5": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -11331,12 +14147,6 @@
 				"semver-compare": "^1.0.0"
 			}
 		},
-		"pn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
-		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -11356,21 +14166,52 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+			"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-regex": "^4.0.0",
-				"ansi-styles": "^3.2.0",
-				"react-is": "^16.8.4"
+				"@jest/types": "^25.5.0",
+				"ansi-regex": "^5.0.0",
+				"ansi-styles": "^4.0.0",
+				"react-is": "^16.12.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 					"dev": true
 				}
 			}
@@ -11404,13 +14245,13 @@
 			}
 		},
 		"prompts": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
-			"integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
 			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.3"
+				"sisteransi": "^1.0.4"
 			}
 		},
 		"promzard": {
@@ -11619,15 +14460,6 @@
 				"once": "^1.3.0"
 			}
 		},
-		"realpath-native": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
-			"dev": true,
-			"requires": {
-				"util.promisify": "^1.0.0"
-			}
-		},
 		"redent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -11722,21 +14554,29 @@
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.15"
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.3",
+				"request-promise-core": "1.1.4",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			}
@@ -11893,6 +14733,16 @@
 				"walker": "~1.0.5"
 			},
 			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"dev": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
 				"execa": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -11906,30 +14756,27 @@
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
-					},
-					"dependencies": {
-						"cross-spawn": {
-							"version": "6.0.5",
-							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-							"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-							"dev": true,
-							"requires": {
-								"nice-try": "^1.0.4",
-								"path-key": "^2.0.1",
-								"semver": "^5.5.0",
-								"shebang-command": "^1.2.0",
-								"which": "^1.2.9"
-							}
-						}
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
 		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+		"saxes": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+			"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+			"dev": true,
+			"requires": {
+				"xmlchars": "^2.2.0"
+			}
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -12006,7 +14853,8 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -12015,9 +14863,9 @@
 			"dev": true
 		},
 		"sisteransi": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-			"integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"dev": true
 		},
 		"slash": {
@@ -12381,9 +15229,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -12535,10 +15383,21 @@
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
-			"dev": true
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+			"integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
+			}
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -12599,28 +15458,28 @@
 			"dev": true
 		},
 		"string-length": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+			"integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -12735,6 +15594,33 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"supports-hyperlinks": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -12840,76 +15726,57 @@
 			"integrity": "sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg==",
 			"dev": true
 		},
-		"test-exclude": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+		"terminal-link": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.3",
-				"minimatch": "^3.0.4",
-				"read-pkg-up": "^4.0.0",
-				"require-main-filename": "^2.0.0"
+				"ansi-escapes": "^4.2.1",
+				"supports-hyperlinks": "^2.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"type-fest": "^0.11.0"
 					}
 				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
 					"dev": true
-				},
-				"read-pkg-up": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+				}
+			}
+		},
+		"test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 					"dev": true,
 					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
 				}
 			}
 		},
@@ -12944,9 +15811,9 @@
 			}
 		},
 		"throat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"dev": true
 		},
 		"through": {
@@ -13078,39 +15945,59 @@
 			"dev": true
 		},
 		"ts-jest": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
-			"integrity": "sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==",
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.2.0.tgz",
+			"integrity": "sha512-9+y2qwzXdAImgLSYLXAb/Rhq9+K4rbt0417b8ai987V60g2uoNWBBmMkYgutI7D8Zhu+IbCSHbBtrHxB9d7xyA==",
 			"dev": true,
 			"requires": {
+				"@types/jest": "26.x",
 				"bs-logger": "0.x",
 				"buffer-from": "1.x",
 				"fast-json-stable-stringify": "2.x",
+				"jest-util": "26.x",
 				"json5": "2.x",
 				"lodash.memoize": "4.x",
 				"make-error": "1.x",
-				"mkdirp": "0.x",
-				"resolve": "1.x",
-				"semver": "^5.5",
-				"yargs-parser": "10.x"
+				"mkdirp": "1.x",
+				"semver": "7.x",
+				"yargs-parser": "18.x"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
 				"json5": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
+						"minimist": "^1.2.5"
 					}
 				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				},
 				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -13325,6 +16212,12 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
+		},
 		"type-fest": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
@@ -13336,6 +16229,15 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
 		},
 		"typescript": {
 			"version": "3.8.3",
@@ -13515,71 +16417,6 @@
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
-		"util.promisify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
-			"integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.17.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.1.5",
-						"is-regex": "^1.0.5",
-						"object-inspect": "^1.7.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
-						"string.prototype.trimleft": "^2.1.1",
-						"string.prototype.trimright": "^2.1.1"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.3"
-					}
-				}
-			}
-		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -13591,6 +16428,25 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
 			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
+		},
+		"v8-to-istanbul": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
+			"integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^1.6.0",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				}
+			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -13623,12 +16479,21 @@
 			}
 		},
 		"w3c-hr-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+			"integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "^1.0.0"
+			}
+		},
+		"w3c-xmlserializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+			"integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+			"dev": true,
+			"requires": {
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"walker": {
@@ -13929,10 +16794,22 @@
 				}
 			}
 		},
+		"ws": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+			"dev": true
+		},
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@changesets/cli": "^2.4.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "@types/jest": "^24.0.25",
+    "@types/jest": "^26.0.10",
     "cross-env": "^5.2.1",
     "eslint": "^6.2.2",
     "eslint-import-resolver-typescript": "^2.0.0",
@@ -28,11 +28,11 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-tsdoc": "^0.2.5",
     "husky": "^4.2.5",
-    "jest": "^24.9.0",
+    "jest": "^26.4.2",
     "lerna": "^3.22.0",
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.1",
-    "ts-jest": "^24.0.2",
+    "ts-jest": "^26.2.0",
     "typescript": "3.8.3"
   },
   "prettier": {

--- a/packages/connect/src/__tests__/batching.tests.jsx
+++ b/packages/connect/src/__tests__/batching.tests.jsx
@@ -56,7 +56,12 @@ describe("batching", () => {
     expect(renderCount).toBe(2);
   });
 
-  test("should batch state changes inside native event listeners", () => {
+  /**
+   * Skip because it started failing when we upgraded to Jest 26, but we are
+   * going to remove it once we merge this PR anyway:
+   * https://github.com/frontity/frontity/pull/415.
+   */
+  test.skip("should batch state changes inside native event listeners", () => {
     expect(renderCount).toBe(1);
     expect(app).toMatchSnapshot();
     const batched = act(() =>

--- a/packages/frontity/src/index.ts
+++ b/packages/frontity/src/index.ts
@@ -24,7 +24,7 @@ import decodeServer from "./utils/decode/server";
 export const decode =
   typeof window !== "undefined" ? decodeClient : decodeServer;
 
-export { URL } from "url";
+export { default as URL } from "./utils/url";
 
 export { default as useFills } from "./utils/slot-and-fill/use-fills";
 export { default as Slot } from "./utils/slot-and-fill/slot";

--- a/packages/frontity/src/utils/__tests__/url.test.ts
+++ b/packages/frontity/src/utils/__tests__/url.test.ts
@@ -1,0 +1,14 @@
+import FrontityURL from "../url";
+
+describe("URL", () => {
+  it("should work like the built-in URL", () => {
+    const url = "https://domain.com/path?query=a";
+    expect(new FrontityURL(url)).toEqual(new URL(url));
+  });
+
+  it("should warn with the deprecation message", () => {
+    const warn = jest.spyOn(global.console, "warn");
+    new FrontityURL("http://domain.com");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontity/src/utils/decode/__tests__/decode.test.ts
+++ b/packages/frontity/src/utils/decode/__tests__/decode.test.ts
@@ -9,7 +9,7 @@ const mockedHe = he as jest.Mocked<typeof he>;
 describe("decode", () => {
   beforeEach(() => {
     mockedHe.decode.mockReset();
-    mockedHe.decode.mockImplementation(require.requireActual("he").decode);
+    mockedHe.decode.mockImplementation(jest.requireActual("he").decode);
   });
 
   test("works on server", () => {

--- a/packages/frontity/src/utils/url.ts
+++ b/packages/frontity/src/utils/url.ts
@@ -1,0 +1,37 @@
+/**
+ * DEPRECATED.
+ *
+ * To be removed in the v2 version. Now that we've deprecated Node 8,
+ * maintaining this is no longer required.
+ *
+ * It was meant to be used for compatibility with Node 8, where the global
+ * `URL` was not present and therefore this was not possible without importing
+ * URL from `"url"`.
+ *
+ * @example
+ * ```js
+ * const url = new URL("https://domain.com");
+ * ```
+ */
+
+import { warn } from "@frontity/error";
+
+/**
+ * Re-export to add a deprecation warning.
+ */
+class FrontityURL extends URL {
+  /**
+   * Overwrite the constructor to add a deprecation warning.
+   *
+   * @param input - The input of {@link NodeURL}.
+   * @param base - The base of {@link NodeURL}.
+   */
+  constructor(input: string, base?: string | URL) {
+    warn(
+      "Importing `URL` from Frontity has been deprecated. Please use `new URL()` instead."
+    );
+    super(input, base);
+  }
+}
+
+export default FrontityURL;

--- a/packages/head-tags/src/__tests__/__snapshots__/state.tests.ts.snap
+++ b/packages/head-tags/src/__tests__/__snapshots__/state.tests.ts.snap
@@ -212,8 +212,7 @@ exports[`state.headTags.get() (post entity) shows a warning message if \`state.f
 Array [
   Array [
     "Property \`state.headTags.links.transform\` is defined but \`state.frontity.url\` is not. All links in <head> tags pointing to other site (e.g. WordPress) instead to the Frontity site won't be changed.
-
-If you have any questions, join our community at https://community.frontity.org/.
+Visit https://community.frontity.org for help! 🙂
 ",
   ],
 ]
@@ -239,8 +238,7 @@ Array [
     }
   ]
 }
-
-If you have any questions, join our community at https://community.frontity.org/.
+Visit https://community.frontity.org for help! 🙂
 ",
   ],
 ]

--- a/packages/head-tags/src/utils/index.ts
+++ b/packages/head-tags/src/utils/index.ts
@@ -1,4 +1,3 @@
-import { URL } from "frontity";
 import {
   HeadTags,
   HeadTag,

--- a/packages/head-tags/src/utils/index.ts
+++ b/packages/head-tags/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { warn } from "frontity";
 import {
   HeadTags,
   HeadTag,
@@ -5,12 +6,6 @@ import {
   PostTypeWithHeadTags,
   TaxonomyWithHeadTags,
 } from "../../types";
-
-// Return a string inviting to ask questions in the community.
-const msg = (text: string) => `${text}
-
-If you have any questions, join our community at https://community.frontity.org/.
-`;
 
 // Attributes that could contain links.
 const possibleLink = ["href", "content"];
@@ -114,12 +109,10 @@ export const useFrontityLinks = ({
         try {
           json = JSON.parse(content);
         } catch (e) {
-          console.warn(
-            msg(
-              `The following content of a <script type="ld+json"> tag is not a valid JSON. Links in that tag will not be changed.
+          warn(
+            `The following content of a <script type="ld+json"> tag is not a valid JSON. Links in that tag will not be changed.
 
 ${content}`
-            )
           );
         }
 
@@ -211,10 +204,8 @@ export const getCurrentHeadTags = ({
 
   // Do not change links if `state.frontity.url` is not defined.
   if (!state.frontity || !state.frontity.url) {
-    console.warn(
-      msg(
-        "Property `state.headTags.links.transform` is defined but `state.frontity.url` is not. All links in <head> tags pointing to other site (e.g. WordPress) instead to the Frontity site won't be changed."
-      )
+    warn(
+      "Property `state.headTags.links.transform` is defined but `state.frontity.url` is not. All links in <head> tags pointing to other site (e.g. WordPress) instead to the Frontity site won't be changed."
     );
     return headTags;
   }

--- a/packages/wp-comments/src/index.ts
+++ b/packages/wp-comments/src/index.ts
@@ -1,4 +1,4 @@
-import { fetch, warn, URL } from "frontity";
+import { fetch, warn } from "frontity";
 import { commentsHandler } from "./libraries";
 import WpComments from "../types";
 

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -1,4 +1,4 @@
-import { URL, error } from "frontity";
+import { error } from "frontity";
 import WpSource from "../types";
 import { parse, normalize, concatPath } from "./libraries/route-utils";
 import { wpOrg, wpCom } from "./libraries/patterns";


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

I've updated Cypress and Jest to their latest versions.

I've deprecated the `URL` import from `"frontity"`, which was the only thing we had for backward compatibility with Node 8.

I've also fixed a couple of issues with Cypress e2e tests:

- Remove WP CLI containers after `run`.
- Remove all the containers (WP, MySQL, WP CLI) after Cypress has sucessfully run.
- Remove all the containers after an error.

**Why**:

<!-- Why are these changes necessary? -->

We've made several changes to our test system, I think it's good to keep it up to date with the latest Jest/Cypress versions.

Nobody supports Node 8 anymore. I think it's not even on maintenance anymore. All serverless platforms have updated to either Node 10 or Node 12. https://nodejs.org/en/about/releases/

**How**:

<!-- How were these changes implemented? -->

Simply by updating the dependencies and creating a wrapper around `URL` to warn about the deprecation.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->

I've added a dummy test to the end of the `wp-basic-tests` e2e tests, because if not Cypress was ignoring the previous test. I guess this is a bug in Cypress, maybe related to the `after` function.