### PR TITLE
Remove "e2e" from tsconfig.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "allowJs": true
   },
   "exclude": ["**/node_modules/*", "**/dist/*", "**/build/*", "e2e/e2e.js"],
-  "include": ["packages", "projects", "e2e"]
+  "include": ["packages", "projects"]
 }


### PR DESCRIPTION
**What**:

Remove "e2e" from the array of `include` in the `tsconfig.json` at the repo root.

**Why**:

It fixes the problem that appeared recently when types of jest in unit tests are overriden by types from cypress: 

<img width="838" alt="Screen Shot 2021-01-29 at 7 50 44 PM" src="https://user-images.githubusercontent.com/5417266/106623458-9fe89980-6542-11eb-863e-c75051f0c779.png">

<img width="433" alt="Screen Shot 2021-01-29 at 7 42 38 PM" src="https://user-images.githubusercontent.com/5417266/106623479-a4ad4d80-6542-11eb-81bf-3e31c11621db.png">

