### PR TITLE
Update e2e ads package dependencies and Cypress retries

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -14,7 +14,7 @@
   "taskTimeout": 60000,
   "baseUrl": "http://localhost:3001",
   "retries": {
-    "runMode": 1,
+    "runMode": 3,
     "openMode": 0
   }
 }

--- a/e2e/packages/ads/package.json
+++ b/e2e/packages/ads/package.json
@@ -9,9 +9,7 @@
   "dependencies": {
     "@frontity/source": "^1.2.0",
     "@frontity/router": "^1.0.19",
-    "frontity": "^1.4.3"
-  },
-  "devDependencies": {
+    "frontity": "^1.4.3",
     "@frontity/google-ad-manager": "^0.2.0"
   }
 }


### PR DESCRIPTION
**What**:
I just moved the devDependencies to dependencies in the e2e ads package and changed the cypress retries fields to 3.

**Why**:
In order to prevent future issues with the tests, as we have already encountered.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- ignore-task-list-end -->
