### PR TITLE
Remove featured images min-height in twentytwenty-theme

### DIFF
--- a/.changeset/unlucky-rings-greet.md
+++ b/.changeset/unlucky-rings-greet.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Fix the extra height that is being added in the featured images of the twentytwenty-theme in mobile.

--- a/packages/twentytwenty-theme/src/components/post/featured-media.js
+++ b/packages/twentytwenty-theme/src/components/post/featured-media.js
@@ -39,7 +39,6 @@ export default connect(FeaturedMedia);
 const Figure = styled.figure`
   margin-top: 5rem;
   position: relative;
-  min-height: 300px;
 
   @media (min-width: 700px) {
     margin-top: 6rem;

--- a/packages/twentytwenty-theme/src/components/post/featured-media.js
+++ b/packages/twentytwenty-theme/src/components/post/featured-media.js
@@ -3,6 +3,15 @@ import { connect, styled } from "frontity";
 import Img from "@frontity/components/image";
 import SectionContainer from "../styles/section-container";
 
+/**
+ * The featured image/video of the post.
+ *
+ * @param props -
+ * - `state`: The Frontity state
+ * - `id`: The ID of the featured image/video.
+ * - `className`: Required in order to wrap the component with `styled()`.
+ * @returns React element.
+ */
 const FeaturedMedia = ({ state, id, className }) => {
   const media = state.source.attachment[id];
 


### PR DESCRIPTION
**What**:

Fix the extra height that is being added in the featured images of the twentytwenty-theme in mobile.

This is how it looks like right now:
![Screenshot from 2020-12-16 09-10-26](https://user-images.githubusercontent.com/34552881/102321966-a9ac4280-3f7e-11eb-833b-3f6bc2fc998d.png)

And this is how it would look after the fix:
![Screenshot from 2020-12-16 09-10-50](https://user-images.githubusercontent.com/34552881/102321992-b2047d80-3f7e-11eb-86d0-14626b2c0df9.png)

**Why**:

It's not part of the original design and it doesn't look good.

**How**:

I just removed the `min-height` css property.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [X] Code
- [X] Update starter themes
- [X] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
<!-- ignore-task-list-end -->
