### PR TITLE
Revert "Forbidding local npm installs"

### DIFF
--- a/.changeset/lemon-walls-cough.md
+++ b/.changeset/lemon-walls-cough.md
@@ -1,0 +1,28 @@
+---
+"@frontity/analytics": patch
+"babel-plugin-frontity": patch
+"@frontity/components": patch
+"@frontity/comscore-analytics": patch
+"@frontity/connect": patch
+"@frontity/core": patch
+"create-frontity": patch
+"@frontity/error": patch
+"@frontity/file-settings": patch
+"frontity": patch
+"@frontity/google-ad-manager": patch
+"@frontity/google-analytics": patch
+"@frontity/google-tag-manager-analytics": patch
+"@frontity/head-tags": patch
+"@frontity/hooks": patch
+"@frontity/html2react": patch
+"@frontity/router": patch
+"@frontity/smart-adserver": patch
+"@frontity/source": patch
+"@frontity/tiny-router": patch
+"@frontity/types": patch
+"@frontity/wp-comments": patch
+"@frontity/wp-source": patch
+"@frontity/yoast": patch
+---
+
+Reverts the preinstall hook added for development workflows.

--- a/e2e/packages/ads/package.json
+++ b/e2e/packages/ads/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's ad libraries",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "@frontity/source": "^1.2.0",
     "@frontity/router": "^1.0.19",

--- a/e2e/packages/analytics/package.json
+++ b/e2e/packages/analytics/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's analytics library",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "@frontity/analytics": "^1.2.0",
     "@frontity/source": "^1.2.0",

--- a/e2e/packages/emotion/package.json
+++ b/e2e/packages/emotion/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.2",
   "private": true,
   "description": "Package to do e2e testing of Frontity's internal Emotion library",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3"
   }

--- a/e2e/packages/fonts/package.json
+++ b/e2e/packages/fonts/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.2",
   "private": true,
   "description": "Package to do e2e testing for fonts",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3"
   }

--- a/e2e/packages/head/package.json
+++ b/e2e/packages/head/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.5",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Head component",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3"
   }

--- a/e2e/packages/html2react/package.json
+++ b/e2e/packages/html2react/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Html2React package",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.5.0",
     "@frontity/html2react": "^1.2.0"

--- a/e2e/packages/iframe/package.json
+++ b/e2e/packages/iframe/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.2",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Iframe component",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "@frontity/components": "^1.3.0",
     "frontity": "^1.5.2"

--- a/e2e/packages/image/package.json
+++ b/e2e/packages/image/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.4",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Image component",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "@frontity/components": "^1.1.15",
     "frontity": "^1.4.3"

--- a/e2e/packages/loadable/package.json
+++ b/e2e/packages/loadable/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.1",
   "private": true,
   "description": "Package to do e2e testing of Frontity's loadable utility",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3"
   }

--- a/e2e/packages/preview/package.json
+++ b/e2e/packages/preview/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Preview",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3",
     "@frontity/source": "^1.3.0"

--- a/e2e/packages/render/package.json
+++ b/e2e/packages/render/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's rendering",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.12.0",
     "@frontity/router": "^1.1.1",

--- a/e2e/packages/script/package.json
+++ b/e2e/packages/script/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Script component",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "@frontity/components": "^1.1.15",
     "frontity": "^1.4.3"

--- a/e2e/packages/slot-and-fill/package.json
+++ b/e2e/packages/slot-and-fill/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Slot and Fill tools",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3"
   }

--- a/e2e/packages/smart-adserver/package.json
+++ b/e2e/packages/smart-adserver/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to run e2e tests of smart-adserver",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3",
     "@frontity/router": "^1.0.19",

--- a/e2e/packages/switch/package.json
+++ b/e2e/packages/switch/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's Switch component",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "@frontity/components": "^1.1.15",
     "frontity": "^1.4.3"

--- a/e2e/packages/tiny-router/package.json
+++ b/e2e/packages/tiny-router/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's tiny-router",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3",
     "@frontity/tiny-router": "^1.1.0"

--- a/e2e/packages/use-in-view/package.json
+++ b/e2e/packages/use-in-view/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's useInView hook",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3",
     "@frontity/hooks": "^2.0.0"

--- a/e2e/packages/wp-basic-tests/package.json
+++ b/e2e/packages/wp-basic-tests/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity and WordPress instances together",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "@frontity/components": "^1.5.1",
     "@frontity/source": "^1.2.2",

--- a/e2e/packages/wp-comments/package.json
+++ b/e2e/packages/wp-comments/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to run e2e tests of wp-comments",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3",
     "@frontity/wp-comments": "^0.2.1"

--- a/e2e/packages/wp-source-errors/package.json
+++ b/e2e/packages/wp-source-errors/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Package to do e2e testing of Frontity's wp-source errors",
-  "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\""
-  },
   "dependencies": {
     "frontity": "^1.4.3",
     "@frontity/source": "^1.3.1",

--- a/e2e/project/package.json
+++ b/e2e/project/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "A project to start sites for e2e testing",
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "dev": "frontity dev",
     "dev:inspect": "node --inspect -r ts-node/register/transpile-only ./node_modules/.bin/frontity dev",
     "build": "frontity build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "lerna run test:ci --stream",
     "test:ci": "jest --clearCache && lerna run test:ci --stream",
     "codecov": "curl -s https://codecov.io/bash | bash -s",
-    "prepare": "lerna bootstrap --hoist --ignore-scripts && lerna run prepublish",
+    "prepare": "lerna bootstrap --hoist",
     "reinstall": "lerna clean --yes && npm run prepare"
   },
   "workspaces": [

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -17,7 +17,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --passWithNoTests --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"

--- a/packages/babel-plugin-frontity/package.json
+++ b/packages/babel-plugin-frontity/package.json
@@ -17,7 +17,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,7 +15,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"

--- a/packages/comscore-analytics/package.json
+++ b/packages/comscore-analytics/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -19,7 +19,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand",

--- a/packages/create-frontity/package.json
+++ b/packages/create-frontity/package.json
@@ -22,7 +22,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "start": "node src/index.js"
   },
   "dependencies": {

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -15,7 +15,6 @@
     "url": "git+https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"

--- a/packages/file-settings/package.json
+++ b/packages/file-settings/package.json
@@ -18,7 +18,6 @@
     "url": "https://github.com/frontity/frontity/issues"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand",

--- a/packages/frontity/package.json
+++ b/packages/frontity/package.json
@@ -21,7 +21,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "start": "node dist/src/cli/index.js",
     "dev": "ts-node src/cli/index.ts",
     "ts": "ts-node",

--- a/packages/google-ad-manager/package.json
+++ b/packages/google-ad-manager/package.json
@@ -17,7 +17,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/google-analytics/package.json
+++ b/packages/google-analytics/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/google-tag-manager-analytics/package.json
+++ b/packages/google-tag-manager-analytics/package.json
@@ -17,7 +17,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/head-tags/package.json
+++ b/packages/head-tags/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -17,7 +17,6 @@
   },
   "sideEffects": false,
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --passWithNoTests --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/html2react/package.json
+++ b/packages/html2react/package.json
@@ -16,7 +16,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -16,7 +16,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --clearCache && ../../node_modules/.bin/jest"
   },

--- a/packages/smart-adserver/package.json
+++ b/packages/smart-adserver/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -17,7 +17,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --clearCache && ../../node_modules/.bin/jest --watch"
   },

--- a/packages/tiny-router/package.json
+++ b/packages/tiny-router/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/.bin/jest --watch --no-cache --runInBand"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,6 @@
     "url": "https://community.frontity.org"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --clearCache && ../../node_modules/.bin/jest"
   },

--- a/packages/wp-comments/package.json
+++ b/packages/wp-comments/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/wp-source/package.json
+++ b/packages/wp-source/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/packages/yoast/package.json
+++ b/packages/yoast/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/frontity/frontity.git"
   },
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "test:ci": "../../node_modules/.bin/jest --ci --coverage",
     "test": "../../node_modules/.bin/jest --watch",
     "test:inspect": "node --inspect ../../node_modules/jest/bin/jest.js --watch --no-cache --runInBand"

--- a/projects/mars-theme-ts/package.json
+++ b/projects/mars-theme-ts/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "A simple Frontity project using mars-theme and a TypeScript frontity settings for testing purposes",
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "dev": "frontity dev",
     "dev:inspect": "node --inspect -r ts-node/register/transpile-only ./node_modules/.bin/frontity dev",
     "build": "frontity build",

--- a/projects/mars-theme/package.json
+++ b/projects/mars-theme/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "A simple Frontity project using mars-theme for testing purposes",
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "dev": "frontity dev",
     "dev:inspect": "node --inspect -r ts-node/register/transpile-only ./node_modules/.bin/frontity dev",
     "build": "frontity build",

--- a/projects/twentytwenty-theme/package.json
+++ b/projects/twentytwenty-theme/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "A simple Frontity project using twentytwenty-theme for testing purposes",
   "scripts": {
-    "preinstall": "node -e \"console.error('Please run \\'npm install\\' in the root.\\n'); process.exit(1);\"",
     "dev": "frontity dev",
     "dev:inspect": "node --inspect -r ts-node/register/transpile-only ./node_modules/.bin/frontity dev",
     "build": "frontity build",


### PR DESCRIPTION
Reverts frontity/frontity#639.

The `preinstall` script, since it's part of the package.json file, will end-up in the published packages on npm and it's gonna throw for users who'll want to try `npx create frontity my-app`.

Temporary reverting this to push a new release.