### PR TITLE
Respect the `{ force: true }` parameter in source.fetch() in postType handler

### DIFF
--- a/.changeset/smart-boxes-know.md
+++ b/.changeset/smart-boxes-know.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+Fix the issue where the `{ force: true }` option was not respected in the postType handler.

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
@@ -228,7 +228,7 @@ Object {
       "isReady": false,
     },
     "/post-1/": Object {
-      "id": 1,
+      "id": 2,
       "isFetching": false,
       "isPost": true,
       "isPostType": true,
@@ -282,6 +282,36 @@ Object {
       ],
       "featured_media": 1,
       "id": 1,
+      "link": "/post-1/",
+      "slug": "post-1",
+      "tags": Array [
+        1,
+      ],
+      "type": "post",
+    },
+    "2": Object {
+      "_embedded": Object {
+        "author": Array [
+          1,
+        ],
+        "wp:featuredmedia": Array [
+          1,
+        ],
+        "wp:term": Array [
+          Array [
+            1,
+          ],
+          Array [
+            1,
+          ],
+        ],
+      },
+      "author": 1,
+      "categories": Array [
+        1,
+      ],
+      "featured_media": 1,
+      "id": 2,
       "link": "/post-1/",
       "slug": "post-1",
       "tags": Array [

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -226,7 +226,7 @@ describe("attachment", () => {
     // Fetch entities
     await store.actions.source.fetch("/post-1");
 
-    // Restore the mock
+    // Restore the mock (just change the ID)
     api.get = jest.fn((_) =>
       Promise.resolve(mockResponse([{ ...post1, id: 2 }]))
     );
@@ -235,6 +235,17 @@ describe("attachment", () => {
     await store.actions.source.fetch("/post-1", { force: true });
 
     expect(store.state.source).toMatchSnapshot();
+
+    // Should have the new ID now
+    expect(store.state.source.get("/post-1").id).toEqual(2);
+
+    // Delete the ID's because there are different
+    const firstPost = store.state.source.post[1];
+    const secondPost = store.state.source.post[2];
+    delete firstPost.id;
+    delete secondPost.id;
+
+    expect(firstPost).toMatchObject(secondPost);
   });
 
   test("Every unknown URL should return a 404 even if it's substring matches a path", async () => {

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -239,7 +239,7 @@ describe("attachment", () => {
     // Should have the new ID now
     expect(store.state.source.get("/post-1").id).toEqual(2);
 
-    // Delete the ID's because there are different
+    // Delete the IDs because there are different
     const firstPost = store.state.source.post[1];
     const secondPost = store.state.source.post[2];
     delete firstPost.id;

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -226,10 +226,12 @@ describe("attachment", () => {
     // Fetch entities
     await store.actions.source.fetch("/post-1");
 
+    // Restore the mock
     api.get = jest.fn((_) =>
       Promise.resolve(mockResponse([{ ...post1, id: 2 }]))
     );
 
+    // Fetch again
     await store.actions.source.fetch("/post-1", { force: true });
 
     expect(store.state.source).toMatchSnapshot();

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -221,14 +221,15 @@ describe("attachment", () => {
   });
 
   test("overwrites the data when fetched with { force: true }", async () => {
-    // Mock Api responses
-    api.get = jest
-      .fn()
-      .mockResolvedValueOnce(mockResponse([post1]))
-      .mockResolvedValueOnce(mockResponse(attachment1));
+    api.get = jest.fn((_) => Promise.resolve(mockResponse([post1])));
 
     // Fetch entities
     await store.actions.source.fetch("/post-1");
+
+    api.get = jest.fn((_) =>
+      Promise.resolve(mockResponse([{ ...post1, id: 2 }]))
+    );
+
     await store.actions.source.fetch("/post-1", { force: true });
 
     expect(store.state.source).toMatchSnapshot();

--- a/packages/wp-source/src/libraries/handlers/postType.ts
+++ b/packages/wp-source/src/libraries/handlers/postType.ts
@@ -49,7 +49,7 @@ const postTypeHandler = ({
 }) => {
   // 1. search id in state or get the entity from WP REST API
   const { route, query } = libraries.source.parse(link);
-  if (!state.source.get(route).id) {
+  if (!state.source.get(route).id || force) {
     const { slug } = params;
 
     // 1.1 transform "posts" endpoint to state.source.postEndpoint


### PR DESCRIPTION
**What**:

Fix #577 . 

**Why**:

The `{force: true}` was not being respected in the postType handler.

**How**:

Fetch the data again if `force === true` in the postType handler.

**Tasks**:

- [x] Code
- [x] TypeScript
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] Update community discussions
- [ ] Update starter themes
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update other packages
- [ ] TypeScript tests
- [ ] End to end tests

<!-- ignore-task-list-end -->
