### PR TITLE
Expose Webpack's errors and warnings in `frontity build`

### DIFF
--- a/.changeset/mighty-queens-leave.md
+++ b/.changeset/mighty-queens-leave.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": minor
+---
+
+Expose Webpack errors and warnings in the `npx frontity build` command.

--- a/.changeset/pink-fans-promise.md
+++ b/.changeset/pink-fans-promise.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Update chalk version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,19 @@
 						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
 					}
 				},
 				"debug": {
@@ -232,6 +245,19 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@babel/parser": {
@@ -368,6 +394,19 @@
 						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
 					}
 				}
 			}
@@ -407,6 +446,19 @@
 						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
 					}
 				},
 				"debug": {
@@ -579,6 +631,17 @@
 						"regenerator-runtime": "^0.13.2"
 					}
 				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"ci-info": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -738,6 +801,19 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.1.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@changesets/parse": {
@@ -797,6 +873,17 @@
 					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				}
 			}
@@ -2190,6 +2277,17 @@
 				"strong-log-transformer": "^2.0.0"
 			},
 			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"execa": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -2268,6 +2366,19 @@
 				"chalk": "^2.3.1",
 				"figgy-pudding": "^3.5.1",
 				"npmlog": "^4.1.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@lerna/collect-updates": {
@@ -2758,6 +2869,19 @@
 				"@lerna/query-graph": "3.18.5",
 				"chalk": "^2.3.1",
 				"columnify": "^1.5.4"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@lerna/log-packed": {
@@ -3405,6 +3529,17 @@
 				"write-json-file": "^3.2.0"
 			},
 			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"load-json-file": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
@@ -3869,9 +4004,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "11.15.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.4.tgz",
-			"integrity": "sha512-z7deEbNOPcS7pb7uyaZhbITh18ruGghYh86VmUL2zJPKeu9tEAqF0goQH0dhWamHoBJpkyWroNxPZjzNvbYVCw==",
+			"version": "12.12.54",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
+			"integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -4612,6 +4747,17 @@
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"cross-spawn": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -4923,17 +5069,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
 		},
 		"char-regex": {
 			"version": "1.0.2",
@@ -5559,19 +5694,6 @@
 				}
 			}
 		},
-		"cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-			"dev": true,
-			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
 		"cssom": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -5776,12 +5898,6 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
-		},
-		"deepmerge": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
 		"defaults": {
@@ -6163,6 +6279,17 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -7373,6 +7500,19 @@
 				"fs-extra": "^7.0.1",
 				"get-workspaces": "^0.5.2",
 				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"get-own-enumerable-property-symbols": {
@@ -8435,6 +8575,17 @@
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -9377,6 +9528,12 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"deepmerge": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+					"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 					"dev": true
 				},
 				"fill-range": {
@@ -14756,6 +14913,21 @@
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "6.0.5",
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+							"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+							"dev": true,
+							"requires": {
+								"nice-try": "^1.0.4",
+								"path-key": "^2.0.1",
+								"semver": "^5.5.0",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
 					}
 				},
 				"normalize-path": {
@@ -16054,6 +16226,17 @@
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
 				},
 				"cliui": {
 					"version": "5.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "babel-plugin-macros": "^2.8.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-polyfill": "^6.26.0",
+    "chalk": "^4.1.0",
     "core-js": "^3.0.1",
     "cross-spawn": "^7.0.2",
     "deepmerge": "^3.2.0",

--- a/packages/core/src/scripts/utils/webpack.ts
+++ b/packages/core/src/scripts/utils/webpack.ts
@@ -1,13 +1,32 @@
+import chalk from "chalk";
 import webpack from "webpack";
 
-// This is the same as running webpack() but async.
+/**
+ * Wrapper to run `webpack` asynchronously.
+ *
+ * @param config - Webpack's config object, defined in {@link
+ * webpack.Configuration}.
+ *
+ * @returns A promise that resolves when Webpack finishes.
+ */
 export const webpackAsync = (
   config: webpack.Configuration
 ): Promise<webpack.Compiler> =>
   new Promise((resolve, reject) => {
     const compiler = webpack(config);
-    compiler.run((err) => {
-      if (err) reject(err);
-      else resolve(compiler);
+    compiler.run((err, stats) => {
+      // Fatal Webpack errors, like wrong configuration.
+      if (err) return reject(err);
+
+      const info = stats.toJson();
+      // Compilation errors, like missing modules, syntax errors, etc.
+      if (stats.hasErrors()) return reject(new Error(info.errors.join("\n\n")));
+
+      // Compilation warnings, like dynamic modules, performance issues, etc.
+      if (stats.hasWarnings())
+        console.warn(`\n${chalk.yellow(info.warnings.join("\n\n"))}\n`);
+
+      // Compilation was successful.
+      return resolve(compiler);
     });
   });

--- a/packages/frontity/package.json
+++ b/packages/frontity/package.json
@@ -41,7 +41,7 @@
     "@frontity/type-declarations": "^1.1.0",
     "@frontity/types": "^1.4.2",
     "@loadable/component": "^5.10.1",
-    "chalk": "^2.4.2",
+    "chalk": "^4.1.0",
     "clipboardy": "^2.1.0",
     "commander": "^2.20.0",
     "detect-port-alt": "^1.1.6",


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

I've added error handling to the `npx frontity build` command.

Fatal Webpack errors, like wrong configurations:

<img width="551" alt="Screenshot 2020-09-01 at 12 01 19" src="https://user-images.githubusercontent.com/3305402/91838531-f1b48d00-ec4d-11ea-9e0e-52bd2f8581a1.png">

Compilation errors, like missing modules, syntax errors, etc:

<img width="544" alt="Screenshot 2020-09-01 at 12 02 08" src="https://user-images.githubusercontent.com/3305402/91838556-fd07b880-ec4d-11ea-9cfb-edc81c06466b.png">

Compilation warnings, like dynamic modules, performance issues, etc:

<img width="551" alt="Screenshot 2020-09-01 at 12 03 07" src="https://user-images.githubusercontent.com/3305402/91838577-05f88a00-ec4e-11ea-88d3-3455b69cfcc2.png">

**Why**:

<!-- Why are these changes necessary? -->

It's something that we didn't do due to the lack of time when we launched the v1.0 but that it is necessary.

Specifically, it's making hard to see the real errors on the Vercel deploy because they don't seem to be reproducible in the local environment using `npx frontity dev --prod`: https://community.frontity.org/t/deploying-to-vercel-issues/2695/19

Apart from that, it's very important for CI's where the command needs to stop the deployment if something goes wrong.

**How**:

<!-- How were these changes implemented? -->

I modified the function that runs `webpack` programmatically to handle the different types of errors.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] TSDocs
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->

It's not tested because we don't have tests for the CLI yet. I thought about adding unit tests but I don't think they would be useful as the tests will be tightly coupled with the implementation.