### PR TITLE
Fetch data asynchronously in the postType handler

### DIFF
--- a/.changeset/young-dots-rest.md
+++ b/.changeset/young-dots-rest.md
@@ -1,0 +1,9 @@
+---
+"@frontity/wp-source": patch
+---
+
+Add a performance improvement for a postType handler.
+
+Until now, we were fetching the data serially in the postType handler for each
+of `post`, `page` and `media` endpoints. With this improvement, the data is
+loaded and processed in parallel for all 3 endpoints.

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -86,7 +86,7 @@ describe("postType", () => {
   });
 });
 
-describe.only("post", () => {
+describe("post", () => {
   test("doesn't exist in source.post", async () => {
     // Mock Api responses
     api.get = jest.fn().mockResolvedValue(mockResponse([post1]));
@@ -225,8 +225,9 @@ describe("page", () => {
     // Mock Api responses
     api.get = jest
       .fn()
-      .mockResolvedValueOnce(mockResponse([]))
-      .mockResolvedValueOnce(mockResponse([page1]));
+      .mockResolvedValueOnce(mockResponse([])) // post
+      .mockResolvedValueOnce(mockResponse([page1])) // page
+      .mockResolvedValueOnce(mockResponse([])); // media
     // Fetch entities
     await store.actions.source.fetch("/page-1/");
     expect(postTypeHandler).toHaveBeenCalled();
@@ -252,8 +253,9 @@ describe("page", () => {
     // Mock Api responses
     api.get = jest
       .fn()
-      .mockResolvedValueOnce(mockResponse([]))
-      .mockResolvedValueOnce(mockResponse([page1]));
+      .mockResolvedValueOnce(mockResponse([])) // post
+      .mockResolvedValueOnce(mockResponse([page1])) // page
+      .mockResolvedValueOnce(mockResponse([])); // media
     // Fetch entities
     await store.actions.source.fetch("/page-1/?some=param");
     expect(postTypeHandler).toHaveBeenCalled();
@@ -279,8 +281,9 @@ describe("page", () => {
     // Mock Api responses
     api.get = jest
       .fn()
-      .mockResolvedValueOnce(mockResponse([]))
-      .mockResolvedValueOnce(mockResponse([page1WithParent]));
+      .mockResolvedValueOnce(mockResponse([])) // post
+      .mockResolvedValueOnce(mockResponse([page1WithParent])) // page
+      .mockResolvedValueOnce(mockResponse([])); // media
     // Fetch entities
     await store.actions.source.fetch("/parent/page-1/");
     expect(postTypeHandler).toHaveBeenCalled();
@@ -293,6 +296,7 @@ describe("attachment", () => {
     // Mock Api responses
     api.get = jest
       .fn()
+      .mockResolvedValueOnce(mockResponse([]))
       .mockResolvedValueOnce(mockResponse([]))
       .mockResolvedValueOnce(mockResponse([attachment1]));
     // Fetch entities
@@ -320,6 +324,7 @@ describe("attachment", () => {
     // Mock Api responses
     api.get = jest
       .fn()
+      .mockResolvedValueOnce(mockResponse([]))
       .mockResolvedValueOnce(mockResponse([]))
       .mockResolvedValueOnce(mockResponse([attachment1]));
     // Fetch entities

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -86,10 +86,10 @@ describe("postType", () => {
   });
 });
 
-describe("post", () => {
+describe.only("post", () => {
   test("doesn't exist in source.post", async () => {
     // Mock Api responses
-    api.get = jest.fn().mockResolvedValueOnce(mockResponse([post1]));
+    api.get = jest.fn().mockResolvedValue(mockResponse([post1]));
     // Fetch entities
     await store.actions.source.fetch("/post-1/");
     expect(store.state.source).toMatchSnapshot();
@@ -127,7 +127,7 @@ describe("post", () => {
 
   test("works with query params (doesn't exist in source.post)", async () => {
     // Mock Api responses
-    api.get = jest.fn().mockResolvedValueOnce(mockResponse([post1]));
+    api.get = jest.fn().mockResolvedValue(mockResponse([post1]));
     // Fetch entities
     await store.actions.source.fetch("/post-1/?some=param");
     expect(store.state.source).toMatchSnapshot();
@@ -151,7 +151,7 @@ describe("post", () => {
 
   test("works with types embedded", async () => {
     // Mock Api responses
-    api.get = jest.fn().mockResolvedValueOnce(mockResponse([post1withType]));
+    api.get = jest.fn().mockResolvedValue(mockResponse([post1withType]));
     // Fetch entities
     await store.actions.source.fetch("/post-1/");
     expect(postTypeHandler).toHaveBeenCalled();
@@ -164,7 +164,9 @@ describe("post", () => {
     // Mock Api responses
     api.get = jest
       .fn()
-      .mockResolvedValueOnce(mockResponse([post1]))
+      .mockResolvedValueOnce(mockResponse([post1])) // post
+      .mockResolvedValueOnce(mockResponse([])) // page
+      .mockResolvedValueOnce(mockResponse([])) // media
       .mockResolvedValueOnce(mockResponse([post1Revision]));
     // Fetch entities
     await store.actions.source.fetch("/post-1/?preview=true");
@@ -195,6 +197,8 @@ describe("post", () => {
     api.get = jest
       .fn()
       .mockResolvedValueOnce(mockResponse([post1]))
+      .mockResolvedValueOnce(mockResponse([]))
+      .mockResolvedValueOnce(mockResponse([]))
       .mockRejectedValueOnce(new ServerError("Forbidden", 403, "Forbidden"));
     // Fetch entities
     await store.actions.source.fetch("/post-1/?preview=true");
@@ -206,10 +210,12 @@ describe("post", () => {
     api.get = jest
       .fn()
       .mockResolvedValueOnce(mockResponse([post1]))
+      .mockResolvedValueOnce(mockResponse([]))
+      .mockResolvedValueOnce(mockResponse([]))
       .mockRejectedValueOnce(new ServerError("Forbidden", 403, "Forbidden"));
     // Fetch entities
     await store.actions.source.fetch("/post-1/?preview=true");
-    expect(api.get).toHaveBeenCalledTimes(1);
+    expect(api.get).toHaveBeenCalledTimes(3); // one time each for post, page & media
     expect(store.state.source).toMatchSnapshot();
   });
 });

--- a/packages/wp-source/src/libraries/handlers/postType.ts
+++ b/packages/wp-source/src/libraries/handlers/postType.ts
@@ -68,14 +68,20 @@ const postTypeHandler = ({
     let isHandled = false;
     let isMismatched = false;
 
-    const promises = finalEndpoints.map((endpoint) =>
+    const promisesAndEndpoints: [
+      string,
+      Promise<Response>
+    ][] = finalEndpoints.map((endpoint) => [
+      endpoint,
       libraries.source.api.get({
         endpoint,
         params: { slug, _embed: true, ...state.source.params },
-      })
-    );
+      }),
+    ]);
 
-    for await (const response of generateAsyncQueue(promises)) {
+    for await (const [endpoint, response] of generateAsyncQueue(
+      promisesAndEndpoints
+    )) {
       const populated = await libraries.source.populate({
         response,
         state,
@@ -90,7 +96,7 @@ const postTypeHandler = ({
         if (populated[0].link === route) {
           isHandled = true;
           isMismatched = false;
-          matchedEndpoint = populated[0].type;
+          matchedEndpoint = endpoint;
           break;
         } else {
           isMismatched = true;

--- a/packages/wp-source/src/libraries/handlers/postType.ts
+++ b/packages/wp-source/src/libraries/handlers/postType.ts
@@ -92,7 +92,6 @@ const postTypeHandler = ({
       if (populated.length > 0) {
         // We have to check if the link property in the data that we
         // populated is the same as the current route.
-
         if (populated[0].link === route) {
           isHandled = true;
           isMismatched = false;

--- a/packages/wp-source/src/libraries/handlers/utils/__tests__/generate-async-queue.ts
+++ b/packages/wp-source/src/libraries/handlers/utils/__tests__/generate-async-queue.ts
@@ -7,19 +7,19 @@ const delayPromise = (ms: number, val?: unknown) =>
 
 describe("generateAsyncQueue", () => {
   test("should order promises correctly", async () => {
-    const promises = [
-      delayPromise(10, "first"),
-      delayPromise(500, "third"),
-      delayPromise(11, "second"),
-      delayPromise(501, "fourth"),
+    const promises: [string, Promise<unknown>][] = [
+      ["test", delayPromise(10, "first")],
+      ["test", delayPromise(500, "third")],
+      ["test", delayPromise(11, "second")],
+      ["test", delayPromise(501, "fourth")],
     ];
 
     const generator = generateAsyncQueue(promises);
 
-    expect((await generator.next()).value).toBe("first");
-    expect((await generator.next()).value).toBe("second");
-    expect((await generator.next()).value).toBe("third");
-    expect((await generator.next()).value).toBe("fourth");
+    expect((await generator.next()).value).toEqual(["test", "first"]);
+    expect((await generator.next()).value).toEqual(["test", "second"]);
+    expect((await generator.next()).value).toEqual(["test", "third"]);
+    expect((await generator.next()).value).toEqual(["test", "fourth"]);
 
     const lastValue = await generator.next();
     expect(lastValue.value).toBe(undefined);
@@ -27,15 +27,15 @@ describe("generateAsyncQueue", () => {
   });
 
   test("should handle rejections with simple try...catch", async () => {
-    const promises = [
-      delayPromise(10, "first"),
-      delayPromise(500, "second"),
-      delayPromise(11),
+    const promises: [string, Promise<unknown>][] = [
+      ["test", delayPromise(10, "first")],
+      ["test", delayPromise(11)],
+      ["test", delayPromise(500, "second")], // this should never be reached
     ];
 
     const generator = generateAsyncQueue(promises);
 
-    expect((await generator.next()).value).toBe("first");
+    expect((await generator.next()).value).toEqual(["test", "first"]);
 
     try {
       await generator.next();

--- a/packages/wp-source/src/libraries/handlers/utils/__tests__/generate-async-queue.ts
+++ b/packages/wp-source/src/libraries/handlers/utils/__tests__/generate-async-queue.ts
@@ -1,0 +1,52 @@
+import generateAsyncQueue from "../generate-async-queue";
+
+const delayPromise = (ms: number, val?: unknown) =>
+  new Promise((resolve, reject) =>
+    setTimeout(() => (val ? resolve(val) : reject()), ms)
+  );
+
+describe("generateAsyncQueue", () => {
+  test("should order promises correctly", async () => {
+    const promises = [
+      delayPromise(10, "first"),
+      delayPromise(500, "third"),
+      delayPromise(11, "second"),
+      delayPromise(501, "fourth"),
+    ];
+
+    const generator = generateAsyncQueue(promises);
+
+    expect((await generator.next()).value).toBe("first");
+    expect((await generator.next()).value).toBe("second");
+    expect((await generator.next()).value).toBe("third");
+    expect((await generator.next()).value).toBe("fourth");
+
+    const lastValue = await generator.next();
+    expect(lastValue.value).toBe(undefined);
+    expect(lastValue.done).toBe(true);
+  });
+
+  test("should handle rejections with simple try...catch", async () => {
+    const promises = [
+      delayPromise(10, "first"),
+      delayPromise(500, "second"),
+      delayPromise(11),
+    ];
+
+    const generator = generateAsyncQueue(promises);
+
+    expect((await generator.next()).value).toBe("first");
+
+    try {
+      await generator.next();
+    } catch (e) {
+      // eslint-disable-next-line
+      expect(e).toBe(undefined);
+      return;
+    }
+
+    // This is a hack to ensure that we never get to this place and return after
+    // having thrown the error
+    expect(() => undefined).not.toBeCalled();
+  });
+});

--- a/packages/wp-source/src/libraries/handlers/utils/generate-async-queue.ts
+++ b/packages/wp-source/src/libraries/handlers/utils/generate-async-queue.ts
@@ -1,0 +1,42 @@
+/**
+ * A helper to generate an async iterator from an array of Promises.
+ *
+ * The result of calling this function should probably be used in an
+ * `await for...of` statement.
+ *
+ * @example
+ * ```
+ * for await (const response of generateAsyncQueue(promises)) {
+ *    const populated = await libraries.source.populate({
+ *      response,
+ *      state,
+ *      force,
+ *    });
+ * }
+ *```
+ * @param promises - An array of promises.
+ *
+ * @returns An async iterator.
+ */
+export default async function* generateAsyncQueue<T>(
+  promises: Promise<T>[]
+): AsyncGenerator<T, void, T> {
+  // Enhance the original array of Promises.
+  // Turn it into an array of tuples, where the first element of each tuple is
+  // the array index. The second element resolves to the tuple of [index, originalResult]
+  const promisesArray: Array<
+    [number, Promise<[number, T]>]
+  > = promises.map((p, i) => [i, p.then((res) => [i, res])]);
+
+  // Create a "pool" of Promises.
+  const map = new Map(promisesArray);
+
+  // Race all of the promises and as soon the first one resolves, yield the
+  // result, remove the tuple with the corresponding promise from the array and
+  // race all of the remaining promises until the "pool" is empty.
+  while (map.size) {
+    const [key, result] = await Promise.race(map.values());
+    yield result;
+    map.delete(key);
+  }
+}

--- a/packages/wp-source/src/libraries/handlers/utils/generate-async-queue.ts
+++ b/packages/wp-source/src/libraries/handlers/utils/generate-async-queue.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```
- * for await (const response of generateAsyncQueue(promises)) {
+ * for await (const [endpoint, response] of generateAsyncQueue(promises)) {
  *    const populated = await libraries.source.populate({
  *      response,
  *      state,
@@ -14,19 +14,20 @@
  *    });
  * }
  *```
- * @param promises - An array of promises.
+ * @param promises - An array of [endpoint, Promise] which corresponds to the
+ * endpoint where the data is fetched from and .
  *
- * @returns An async iterator.
+ * @returns An async iterator which resolves with a value of [response].
  */
 export default async function* generateAsyncQueue<T>(
-  promises: Promise<T>[]
-): AsyncGenerator<T, void, T> {
-  // Enhance the original array of Promises.
+  promises: [endpoint, Promise<T>][]
+): AsyncGenerator<[endpoint, T], void, unknown> {
+  // Enhance the original array of Promises & endpoints.
   // Turn it into an array of tuples, where the first element of each tuple is
   // the array index. The second element resolves to the tuple of [index, originalResult]
   const promisesArray: Array<
-    [number, Promise<[number, T]>]
-  > = promises.map((p, i) => [i, p.then((res) => [i, res])]);
+    [index, Promise<[index, endpoint, T]>]
+  > = promises.map((p, i) => [i, p[1].then((res) => [i, p[0], res])]);
 
   // Create a "pool" of Promises.
   const map = new Map(promisesArray);
@@ -35,8 +36,18 @@ export default async function* generateAsyncQueue<T>(
   // result, remove the tuple with the corresponding promise from the array and
   // race all of the remaining promises until the "pool" is empty.
   while (map.size) {
-    const [key, result] = await Promise.race(map.values());
-    yield result;
+    const [key, endpoint, result] = await Promise.race(map.values());
+    yield [endpoint, result];
     map.delete(key);
   }
 }
+
+/**
+ * Type alias for the index of the Promise in the array.
+ */
+type index = number;
+
+/**
+ * Type alias for the name of the endpoint.
+ */
+type endpoint = string;


### PR DESCRIPTION
Based on the comments in https://community.frontity.org/t/issue-with-having-2-duplicate-requests-to-posts-and-pages/4270/3 I investigated if we can optimize data fetching in postType handler.

Until now, we were fetching the data serially in the postType handler for each of `post`, `page` and `media` endpoints. With this improvement, the data is loaded and processed in parallel for all 3 endpoints.

**How**:

I have borrowed some ideas for the implementation from https://observablehq.com/@ehouais/multiple-promises-as-an-async-generator

**Tasks**:

- [x] Code
- [x] TSDocs
- [x] TypeScript
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->

