### PR TITLE
Refactor E2E types and add missing tasks (missing commit)

### DIFF
--- a/e2e/integration/wordpress-01/head-tags-aioseop.spec.ts
+++ b/e2e/integration/wordpress-01/head-tags-aioseop.spec.ts
@@ -1,5 +1,11 @@
+import { ResolvePackages } from "../../../packages/types/src/utils";
+import Router from "../../../packages/router/types";
 import type { taskTypes } from "../../plugins";
 const task: taskTypes = cy.task;
+
+type WindowWithFrontity = Cypress.AUTWindow & {
+  frontity: ResolvePackages<Router>;
+};
 
 describe("Head Tags - All in One SEO Pack", () => {
   before(() => {
@@ -22,7 +28,7 @@ describe("Head Tags - All in One SEO Pack", () => {
    * @param link - The pathname to wich the test should navigate.
    * @returns The full url.
    */
-  const fullURL = (link) =>
+  const fullURL = (link: string) =>
     `http://localhost:3001${link}?frontity_name=head-tags`;
 
   /**
@@ -31,7 +37,7 @@ describe("Head Tags - All in One SEO Pack", () => {
    * @param link - The given link.
    * @param title - The page title for the given link.
    */
-  const checkTitle = (link, title) => {
+  const checkTitle = (link: string, title: string) => {
     it("should render the correct title", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get("title").should("contain", title);
@@ -44,7 +50,7 @@ describe("Head Tags - All in One SEO Pack", () => {
    *
    * @param link - The given link.
    */
-  const checkCanonical = (link) => {
+  const checkCanonical = (link: string) => {
     it("should render the correct canonical link", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get('link[rel="canonical"]').toMatchSnapshot();
@@ -57,7 +63,7 @@ describe("Head Tags - All in One SEO Pack", () => {
    *
    * @param link - The given link.
    */
-  const checkSchema = (link) => {
+  const checkSchema = (link: string) => {
     it("should render the schema tag", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get('script[type="application/ld+json"]').toMatchSnapshot();
@@ -70,8 +76,8 @@ describe("Head Tags - All in One SEO Pack", () => {
    *
    * @param link - The link of the page.
    */
-  const routerSet = (link) => {
-    cy.window().then((win) => {
+  const routerSet = (link: string) => {
+    cy.window().then((win: WindowWithFrontity) => {
       win.frontity.actions.router.set(link);
     });
   };

--- a/e2e/integration/wordpress-01/head-tags-wpseo.spec.ts
+++ b/e2e/integration/wordpress-01/head-tags-wpseo.spec.ts
@@ -1,5 +1,11 @@
+import { ResolvePackages } from "../../../packages/types/src/utils";
+import Router from "../../../packages/router/types";
 import type { taskTypes } from "../../plugins";
 const task: taskTypes = cy.task;
+
+type WindowWithFrontity = Cypress.AUTWindow & {
+  frontity: ResolvePackages<Router>;
+};
 
 describe("Head Tags - WP SEO", () => {
   before(() => {
@@ -24,7 +30,7 @@ describe("Head Tags - WP SEO", () => {
    * @param link - The pathname to wich the test should navigate.
    * @returns The full url.
    */
-  const fullURL = (link) =>
+  const fullURL = (link: string) =>
     `http://localhost:3001${link}?frontity_name=head-tags`;
 
   /**
@@ -33,7 +39,7 @@ describe("Head Tags - WP SEO", () => {
    * @param link - The given link.
    * @param title - The page title for the given link.
    */
-  const checkTitle = (link, title) => {
+  const checkTitle = (link: string, title: string) => {
     it("should render the correct title", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get("title").should("contain", title);
@@ -46,7 +52,7 @@ describe("Head Tags - WP SEO", () => {
    *
    * @param link - The given link.
    */
-  const checkCanonical = (link) => {
+  const checkCanonical = (link: string) => {
     it("should render the correct canonical link", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get('link[rel="canonical"]').toMatchSnapshot();
@@ -59,7 +65,7 @@ describe("Head Tags - WP SEO", () => {
    *
    * @param link - The given link.
    */
-  const checkCustomTag = (link) => {
+  const checkCustomTag = (link: string) => {
     it("should render a custom tag", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get('meta[name="custom-tag"]').toMatchSnapshot();
@@ -72,8 +78,8 @@ describe("Head Tags - WP SEO", () => {
    *
    * @param link - The link of the page.
    */
-  const routerSet = (link) => {
-    cy.window().then((win) => {
+  const routerSet = (link: string) => {
+    cy.window().then((win: WindowWithFrontity) => {
       win.frontity.actions.router.set(link);
     });
   };

--- a/e2e/integration/wordpress-01/head-tags-yoast-13.spec.ts
+++ b/e2e/integration/wordpress-01/head-tags-yoast-13.spec.ts
@@ -1,5 +1,11 @@
+import { ResolvePackages } from "../../../packages/types/src/utils";
+import Router from "../../../packages/router/types";
 import type { taskTypes } from "../../plugins";
 const task: taskTypes = cy.task;
+
+type WindowWithFrontity = Cypress.AUTWindow & {
+  frontity: ResolvePackages<Router>;
+};
 
 describe("Head Tags - Yoast 13.5", () => {
   before(() => {
@@ -22,7 +28,7 @@ describe("Head Tags - Yoast 13.5", () => {
    * @param link - The pathname to wich the test should navigate.
    * @returns The full url.
    */
-  const fullURL = (link) =>
+  const fullURL = (link: string) =>
     `http://localhost:3001${link}?frontity_name=head-tags`;
 
   /**
@@ -31,7 +37,7 @@ describe("Head Tags - Yoast 13.5", () => {
    * @param link - The given link.
    * @param title - The page title for the given link.
    */
-  const checkTitle = (link, title) => {
+  const checkTitle = (link: string, title: string) => {
     it("should render the correct title", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get("title").should("contain", title);
@@ -50,7 +56,7 @@ describe("Head Tags - Yoast 13.5", () => {
    * plugin we are using to generate snapshots gives an error when trying to
    * generate a snapshot for that tag (it also doesn't work well with strings).
    */
-  const checkMetaTags = (link) => {
+  const checkMetaTags = (link: string) => {
     it("should render the correct canonical URL", () => {
       cy.visitSSR(fullURL(link)).then(() => {
         cy.get('link[rel="canonical"]').toMatchSnapshot();
@@ -97,8 +103,8 @@ describe("Head Tags - Yoast 13.5", () => {
    *
    * @param link - The link of the page.
    */
-  const routerSet = (link) => {
-    cy.window().then((win) => {
+  const routerSet = (link: string) => {
+    cy.window().then((win: WindowWithFrontity) => {
       win.frontity.actions.router.set(link);
     });
   };


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

A fix I forgot to push to the https://github.com/frontity/frontity/pull/677 PR that adds `window.frontity` to some e2e tests.

**Why**:

<!-- Why are these changes necessary? -->

Because I forgot to push it 😓

**How**:

<!-- How were these changes implemented? -->

By redeclaring `window`.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] End to end tests
<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] Code
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
