### PR TITLE
Remove React import from create-package step

### DIFF
--- a/.changeset/strong-poets-sell.md
+++ b/.changeset/strong-poets-sell.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Remove React import from `npx frontity create-package` command.

--- a/packages/frontity/src/steps/create-package.ts
+++ b/packages/frontity/src/steps/create-package.ts
@@ -79,9 +79,7 @@ export const createSrcIndexJs = async (
   packagePath: string
 ) => {
   const filePath = resolvePath(projectPath, packagePath, "src/index.js");
-  const fileData = `import React from "react";
-
-const Root = () => {
+  const fileData = `const Root = () => {
   return (
     <>
       You can edit your package in:


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

I removed the `import React from "react"` line from the template of `npx frontity create-package`.

**Why**:

<!-- Why are these changes necessary? -->

This is not required anymore with the new JSX.

**How**:

<!-- How were these changes implemented? -->

Simply removing the line.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->

We don't have e2e tests for the CLI yet, so I didn't add anything else.