### PR TITLE
Normalize upper/lower case paths

### DIFF
--- a/.changeset/quick-flowers-pretend.md
+++ b/.changeset/quick-flowers-pretend.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+Make `libraries.source.normalize()` to lowercase the pathname of links. This fixes a bug when links with uppercase letters are visited.

--- a/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
+++ b/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
@@ -276,6 +276,10 @@ describe("route utils - normalize", () => {
     expect(normalize("/some/path")).toBe("/some/path/");
   });
 
+  test("from path (upper case)", () => {
+    expect(normalize("/SOME/PATH/")).toBe("/some/path/");
+  });
+
   test("from path and page", () => {
     expect(normalize("/some/path/page/2")).toBe("/some/path/page/2/");
   });

--- a/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
+++ b/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
@@ -288,6 +288,10 @@ describe("route utils - normalize", () => {
     expect(normalize("/some/path?k1=v1&k2=v2")).toBe("/some/path/?k1=v1&k2=v2");
   });
 
+  test("from path and query (upper case)", () => {
+    expect(normalize("/some/PATH?K1=V1&k2=v2")).toBe("/some/path/?K1=V1&k2=v2");
+  });
+
   test("from path, page and query", () => {
     expect(normalize("/some/path/page/2?k1=v1&k2=v2")).toBe(
       "/some/path/page/2/?k1=v1&k2=v2"

--- a/packages/wp-source/src/libraries/route-utils.ts
+++ b/packages/wp-source/src/libraries/route-utils.ts
@@ -146,7 +146,7 @@ const paramsToLink = ({
   const pathAndPage = page > 1 ? `${path}page/${page}/` : path;
   const queryString = objToQuery(query);
 
-  return `${pathAndPage}${queryString}${hash}`;
+  return `${pathAndPage.toLowerCase()}${queryString}${hash}`;
 };
 
 /**
@@ -181,6 +181,6 @@ export const stringify: WpSource["libraries"]["source"]["stringify"] = (
  * @returns The normalized link.
  */
 export const normalize = (link: string): string =>
-  paramsToLink(linkToParams(link.toLowerCase()));
+  paramsToLink(linkToParams(link));
 
 export default { parse, stringify, normalize };

--- a/packages/wp-source/src/libraries/route-utils.ts
+++ b/packages/wp-source/src/libraries/route-utils.ts
@@ -181,6 +181,6 @@ export const stringify: WpSource["libraries"]["source"]["stringify"] = (
  * @returns The normalized link.
  */
 export const normalize = (link: string): string =>
-  paramsToLink(linkToParams(link));
+  paramsToLink(linkToParams(link.toLowerCase()));
 
 export default { parse, stringify, normalize };


### PR DESCRIPTION
**What**:

Normalize upper/lower case paths.

**Why**:

If my request (Frontity) is /book/ABC, I expect to see the same result when I request /book/abc.

**How**:

Improving the route-utils/normalize function to force lower case path.

**Tasks**:

- [x] Code
- [x] Unit tests
- [x] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [x] Update community discussions
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
<!-- ignore-task-list-end -->

**Additional Comments**

- Community discussion: https://community.frontity.org/t/how-make-slug-case-insensitive/3138
- Issue: https://github.com/frontity/frontity/issues/604