### PR TITLE
Add correct context to replaceLocation

### DIFF
--- a/.changeset/healthy-bugs-thank.md
+++ b/.changeset/healthy-bugs-thank.md
@@ -1,0 +1,5 @@
+---
+"@frontity/tiny-router": patch
+---
+
+Pass the correct context to replaceLocation to prevent and Illegal invocation in external redirects from client side navigation.

--- a/packages/tiny-router/src/actions.ts
+++ b/packages/tiny-router/src/actions.ts
@@ -121,7 +121,8 @@ export const init: TinyRouter["actions"]["router"]["init"] = ({
     // Wrap `window.replace.location` so we can mock it in the e2e tests.
     // This is required because `window.location` is protected by the browser
     // and can't be modified.
-    window.replaceLocation = window.replaceLocation || window.location.replace;
+    window.replaceLocation =
+      window.replaceLocation || window.location.replace.bind(window.location);
 
     // Observe the current data object. If it is ever a redirection, replace the
     // current link with the new one.


### PR DESCRIPTION
**What**:

Pass the correct context to ` replaceLocation` to prevent an `Illegal invocation`. There aren't tests for this, but I tested it manually and it seems to be working now in the `mars-theme` project.

**Why**:

With the new redirects feature, the external redirects aren't working properly in client side navigation because it returns an Illegal invocation.

**How**:

Use `bind` with `window.location` instead of just `window.location.replace`

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
