### PR TITLE
CLI: Fix `installPackage` step of create-package to make it work with npm 7

### DIFF
--- a/.changeset/curvy-ways-kiss.md
+++ b/.changeset/curvy-ways-kiss.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Fix the `create-package` command to work with npm 7

--- a/packages/frontity/src/steps/create-package.ts
+++ b/packages/frontity/src/steps/create-package.ts
@@ -113,5 +113,5 @@ export const installPackage = async (
   projectPath: string,
   packagePath: string
 ) => {
-  await promisify(exec)(`npm install ${packagePath}`, { cwd: projectPath });
+  await promisify(exec)(`npm install ./${packagePath}`, { cwd: projectPath });
 };


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found in the
https://docs.frontity.org/contributing/code-contributions.
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Fix the `npx frontity create-package` command that is failing if **npm 7** is used, returning the following error:

```
npm ERR! fatal: Could not read from remote repository. 
```

**Why**:

<!-- Why are these changes necessary? -->

To make that command work with the latest version of npm. A user mentioned this problem in the community: https://community.frontity.org/t/npx-frontity-create-package-theme-error/3966

**How**:

<!-- How were these changes implemented? -->

Just adding `./` before the package path when the generated package is about to be installed.

When running `npx frontity create-package my-first-package`, the package path is `packages/my-first-package`. Once the package is created, it's installed via `npm install ${packagePath}` (e.g. `npm install packages/my-first-package`). That command used to work fine with npm 6, but not anymore.

Taking a look at the [npm-install docs](https://docs.npmjs.com/cli/v7/commands/npm-install), it seems that npm is considering `packages/my-first-package` as `githubname/reponame`, so that's the reason it fails with a

```
npm ERR! fatal: Could not read from remote repository. 
```

BTW, The `githubname/reponame` case was covered also in npm 6 so I don't understand why it wasn't failing before. :shrug: 

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Open an issue for this feature in the [docs repo](https://github.com/frontity/docs/wiki/Code-Releases)
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
