### PR TITLE
Catch error whill returning result in getMatch function

### DIFF
--- a/packages/wp-source/src/libraries/get-match.ts
+++ b/packages/wp-source/src/libraries/get-match.ts
@@ -77,8 +77,9 @@ export const getMatch = <Patt extends Pattern>(
     })
     .find(({ regexp }) => regexp.test(link));
 
-  return result
-    ? {
+  if (result) {
+    try {
+      return {
         func: result.func,
         params: result.pattern.startsWith("RegExp:")
           ? result.regexp.exec(link).groups
@@ -86,5 +87,11 @@ export const getMatch = <Patt extends Pattern>(
         name: result.name,
         pattern: result.pattern,
       }
-    : null;
+
+    } catch {
+      return null;
+    }
+  } else {
+    return null;
+  }
 };


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Adding a try/catch in the wp-source get-match.ts file, because the "extractParameters" function can cause the following error:
TypeError: Cannot read property 'slice' of null
      at extractParameters (webpack-internal:///./node_modules/@frontity/wp-source/src/libraries/get-match.ts:16:34)

**Why**:

Instead of returning a 404 Not Found error, the code is returning a 500 Internal Server error. Please see https://trashisfortossers.com/2015/07/day-1-upstate-new-york.html?spref=pi as an example.

**How**:

On my own personal fork and tested.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [ ] Code
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
