### PR TITLE
Fix `new URL` type error in Safari

### DIFF
--- a/.changeset/modern-gorillas-relax.md
+++ b/.changeset/modern-gorillas-relax.md
@@ -1,0 +1,8 @@
+---
+"@frontity/google-ad-manager": patch
+"@frontity/head-tags": patch
+"@frontity/wp-comments": patch
+"@frontity/wp-source": patch
+---
+
+Do not import `URL` from `frontity` anymore.

--- a/.changeset/unlucky-cups-remain.md
+++ b/.changeset/unlucky-cups-remain.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Fix URL class wrapper in Safari.

--- a/packages/frontity/src/utils/url.ts
+++ b/packages/frontity/src/utils/url.ts
@@ -30,7 +30,8 @@ class FrontityURL extends URL {
     warn(
       "Importing `URL` from Frontity has been deprecated. Please use `new URL()` instead."
     );
-    super(input, base);
+    // Calling `new URL("http://some.url", undefined)` fails in Sarafi.
+    base ? super(input, base) : super(input);
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Avoid calling `new URL` with `undefined` in the second argument.

**Why**:

<!-- Why are these changes necessary? -->

It fails in Safari.

**How**:

<!-- How were these changes implemented? -->

Using a conditional.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Update community discussions
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->

I've also added changesets for the packages were the `URL` import from `frontity` was removed so people don't get a warning.