### PR TITLE
Add script to load Google Tag Manager container in its package

### DIFF
--- a/.changeset/tall-timers-mate.md
+++ b/.changeset/tall-timers-mate.md
@@ -1,0 +1,5 @@
+---
+"@frontity/google-tag-manager-analytics": patch
+---
+
+Add the script to load the Google Tag Manager container, that is needed to listen to default Google Tag Manager events.

--- a/e2e/integration/frontity-01/google-tag-manager-analytics.spec.js
+++ b/e2e/integration/frontity-01/google-tag-manager-analytics.spec.js
@@ -27,28 +27,28 @@ describe("Google Tag Manager", () => {
   });
 
   it("should have sent the first pageview", () => {
-    cy.window().its("dataLayer").its(0).should("deep.equal", pageviewHome);
+    cy.window().its("dataLayer").its(1).should("deep.equal", pageviewHome);
   });
 
   it("should sent a pageview if the page changes", () => {
     cy.get("button#change-link").click();
-    cy.window().its("dataLayer").its(1).should("deep.equal", pageviewSomePost);
+    cy.window().its("dataLayer").its(2).should("deep.equal", pageviewSomePost);
   });
 
   it("should sent pageviews when going back or forward", () => {
     cy.get("button#change-link").click();
     cy.go("back");
-    cy.window().its("dataLayer").its(2).should("deep.equal", pageviewHome);
+    cy.window().its("dataLayer").its(3).should("deep.equal", pageviewHome);
 
     cy.go("forward");
-    cy.window().its("dataLayer").its(3).should("deep.equal", pageviewSomePost);
+    cy.window().its("dataLayer").its(4).should("deep.equal", pageviewSomePost);
   });
 
   it("should send events", () => {
     // Wait for the first pageview to be sent.
-    cy.window().its("dataLayer").its(0).should("deep.equal", pageviewHome);
+    cy.window().its("dataLayer").its(1).should("deep.equal", pageviewHome);
     // Send event.
     cy.get("button#send-event").click();
-    cy.window().its("dataLayer").its(1).should("deep.equal", someEvent);
+    cy.window().its("dataLayer").its(2).should("deep.equal", someEvent);
   });
 });

--- a/packages/google-tag-manager-analytics/src/components/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/google-tag-manager-analytics/src/components/__tests__/__snapshots__/index.tsx.snap
@@ -4,7 +4,15 @@ exports[`GoogleTagManager doesn't add anything if there's no container ids 1`] =
 
 exports[`GoogleTagManager doesn't add anything if there's no container ids 2`] = `null`;
 
-exports[`GoogleTagManager works with a single container id 1`] = `"<script data-rh=\\"true\\" async=\\"true\\" src=\\"https://www.googletagmanager.com/gtm.js?id=GTM-XXXXXXX\\"></script>"`;
+exports[`GoogleTagManager works with a single container id 1`] = `
+"<script data-rh=\\"true\\" async=\\"true\\" src=\\"https://www.googletagmanager.com/gtm.js?id=GTM-XXXXXXX\\"></script><script data-rh=\\"true\\" >
+        var dataLayer = window.dataLayer || [];
+        dataLayer.push({
+          \\"gtm.start\\": new Date().getTime(),
+          event: \\"gtm.js\\",
+        })
+        </script>"
+`;
 
 exports[`GoogleTagManager works with a single container id 2`] = `
 <noscript>
@@ -29,7 +37,15 @@ exports[`GoogleTagManager works with a single container id 2`] = `
 </noscript>
 `;
 
-exports[`GoogleTagManager works with multiple container ids 1`] = `"<script data-rh=\\"true\\" async=\\"true\\" src=\\"https://www.googletagmanager.com/gtm.js?id=GTM-XXXXXXX\\"></script><script data-rh=\\"true\\" async=\\"true\\" src=\\"https://www.googletagmanager.com/gtm.js?id=GTM-YYYYYYY\\"></script>"`;
+exports[`GoogleTagManager works with multiple container ids 1`] = `
+"<script data-rh=\\"true\\" async=\\"true\\" src=\\"https://www.googletagmanager.com/gtm.js?id=GTM-XXXXXXX\\"></script><script data-rh=\\"true\\" async=\\"true\\" src=\\"https://www.googletagmanager.com/gtm.js?id=GTM-YYYYYYY\\"></script><script data-rh=\\"true\\" >
+        var dataLayer = window.dataLayer || [];
+        dataLayer.push({
+          \\"gtm.start\\": new Date().getTime(),
+          event: \\"gtm.js\\",
+        })
+        </script>"
+`;
 
 exports[`GoogleTagManager works with multiple container ids 2`] = `
 Array [

--- a/packages/google-tag-manager-analytics/src/components/index.tsx
+++ b/packages/google-tag-manager-analytics/src/components/index.tsx
@@ -34,6 +34,15 @@ const GtmCode: React.FC<GtmCodeProps> = ({ containerId }) => (
         async
         src={`https://www.googletagmanager.com/gtm.js?id=${containerId}`}
       />
+      <script>
+        {`
+        var dataLayer = window.dataLayer || [];
+        dataLayer.push({
+          "gtm.start": new Date().getTime(),
+          event: "gtm.js",
+        })
+      `}
+      </script>
     </Head>
     {/* Add the GTM noscript in the <body> */}
     <noscript>

--- a/packages/google-tag-manager-analytics/src/components/index.tsx
+++ b/packages/google-tag-manager-analytics/src/components/index.tsx
@@ -41,7 +41,7 @@ const GtmCode: React.FC<GtmCodeProps> = ({ containerId }) => (
           "gtm.start": new Date().getTime(),
           event: "gtm.js",
         })
-      `}
+        `}
       </script>
     </Head>
     {/* Add the GTM noscript in the <body> */}


### PR DESCRIPTION
**What**:

This Pull Request adds a `<script>` to the `@frontity/google-tag-manager-analytics` package to loads the container that is needed to listen to the default Google Tag Manager events like clicks.

**Why**:

This container, that isn't loaded right now, is needed to listen to the default Google Tag Manager events like clicks. There is more information about that in [this issue](https://github.com/frontity/frontity/issues/536#issuecomment-685465051).

**How**:

Adding the part of the [GTM recommend script](https://developers.google.com/tag-manager/quickstart) that is missing. Apart from that I've updated the snapshot for the unit tests and the indexes of the `dataLayer` array in the e2e tests.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Update community discussions
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)

<!-- ignore-task-list-end -->