### PR TITLE
Skip the redirections for embedded mode

### DIFF
--- a/.changeset/early-eyes-add.md
+++ b/.changeset/early-eyes-add.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+Bail out of redirection if frontity is running into embedded mode.

--- a/e2e/integration/wordpress-01/redirections.spec.ts
+++ b/e2e/integration/wordpress-01/redirections.spec.ts
@@ -62,19 +62,6 @@ describe("Redirections", () => {
     cy.get("#link-counter").should("contain.text", "3");
   });
 
-  it("Should not redirect when navigating on the client in embedded mode", () => {
-    cy.visit(
-      "http://localhost:3001?frontity_name=redirections&frontity_embedded=true"
-    );
-
-    // Go to the "redirected" page.
-    cy.get("#open-post").click();
-
-    cy.location("href").should("eq", "http://localhost:3001/hello-world/");
-    cy.get("#post").should("not.exist");
-    cy.get("#link-counter").should("contain.text", "2");
-  });
-
   it("The back and forward button should work fine when navigating", () => {
     cy.visit("http://localhost:3001?frontity_name=redirections");
 
@@ -390,18 +377,6 @@ describe("Redirections", () => {
     // so that this request triggers a 404
     cy.visit(
       "http://localhost:3001/self-redirect-404/?frontity_name=redirections&redirections=404",
-      { failOnStatusCode: false }
-    );
-
-    cy.get("#404").should("exist");
-    cy.get("#link-counter").should("contain.text", "1");
-  });
-
-  it("Should handle self-redirections gracefully when redirections=404 in embedded mode", () => {
-    // For this test we explicitly DO NOT create a post for /self-redirect-404/
-    // so that this request triggers a 404
-    cy.visit(
-      "http://localhost:3001/self-redirect-404/?frontity_name=redirections&frontity_embedded=true&redirections=404",
       { failOnStatusCode: false }
     );
 

--- a/e2e/integration/wordpress-01/redirections.spec.ts
+++ b/e2e/integration/wordpress-01/redirections.spec.ts
@@ -62,6 +62,19 @@ describe("Redirections", () => {
     cy.get("#link-counter").should("contain.text", "3");
   });
 
+  it("Should not redirect when navigating on the client in embedded mode", () => {
+    cy.visit(
+      "http://localhost:3001?frontity_name=redirections&frontity_embedded=true"
+    );
+
+    // Go to the "redirected" page.
+    cy.get("#open-post").click();
+
+    cy.location("href").should("eq", "http://localhost:3001/hello-world/");
+    cy.get("#post").should("not.exist");
+    cy.get("#link-counter").should("contain.text", "2");
+  });
+
   it("The back and forward button should work fine when navigating", () => {
     cy.visit("http://localhost:3001?frontity_name=redirections");
 
@@ -377,6 +390,18 @@ describe("Redirections", () => {
     // so that this request triggers a 404
     cy.visit(
       "http://localhost:3001/self-redirect-404/?frontity_name=redirections&redirections=404",
+      { failOnStatusCode: false }
+    );
+
+    cy.get("#404").should("exist");
+    cy.get("#link-counter").should("contain.text", "1");
+  });
+
+  it("Should handle self-redirections gracefully when redirections=404 in embedded mode", () => {
+    // For this test we explicitly DO NOT create a post for /self-redirect-404/
+    // so that this request triggers a 404
+    cy.visit(
+      "http://localhost:3001/self-redirect-404/?frontity_name=redirections&frontity_embedded=true&redirections=404",
       { failOnStatusCode: false }
     );
 

--- a/e2e/integration/wordpress-01/redirections.spec.ts
+++ b/e2e/integration/wordpress-01/redirections.spec.ts
@@ -32,6 +32,21 @@ describe("Redirections", () => {
     cy.get("#link-counter").should("contain.text", "1");
   });
 
+  it("Should not redirect server side when in embedded mode for 404", () => {
+    cy.visit(
+      "http://localhost:3001/hello-world/?frontity_name=redirections&frontity_embedded=true&redirections=404",
+      { failOnStatusCode: false }
+    );
+
+    cy.location("href").should(
+      "eq",
+      "http://localhost:3001/hello-world/?redirections=404"
+    );
+    cy.get("#post").should("not.exist");
+    cy.get("#404").should("exist");
+    cy.get("#link-counter").should("contain.text", "1");
+  });
+
   it("Should handle query params in a redirection", () => {
     cy.visit(
       "http://localhost:3001/hello-world/?frontity_name=redirections&redirections=all"
@@ -77,6 +92,22 @@ describe("Redirections", () => {
   it("Should redirect when navigating on the client in embedded mode", () => {
     cy.visit(
       "http://localhost:3001?frontity_name=redirections&frontity_embedded=true"
+    );
+
+    // Go to the "redirected" page.
+    cy.get("#open-post").click();
+
+    cy.location("href").should(
+      "eq",
+      "http://localhost:3001/hello-world-redirected/"
+    );
+    cy.get("#post").should("exist");
+    cy.get("#link-counter").should("contain.text", "3");
+  });
+
+  it("Should redirect 404s when navigating on the client in embedded mode", () => {
+    cy.visit(
+      "http://localhost:3001?frontity_name=redirections&frontity_embedded=true&redirections=404"
     );
 
     // Go to the "redirected" page.

--- a/e2e/integration/wordpress-01/redirections.spec.ts
+++ b/e2e/integration/wordpress-01/redirections.spec.ts
@@ -20,6 +20,18 @@ describe("Redirections", () => {
     cy.get("#link-counter").should("contain.text", "1");
   });
 
+  it("Should not redirect server side when in embedded mode", () => {
+    cy.visit(
+      "http://localhost:3001/hello-world/?frontity_name=redirections&frontity_embedded=true",
+      { failOnStatusCode: false }
+    );
+
+    cy.location("href").should("eq", "http://localhost:3001/hello-world/");
+    cy.get("#post").should("not.exist");
+    cy.get("#404").should("exist");
+    cy.get("#link-counter").should("contain.text", "1");
+  });
+
   it("Should handle query params in a redirection", () => {
     cy.visit(
       "http://localhost:3001/hello-world/?frontity_name=redirections&redirections=all"
@@ -50,6 +62,22 @@ describe("Redirections", () => {
 
   it("Should redirect when navigating on the client", () => {
     cy.visit("http://localhost:3001?frontity_name=redirections");
+
+    // Go to the "redirected" page.
+    cy.get("#open-post").click();
+
+    cy.location("href").should(
+      "eq",
+      "http://localhost:3001/hello-world-redirected/"
+    );
+    cy.get("#post").should("exist");
+    cy.get("#link-counter").should("contain.text", "3");
+  });
+
+  it("Should redirect when navigating on the client in embedded mode", () => {
+    cy.visit(
+      "http://localhost:3001?frontity_name=redirections&frontity_embedded=true"
+    );
 
     // Go to the "redirected" page.
     cy.get("#open-post").click();

--- a/packages/wp-source/src/__tests__/3xx-redirections.tests.ts
+++ b/packages/wp-source/src/__tests__/3xx-redirections.tests.ts
@@ -132,6 +132,33 @@ describe.each`
               }
           `);
     });
+
+    it(`${platform}: Should skip the redirection for 'all' in embedded mode`, async () => {
+      store.state.frontity.options = store.state.frontity.options || {};
+      store.state.frontity.options.embedded = "true";
+      store.state.source.redirections = "all";
+
+      await store.actions.source.fetch("/some-post/");
+
+      expect(mockedFetch).toHaveBeenCalledTimes(0);
+      expect(handler.func).toHaveBeenCalled();
+
+      expect(store.state.source.data).toMatchInlineSnapshot(`
+              Object {
+                "/some-post/": Object {
+                  "id": 1,
+                  "isFetching": false,
+                  "isPostType": true,
+                  "isReady": true,
+                  "link": "/some-post/",
+                  "page": 1,
+                  "query": Object {},
+                  "route": "/some-post/",
+                  "type": "example",
+                },
+              }
+          `);
+    });
   });
 
   describe("redirections: 404", () => {

--- a/packages/wp-source/src/__tests__/3xx-redirections.tests.ts
+++ b/packages/wp-source/src/__tests__/3xx-redirections.tests.ts
@@ -132,33 +132,6 @@ describe.each`
               }
           `);
     });
-
-    it(`${platform}: Should skip the redirection for 'all' in embedded mode`, async () => {
-      store.state.frontity.options = store.state.frontity.options || {};
-      store.state.frontity.options.embedded = "true";
-      store.state.source.redirections = "all";
-
-      await store.actions.source.fetch("/some-post/");
-
-      expect(mockedFetch).toHaveBeenCalledTimes(0);
-      expect(handler.func).toHaveBeenCalled();
-
-      expect(store.state.source.data).toMatchInlineSnapshot(`
-              Object {
-                "/some-post/": Object {
-                  "id": 1,
-                  "isFetching": false,
-                  "isPostType": true,
-                  "isReady": true,
-                  "link": "/some-post/",
-                  "page": 1,
-                  "query": Object {},
-                  "route": "/some-post/",
-                  "type": "example",
-                },
-              }
-          `);
-    });
   });
 
   describe("redirections: 404", () => {

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -22,6 +22,8 @@ const actions: WpSource["actions"]["source"] = {
   fetch: ({ state, libraries }) => async (...params) => {
     const [resource, options] = params;
     const { source } = state;
+    // `embedded` flag.
+    const isEmbedded = state.frontity.options.embedded;
 
     // Get the normalize and parse from libraries instead of importing them.
     // This way they can be e.g. overriden at runtime by another package
@@ -91,7 +93,7 @@ const actions: WpSource["actions"]["source"] = {
 
       // Check if we need to check if it is a 30X redirection before fetching
       // the backend.
-      if (isEagerRedirection(state.source.redirections, link)) {
+      if (!isEmbedded && isEagerRedirection(state.source.redirections, link)) {
         const redirection = await fetchRedirection({ link, state });
         // If there is a redirection, populate the data object and finish here.
         if (
@@ -154,7 +156,11 @@ const actions: WpSource["actions"]["source"] = {
       }
 
       // Check it there is a 301 redirection stored in the backend.
-      if (error.status === 404 && is404Redirection(state.source.redirections)) {
+      if (
+        error.status === 404 &&
+        !isEmbedded &&
+        is404Redirection(state.source.redirections)
+      ) {
         const redirection = await fetchRedirection({ link, state });
         // If there is a redirection, populate the data object and finish here.
         if (

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -23,7 +23,7 @@ const actions: WpSource["actions"]["source"] = {
     const [resource, options] = params;
     const { source } = state;
     // `embedded` flag.
-    const isEmbedded = state.frontity.options.embedded;
+    const isEmbedded = state.frontity?.options?.embedded || false;
 
     // Get the normalize and parse from libraries instead of importing them.
     // This way they can be e.g. overriden at runtime by another package

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -25,7 +25,7 @@ const actions: WpSource["actions"]["source"] = {
     // Should skip redirection for embedded mode on the server only.
     const shouldSkipRedirection =
       (state.frontity?.options?.embedded &&
-        state.frontity?.rendering === "ssr") ||
+        state.frontity?.platform === "server") ||
       false;
 
     // Get the normalize and parse from libraries instead of importing them.


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here: 
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Handle the redirections for embedded mode.

**Why**:

<!-- Why are these changes necessary? -->
To avoid the infinite loop for redirections handled by wordpress instance.

**How**:

<!-- How were these changes implemented? -->
The frontity embedded plugin sends the `frontity_embedded=true` option so we can detect the redirections that are coming from it and skip them.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] TypeScript
- [x] Unit tests
- [x] End to end tests
- [x] TypeScript tests
- [x] Update other packages
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] Update starter themes
- [ ] Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
~Opened as draft as I wanna confirm first that this is the right direction.~ Done