### PR TITLE
Fix performance warning appearing in development

### DIFF
--- a/packages/core/src/config/webpack/__tests__/__snapshots__/index.ts.snap
+++ b/packages/core/src/config/webpack/__tests__/__snapshots__/index.ts.snap
@@ -78,7 +78,6 @@ Object {
       "publicPath": "/static/",
     },
     "performance": Object {
-      "hints": "warning",
       "maxAssetSize": 500000,
       "maxEntrypointSize": 500000,
     },
@@ -224,7 +223,6 @@ Object {
       "publicPath": "/static/",
     },
     "performance": Object {
-      "hints": "warning",
       "maxAssetSize": 500000,
       "maxEntrypointSize": 500000,
     },
@@ -357,7 +355,6 @@ Object {
       "publicPath": "/static/",
     },
     "performance": Object {
-      "hints": "warning",
       "maxAssetSize": 5000000,
       "maxEntrypointSize": 5000000,
     },
@@ -496,7 +493,6 @@ Object {
       "publicPath": "/static/",
     },
     "performance": Object {
-      "hints": "warning",
       "maxAssetSize": 500000,
       "maxEntrypointSize": 500000,
     },
@@ -634,7 +630,6 @@ Object {
       "publicPath": "/static/",
     },
     "performance": Object {
-      "hints": "warning",
       "maxAssetSize": 500000,
       "maxEntrypointSize": 500000,
     },
@@ -761,7 +756,6 @@ Object {
       "publicPath": "/static/",
     },
     "performance": Object {
-      "hints": "warning",
       "maxAssetSize": 5000000,
       "maxEntrypointSize": 5000000,
     },

--- a/packages/core/src/config/webpack/performance.ts
+++ b/packages/core/src/config/webpack/performance.ts
@@ -1,5 +1,5 @@
 import { Configuration } from "webpack";
-import { Target } from "../../../types";
+import { Target, Mode } from "../../../types";
 
 /**
  * The options of the {@link performance} function.
@@ -23,7 +23,6 @@ interface PerformanceOptions {
 const performance = ({
   target,
 }: PerformanceOptions): Configuration["performance"] => ({
-  hints: "warning",
   ...(target === "server"
     ? {
         // Max size recommended for the server bundle: 5Mbs.

--- a/packages/core/src/config/webpack/performance.ts
+++ b/packages/core/src/config/webpack/performance.ts
@@ -1,5 +1,5 @@
 import { Configuration } from "webpack";
-import { Target, Mode } from "../../../types";
+import { Target } from "../../../types";
 
 /**
  * The options of the {@link performance} function.


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

I have removed the `performance.hints` field I added in https://github.com/frontity/frontity/pull/547.

**Why**:

<!-- Why are these changes necessary? -->

Apparently that adds the warning also in development mode. It's the default anyway.

**How**:

<!-- How were these changes implemented? -->

By simply removing it from the Webpack configuration.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests

No changeset is necessary because this is a fix for an unreleased PR: https://github.com/frontity/frontity/pull/547

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] End to end tests
- [ ] TSDocs
- [ ] TypeScript
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- ignore-task-list-end -->

<!-- Feel free to add any additional comments. -->