### PR TITLE
Change CLI webhook to n8n instead of Integromat

### DIFF
--- a/.changeset/breezy-files-tell.md
+++ b/.changeset/breezy-files-tell.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Change CLI webhook to point to n8n instead of Integromat.

--- a/packages/frontity/src/steps/index.ts
+++ b/packages/frontity/src/steps/index.ts
@@ -312,12 +312,15 @@ export const subscribe = async (email: string) => {
   if (!isEmailValid(email))
     throw new Error("Email not valid. Please enter a valid email.");
 
-  return fetch("https://hook.integromat.com/gm0b502jo5acuhzko7gszx0kd9r52ofi", {
-    method: "POST",
-    body: JSON.stringify({
-      event: "frontity-subscribe",
-      email: email.toLowerCase(),
-    }),
-    headers: { "Content-Type": "application/json" },
-  });
+  return fetch(
+    "https://n8n.frontity.org/webhook/62923334-59a4-484c-a9c2-632814b94225",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        event: "frontity-subscribe",
+        email: email.toLowerCase(),
+      }),
+      headers: { "Content-Type": "application/json" },
+    }
+  );
 };


### PR DESCRIPTION
**What**:

Change CLI webhook to n8n.

**Why**:

To stop using Integromat.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->