### PR TITLE
Implement support for hash links in source and router

### DIFF
--- a/packages/tiny-router/src/__tests__/index.test.ts
+++ b/packages/tiny-router/src/__tests__/index.test.ts
@@ -73,6 +73,20 @@ describe("actions", () => {
       expect(store.state.router.link).toBe(normalized);
     });
 
+    test.only("should work with hash links", () => {
+      const store = createStore(config);
+      store.state.router.link = "/some-path/#some-div";
+
+      const link = "#some-div";
+      const normalized = "/some-path/#some-div";
+
+      normalize.mockReturnValue(normalized);
+
+      store.actions.router.set(link);
+      expect(normalize).toHaveBeenCalledWith("/some-path/#some-div");
+      expect(store.state.router.link).toBe(normalized);
+    });
+
     test("should populate latest link, method and state", () => {
       const store = createStore(config);
 

--- a/packages/tiny-router/src/actions.ts
+++ b/packages/tiny-router/src/actions.ts
@@ -40,6 +40,13 @@ export const set: TinyRouter["actions"]["router"]["set"] = ({
   actions,
   libraries,
 }) => (link, options = {}): void => {
+  if (!link.startsWith("/")) {
+    const parsed = libraries.source.parse(state.router.link);
+    delete parsed.hash;
+    delete parsed.query;
+    link = libraries.source.stringify(parsed) + link;
+  }
+
   // Normalizes link.
   if (libraries.source && libraries.source.normalize)
     link = libraries.source.normalize(link);

--- a/packages/tiny-router/types.ts
+++ b/packages/tiny-router/types.ts
@@ -25,6 +25,8 @@ interface TinyRouter extends Router {
   libraries: {
     source?: {
       normalize?: Source["libraries"]["source"]["normalize"];
+      parse?: Source["libraries"]["source"]["parse"];
+      stringify?: Source["libraries"]["source"]["stringify"];
     };
   };
 }

--- a/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
+++ b/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
@@ -29,6 +29,22 @@ Object {
 }
 `;
 
+exports[`actions.source.fetch should ignore the hash in the link 1`] = `
+Object {
+  "/some/route/": Object {
+    "id": 1,
+    "isFetching": false,
+    "isPostType": true,
+    "isReady": true,
+    "link": "/some/route/",
+    "page": 1,
+    "query": Object {},
+    "route": "/some/route/",
+    "type": "example",
+  },
+}
+`;
+
 exports[`actions.source.fetch should run again when \`force\` is used 1`] = `
 Object {
   "/some/route/": Object {

--- a/packages/wp-source/src/__tests__/actions.tests.ts
+++ b/packages/wp-source/src/__tests__/actions.tests.ts
@@ -79,6 +79,12 @@ describe("actions.source.fetch", () => {
     expect(store.state.source.data).toMatchSnapshot();
   });
 
+  test("should ignore the hash in the link", async () => {
+    await store.actions.source.fetch("/some/route/#some-div");
+    expect(handler.func).toHaveBeenCalledTimes(1);
+    expect(store.state.source.data).toMatchSnapshot();
+  });
+
   test("does nothing if data exists", async () => {
     store.state.source.data["/some/route/"] = {
       type: "example",

--- a/packages/wp-source/src/__tests__/state.tests.ts
+++ b/packages/wp-source/src/__tests__/state.tests.ts
@@ -37,6 +37,22 @@ describe("state.source.get", () => {
     expect(source.get("https://wp.site.test/some-post/")).toEqual(post);
   });
 
+  test("returns the correct object (path, hash)", () => {
+    const post = {
+      type: "post",
+      id: 1,
+      isPostType: true,
+      isReady: true,
+      isFetching: false,
+    };
+    const { source } = initStore({ "/some-post/": post }).state;
+    expect(source.get("/some-post#some-div")).toEqual(post);
+    expect(source.get("/some-post/#some-div")).toEqual(post);
+    expect(source.get("https://wp.site.test/some-post/#some-div")).toEqual(
+      post
+    );
+  });
+
   test("returns the correct object (path, page)", () => {
     const archive = {
       taxonomy: "tag",

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -20,7 +20,7 @@ const actions: WpSource["actions"]["source"] = {
     const { handlers, redirections } = libraries.source;
 
     // Get route and route params.
-    const link = normalize(route);
+    const link = normalize(route, { removeHash: true });
     const linkParams = parse(route);
     const { query, page, queryString } = linkParams;
 

--- a/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
+++ b/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
@@ -171,6 +171,27 @@ describe("route utils - parse", () => {
       queryString: "",
     });
   });
+
+  test("from hash", () => {
+    expect(parse("#some-div")).toEqual({
+      path: "/",
+      route: "/",
+      page: 1,
+      query: {},
+      queryString: "",
+      hash: "#some-div",
+    });
+  });
+  test("from path and hash", () => {
+    expect(parse("/some-path/#some-div")).toEqual({
+      path: "/some-path/",
+      route: "/some-path/",
+      page: 1,
+      query: {},
+      queryString: "",
+      hash: "#some-div",
+    });
+  });
 });
 
 describe("route utils - stringify", () => {
@@ -335,6 +356,11 @@ describe("route utils - normalize", () => {
   test("from name (page)", () => {
     expect(normalize("custom-list/page/2/")).toBe("custom-list/page/2/");
   });
+
+  test("from hash", () => {
+    expect(normalize("#some-div")).toBe("/#some-div");
+  });
+
   test("with option `removeHash`", () => {
     expect(normalize("/some-post#some-div", { removeHash: true })).toBe(
       "/some-post/"

--- a/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
+++ b/packages/wp-source/src/libraries/__tests__/route-utils.test.ts
@@ -335,4 +335,9 @@ describe("route utils - normalize", () => {
   test("from name (page)", () => {
     expect(normalize("custom-list/page/2/")).toBe("custom-list/page/2/");
   });
+  test("with option `removeHash`", () => {
+    expect(normalize("/some-post#some-div", { removeHash: true })).toBe(
+      "/some-post/"
+    );
+  });
 });

--- a/packages/wp-source/src/libraries/route-utils.ts
+++ b/packages/wp-source/src/libraries/route-utils.ts
@@ -127,16 +127,14 @@ const linkToParams = (link: string): LinkParams => {
  * Turn a set of Frontity link params into a string link.
  *
  * @param linkParams - The link params, defined by {@link LinkParams}.
+ * @param options - Options to remove some parts of the link.
  *
  * @returns The link, in string format.
  */
-const paramsToLink = ({
-  path = "/",
-  route,
-  page = 1,
-  query = {},
-  hash = "",
-}: LinkParams): string => {
+const paramsToLink = (
+  { path = "/", route, page = 1, query = {}, hash = "" }: LinkParams,
+  options: { removeHash: boolean } = { removeHash: false }
+): string => {
   // Use route if present, otherwise use path.
   path = route || path;
 
@@ -146,7 +144,9 @@ const paramsToLink = ({
   const pathAndPage = page > 1 ? `${path}page/${page}/` : path;
   const queryString = objToQuery(query);
 
-  return `${pathAndPage.toLowerCase()}${queryString}${hash}`;
+  return `${pathAndPage.toLowerCase()}${queryString}${
+    !options.removeHash ? hash : ""
+  }`;
 };
 
 /**
@@ -177,10 +177,13 @@ export const stringify: WpSource["libraries"]["source"]["stringify"] = (
  * @example `/some-post -> /some-post/`
  *
  * @param link - The link to be normalized.
+ * @param options - Options to remove some parts of the link.
  *
  * @returns The normalized link.
  */
-export const normalize = (link: string): string =>
-  paramsToLink(linkToParams(link));
+export const normalize = (
+  link: string,
+  options: { removeHash: boolean } = { removeHash: false }
+): string => paramsToLink(linkToParams(link), options);
 
 export default { parse, stringify, normalize };

--- a/packages/wp-source/src/libraries/route-utils.ts
+++ b/packages/wp-source/src/libraries/route-utils.ts
@@ -133,7 +133,7 @@ const linkToParams = (link: string): LinkParams => {
  */
 const paramsToLink = (
   { path = "/", route, page = 1, query = {}, hash = "" }: LinkParams,
-  options: { removeHash: boolean } = { removeHash: false }
+  options: { removeHash?: boolean } = { removeHash: false }
 ): string => {
   // Use route if present, otherwise use path.
   path = route || path;
@@ -183,7 +183,7 @@ export const stringify: WpSource["libraries"]["source"]["stringify"] = (
  */
 export const normalize = (
   link: string,
-  options: { removeHash: boolean } = { removeHash: false }
+  options: { removeHash?: boolean } = { removeHash: false }
 ): string => paramsToLink(linkToParams(link), options);
 
 export default { parse, stringify, normalize };

--- a/packages/wp-source/src/libraries/route-utils.ts
+++ b/packages/wp-source/src/libraries/route-utils.ts
@@ -133,7 +133,7 @@ const linkToParams = (link: string): LinkParams => {
  */
 const paramsToLink = (
   { path = "/", route, page = 1, query = {}, hash = "" }: LinkParams,
-  options: { removeHash?: boolean } = { removeHash: false }
+  options: ParamsToLinkOptions = { removeHash: false }
 ): string => {
   // Use route if present, otherwise use path.
   path = route || path;
@@ -183,7 +183,17 @@ export const stringify: WpSource["libraries"]["source"]["stringify"] = (
  */
 export const normalize = (
   link: string,
-  options: { removeHash?: boolean } = { removeHash: false }
+  options: ParamsToLinkOptions = { removeHash: false }
 ): string => paramsToLink(linkToParams(link), options);
+
+/**
+ * Options to remove some parts of the link in {@link paramsToLink} function.
+ */
+interface ParamsToLinkOptions {
+  /**
+   * Remove the hash part from the link.
+   */
+  removeHash?: boolean;
+}
 
 export default { parse, stringify, normalize };

--- a/packages/wp-source/src/state.ts
+++ b/packages/wp-source/src/state.ts
@@ -10,7 +10,7 @@ import {
 
 const state: WpSource["state"]["source"] = {
   get: ({ state }) => (link) => {
-    const normalizedLink = normalize(link);
+    const normalizedLink = normalize(link, { removeHash: true });
     const data = state.source.data[normalizedLink];
     if (data) {
       return data;


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
This is the work I did so far regarding the implementation of support for hash links in source and router.

**Why**:

Because currently hash links are not supported.

**How**:

Explained here: https://community.frontity.org/t/add-support-for-hash-links-in-frontity-tiny-router/3189

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [ ] Code
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
