### PR TITLE
Add `--analyze` flag to the `npx frontity dev` command

### DIFF
--- a/.changeset/new-insects-draw.md
+++ b/.changeset/new-insects-draw.md
@@ -1,0 +1,6 @@
+---
+"@frontity/core": minor
+"frontity": minor
+---
+
+Add an `--analyze` option to the `dev` command. The flag should be explicitly set in order to generate HTML files for bundle analysis.

--- a/.changeset/new-insects-draw.md
+++ b/.changeset/new-insects-draw.md
@@ -3,4 +3,4 @@
 "frontity": minor
 ---
 
-Add an `--analyze` option to the `dev` command. The flag should be explicitly set in order to generate HTML files for bundle analysis.
+Add an `--analyze` option to the `dev` and `build` commands. The flag should be explicitly set in order to generate HTML files for bundle analysis.

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -22,6 +22,13 @@ interface ConfigOptions {
    * The public path of Webpack.
    */
   publicPath: string;
+
+  /**
+   * Flag indicating if the Bundle Analyzer plugin should be included.
+   *
+   * @defaultValue false
+   */
+  analyze?: boolean;
 }
 
 /**
@@ -32,7 +39,12 @@ interface ConfigOptions {
  * @returns The configuration object for Webpack, Babel and Frontity. Each
  * configuration object contains the three targets: "module", "es5" and "server".
  */
-const config = ({ mode, entryPoints, publicPath }: ConfigOptions): Config => {
+const config = ({
+  mode,
+  entryPoints,
+  publicPath,
+  analyze = false,
+}: ConfigOptions): Config => {
   const frontity = getFrontity();
   const babel = getBabel();
   const webpack = getWebpack({
@@ -41,6 +53,7 @@ const config = ({ mode, entryPoints, publicPath }: ConfigOptions): Config => {
     frontity,
     entryPoints,
     publicPath,
+    analyze,
   });
 
   return {

--- a/packages/core/src/config/webpack/__tests__/__snapshots__/index.tests.ts.snap
+++ b/packages/core/src/config/webpack/__tests__/__snapshots__/index.tests.ts.snap
@@ -1,5 +1,152 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Webpack includes the Bundle Analyzer plugin if specified 1`] = `
+Array [
+  BundleAnalyzerPlugin {
+    "logger": Logger {
+      "activeLevels": Set {
+        "silent",
+      },
+    },
+    "opts": Object {
+      "analyzerHost": "127.0.0.1",
+      "analyzerMode": "static",
+      "analyzerPort": 8888,
+      "defaultSizes": "parsed",
+      "excludeAssets": null,
+      "generateStatsFile": false,
+      "logLevel": "silent",
+      "openAnalyzer": false,
+      "reportFilename": "../analyze/es5-production.html",
+      "reportTitle": [Function],
+      "startAnalyzer": true,
+      "statsFilename": "stats.json",
+      "statsOptions": null,
+    },
+    "server": null,
+  },
+  WatchIgnorePlugin {
+    "paths": Array [
+      /build/,
+    ],
+  },
+  IgnorePlugin {
+    "checkIgnore": [Function],
+    "options": Object {
+      "contextRegExp": undefined,
+      "resourceRegExp": /\\^encoding\\$/,
+    },
+  },
+  LoadablePlugin {
+    "compiler": null,
+    "handleEmit": [Function],
+    "opts": Object {
+      "filename": "../bundling/chunks.es5.json",
+      "outputAsset": true,
+      "path": undefined,
+      "writeToDisk": undefined,
+    },
+    "writeAssetsFile": [Function],
+  },
+]
+`;
+
+exports[`Webpack includes the Bundle Analyzer plugin if specified 2`] = `
+Array [
+  BundleAnalyzerPlugin {
+    "logger": Logger {
+      "activeLevels": Set {
+        "silent",
+      },
+    },
+    "opts": Object {
+      "analyzerHost": "127.0.0.1",
+      "analyzerMode": "static",
+      "analyzerPort": 8888,
+      "defaultSizes": "parsed",
+      "excludeAssets": null,
+      "generateStatsFile": false,
+      "logLevel": "silent",
+      "openAnalyzer": false,
+      "reportFilename": "../analyze/module-production.html",
+      "reportTitle": [Function],
+      "startAnalyzer": true,
+      "statsFilename": "stats.json",
+      "statsOptions": null,
+    },
+    "server": null,
+  },
+  WatchIgnorePlugin {
+    "paths": Array [
+      /build/,
+    ],
+  },
+  IgnorePlugin {
+    "checkIgnore": [Function],
+    "options": Object {
+      "contextRegExp": undefined,
+      "resourceRegExp": /\\^encoding\\$/,
+    },
+  },
+  LoadablePlugin {
+    "compiler": null,
+    "handleEmit": [Function],
+    "opts": Object {
+      "filename": "../bundling/chunks.module.json",
+      "outputAsset": true,
+      "path": undefined,
+      "writeToDisk": undefined,
+    },
+    "writeAssetsFile": [Function],
+  },
+]
+`;
+
+exports[`Webpack includes the Bundle Analyzer plugin if specified 3`] = `
+Array [
+  BundleAnalyzerPlugin {
+    "logger": Logger {
+      "activeLevels": Set {
+        "silent",
+      },
+    },
+    "opts": Object {
+      "analyzerHost": "127.0.0.1",
+      "analyzerMode": "static",
+      "analyzerPort": 8888,
+      "defaultSizes": "parsed",
+      "excludeAssets": null,
+      "generateStatsFile": false,
+      "logLevel": "silent",
+      "openAnalyzer": false,
+      "reportFilename": "analyze/server-production.html",
+      "reportTitle": [Function],
+      "startAnalyzer": true,
+      "statsFilename": "stats.json",
+      "statsOptions": null,
+    },
+    "server": null,
+  },
+  WatchIgnorePlugin {
+    "paths": Array [
+      /build/,
+    ],
+  },
+  IgnorePlugin {
+    "checkIgnore": [Function],
+    "options": Object {
+      "contextRegExp": undefined,
+      "resourceRegExp": /\\^encoding\\$/,
+    },
+  },
+  LimitChunkCountPlugin {
+    "options": Object {
+      "maxChunks": 1,
+    },
+  },
+]
+`;
+
 exports[`Webpack returns for development 1`] = `
 Object {
   "es5": Object {
@@ -85,29 +232,6 @@ Object {
       "maxEntrypointSize": 500000,
     },
     "plugins": Array [
-      BundleAnalyzerPlugin {
-        "logger": Logger {
-          "activeLevels": Set {
-            "silent",
-          },
-        },
-        "opts": Object {
-          "analyzerHost": "127.0.0.1",
-          "analyzerMode": "static",
-          "analyzerPort": 8888,
-          "defaultSizes": "parsed",
-          "excludeAssets": null,
-          "generateStatsFile": false,
-          "logLevel": "silent",
-          "openAnalyzer": false,
-          "reportFilename": "../analyze/es5-development.html",
-          "reportTitle": [Function],
-          "startAnalyzer": true,
-          "statsFilename": "stats.json",
-          "statsOptions": null,
-        },
-        "server": null,
-      },
       WatchIgnorePlugin {
         "paths": Array [
           /build/,
@@ -246,29 +370,6 @@ Object {
       "maxEntrypointSize": 500000,
     },
     "plugins": Array [
-      BundleAnalyzerPlugin {
-        "logger": Logger {
-          "activeLevels": Set {
-            "silent",
-          },
-        },
-        "opts": Object {
-          "analyzerHost": "127.0.0.1",
-          "analyzerMode": "static",
-          "analyzerPort": 8888,
-          "defaultSizes": "parsed",
-          "excludeAssets": null,
-          "generateStatsFile": false,
-          "logLevel": "silent",
-          "openAnalyzer": false,
-          "reportFilename": "../analyze/module-development.html",
-          "reportTitle": [Function],
-          "startAnalyzer": true,
-          "statsFilename": "stats.json",
-          "statsOptions": null,
-        },
-        "server": null,
-      },
       WatchIgnorePlugin {
         "paths": Array [
           /build/,
@@ -394,29 +495,6 @@ Object {
       "maxEntrypointSize": 5000000,
     },
     "plugins": Array [
-      BundleAnalyzerPlugin {
-        "logger": Logger {
-          "activeLevels": Set {
-            "silent",
-          },
-        },
-        "opts": Object {
-          "analyzerHost": "127.0.0.1",
-          "analyzerMode": "static",
-          "analyzerPort": 8888,
-          "defaultSizes": "parsed",
-          "excludeAssets": null,
-          "generateStatsFile": false,
-          "logLevel": "silent",
-          "openAnalyzer": false,
-          "reportFilename": "analyze/server-development.html",
-          "reportTitle": [Function],
-          "startAnalyzer": true,
-          "statsFilename": "stats.json",
-          "statsOptions": null,
-        },
-        "server": null,
-      },
       WatchIgnorePlugin {
         "paths": Array [
           /build/,
@@ -546,29 +624,6 @@ Object {
       "maxEntrypointSize": 500000,
     },
     "plugins": Array [
-      BundleAnalyzerPlugin {
-        "logger": Logger {
-          "activeLevels": Set {
-            "silent",
-          },
-        },
-        "opts": Object {
-          "analyzerHost": "127.0.0.1",
-          "analyzerMode": "static",
-          "analyzerPort": 8888,
-          "defaultSizes": "parsed",
-          "excludeAssets": null,
-          "generateStatsFile": false,
-          "logLevel": "silent",
-          "openAnalyzer": false,
-          "reportFilename": "../analyze/es5-production.html",
-          "reportTitle": [Function],
-          "startAnalyzer": true,
-          "statsFilename": "stats.json",
-          "statsOptions": null,
-        },
-        "server": null,
-      },
       WatchIgnorePlugin {
         "paths": Array [
           /build/,
@@ -690,29 +745,6 @@ Object {
       "maxEntrypointSize": 500000,
     },
     "plugins": Array [
-      BundleAnalyzerPlugin {
-        "logger": Logger {
-          "activeLevels": Set {
-            "silent",
-          },
-        },
-        "opts": Object {
-          "analyzerHost": "127.0.0.1",
-          "analyzerMode": "static",
-          "analyzerPort": 8888,
-          "defaultSizes": "parsed",
-          "excludeAssets": null,
-          "generateStatsFile": false,
-          "logLevel": "silent",
-          "openAnalyzer": false,
-          "reportFilename": "../analyze/module-production.html",
-          "reportTitle": [Function],
-          "startAnalyzer": true,
-          "statsFilename": "stats.json",
-          "statsOptions": null,
-        },
-        "server": null,
-      },
       WatchIgnorePlugin {
         "paths": Array [
           /build/,
@@ -823,29 +855,6 @@ Object {
       "maxEntrypointSize": 5000000,
     },
     "plugins": Array [
-      BundleAnalyzerPlugin {
-        "logger": Logger {
-          "activeLevels": Set {
-            "silent",
-          },
-        },
-        "opts": Object {
-          "analyzerHost": "127.0.0.1",
-          "analyzerMode": "static",
-          "analyzerPort": 8888,
-          "defaultSizes": "parsed",
-          "excludeAssets": null,
-          "generateStatsFile": false,
-          "logLevel": "silent",
-          "openAnalyzer": false,
-          "reportFilename": "analyze/server-production.html",
-          "reportTitle": [Function],
-          "startAnalyzer": true,
-          "statsFilename": "stats.json",
-          "statsOptions": null,
-        },
-        "server": null,
-      },
       WatchIgnorePlugin {
         "paths": Array [
           /build/,

--- a/packages/core/src/config/webpack/__tests__/index.tests.ts
+++ b/packages/core/src/config/webpack/__tests__/index.tests.ts
@@ -81,3 +81,18 @@ test("Webpack changes the public path if specified", () => {
   expect(module.output.publicPath).toBe(publicPath);
   expect(server.output.publicPath).toBe(publicPath);
 });
+
+test("Webpack includes the Bundle Analyzer plugin if specified", () => {
+  const { es5, module, server } = getWebpack({
+    mode: "production",
+    babel: babel["production"],
+    frontity,
+    entryPoints,
+    publicPath: "/static",
+    analyze: true,
+  });
+
+  expect(es5.plugins).toMatchSnapshot();
+  expect(module.plugins).toMatchSnapshot();
+  expect(server.plugins).toMatchSnapshot();
+});

--- a/packages/core/src/config/webpack/index.ts
+++ b/packages/core/src/config/webpack/index.ts
@@ -48,6 +48,11 @@ interface WebpackOptions {
    * The config of Frontity, generated in the previous step.
    */
   frontity: FrontityConfig;
+
+  /**
+   * Flag indicating if the Bundle Analyzer plugin should be included.
+   */
+  analyze?: boolean;
 }
 
 /**
@@ -74,6 +79,7 @@ const getConfig = ({
   babel,
   publicPath,
   frontity,
+  analyze,
 }: ConfigOptions): Configuration => ({
   mode,
   name: name({ target }),
@@ -84,7 +90,7 @@ const getConfig = ({
   module: modules({ target, babel, mode }),
   resolve: resolve(),
   externals: externals({ target }),
-  plugins: plugins({ target, mode, outDir: frontity.outDir }),
+  plugins: plugins({ target, mode, outDir: frontity.outDir, analyze }),
   performance: performance({ target }),
   stats: stats({ mode }),
 });

--- a/packages/core/src/config/webpack/plugins.ts
+++ b/packages/core/src/config/webpack/plugins.ts
@@ -9,28 +9,66 @@ import {
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 import { Target, Mode } from "../../../types";
 
-export default ({
+/**
+ * The options for the {@link plugins} function.
+ */
+interface PluginsOptions {
+  /**
+   * The target of the build: "server", "es5" or "module".
+   */
+  target: Target;
+
+  /**
+   * The mode of the build: "development" or "production".
+   */
+  mode: Mode;
+
+  /**
+   * The output directory.
+   */
+  outDir: string;
+
+  /**
+   * Flag indicating if the Bundle Analyzer plugin should be included.
+   */
+  analyze: boolean;
+}
+
+/**
+ * Generate the object for Webpack's plugins configuration.
+ *
+ * Official Webpack docs: https://webpack.js.org/configuration/plugins/.
+ *
+ * @param options - Object of type {@link PluginsOptions}.
+ *
+ * @returns The configuration object for Webpack.
+ */
+const plugins = ({
   target,
   mode,
   outDir,
-}: {
-  target: Target;
-  mode: Mode;
-  outDir: string;
-}): Configuration["plugins"] => {
-  const config: Configuration["plugins"] = [
-    // Create HTML files for bundle analyzing.
-    new BundleAnalyzerPlugin({
-      analyzerMode: "static",
-      reportFilename: `${
-        target !== "server" ? `../` : ""
-      }analyze/${target}-${mode}.html`,
-      openAnalyzer: false,
-      logLevel: "silent",
-    }),
+  analyze,
+}: PluginsOptions): Configuration["plugins"] => {
+  const config: Configuration["plugins"] = [];
+
+  // Create HTML files for bundle analyzing.
+  if (analyze)
+    config.push(
+      new BundleAnalyzerPlugin({
+        analyzerMode: "static",
+        reportFilename: `${
+          target !== "server" ? `../` : ""
+        }analyze/${target}-${mode}.html`,
+        openAnalyzer: false,
+        logLevel: "silent",
+      })
+    );
+
+  // Ignore some files and folders.
+  config.push(
     new WatchIgnorePlugin([new RegExp(outDir)]),
-    new IgnorePlugin(/^encoding$/),
-  ];
+    new IgnorePlugin(/^encoding$/)
+  );
 
   // Support HMR in development. Only needed in client.
   if (target !== "server" && mode === "development")
@@ -49,3 +87,5 @@ export default ({
     config.push(new optimize.LimitChunkCountPlugin({ maxChunks: 1 }));
   return config;
 };
+
+export default plugins;

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -79,6 +79,14 @@ export interface BuildOptions {
    * @defaultValue "/static/"
    */
   publicPath: string;
+
+  /**
+   * Indicate if the Bundle Analyzer plugin should be included in the Webpack
+   * configuration, in order to generate HTML files for bundle analyzing.
+   *
+   * @defaultValue false
+   */
+  analyze?: boolean;
 }
 
 /**
@@ -93,6 +101,7 @@ export default async ({
   mode = "production",
   target = "both",
   publicPath = "/static/",
+  analyze = false,
 }: BuildOptions): Promise<void> => {
   console.log();
   console.log(`  - mode: ${mode}`);
@@ -114,7 +123,7 @@ export default async ({
   const entryPoints = await generateEntryPoints({ sites, outDir, mode });
 
   // Get FrontityConfig for Webpack.
-  const config = getConfig({ mode, entryPoints, publicPath });
+  const config = getConfig({ mode, entryPoints, publicPath, analyze });
 
   // Build and wait until webpack finished the clients first.
   // We need to do this because the server bundle needs to import

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -143,6 +143,7 @@ export default async ({
   await webpackAsync(config.webpack.server);
   console.log();
 
-  // Remove the bundling folder after the build if --analyze was not used.
-  if (analyze === false) await remove(join(outDir, "bundling"));
+  // Remove the bundling folder after the build in production because
+  // it is not needed anymore.
+  if (mode === "production") await remove(join(outDir, "bundling"));
 };

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -143,7 +143,6 @@ export default async ({
   await webpackAsync(config.webpack.server);
   console.log();
 
-  // Remove the bundling folder after the build in production because
-  // it is not needed anymore.
-  if (mode === "production") await remove(join(outDir, "bundling"));
+  // Remove the bundling folder after the build if --analyze was not used.
+  if (analyze === false) await remove(join(outDir, "bundling"));
 };

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -106,6 +106,14 @@ export interface DevOptions {
    * @defaultValue "/static/"
    */
   publicPath: string;
+
+  /**
+   * Indicate if the Bundle Analyzer plugin should be included in the Webpack
+   * configuration, in order to generate HTML files for bundle analyzing.
+   *
+   * @defaultValue false
+   */
+  analyze?: boolean;
 }
 
 /**
@@ -122,6 +130,7 @@ export default async ({
   target,
   openBrowser = true,
   publicPath = "/static/",
+  analyze,
 }: DevOptions): Promise<void> => {
   // Get config from frontity.config.js files.
   const frontityConfig = getFrontity();
@@ -150,7 +159,7 @@ export default async ({
   });
 
   // Get config for webpack, babel and frontity.
-  const config = getConfig({ mode, entryPoints, publicPath });
+  const config = getConfig({ mode, entryPoints, publicPath, analyze });
 
   // Build and wait until webpack finished the client first.
   // We need to do this because the server bundle needs to import

--- a/packages/frontity/src/cli/__tests__/__snapshots__/build.ci.test.ts.snap
+++ b/packages/frontity/src/cli/__tests__/__snapshots__/build.ci.test.ts.snap
@@ -12,6 +12,7 @@ exports[`build should get values from ENV variables 1`] = `
 Array [
   Array [
     Object {
+      "analyze": true,
       "development": true,
       "publicPath": "/public/path",
       "target": "es5",
@@ -24,6 +25,7 @@ exports[`build should ignore ENV variables for passed arguments 1`] = `
 Array [
   Array [
     Object {
+      "analyze": false,
       "development": false,
       "publicPath": "/static",
       "target": "module",
@@ -36,6 +38,7 @@ exports[`build should receive default values 1`] = `
 Array [
   Array [
     Object {
+      "analyze": false,
       "development": false,
       "publicPath": "/static/",
       "target": "both",

--- a/packages/frontity/src/cli/__tests__/__snapshots__/dev.ci.test.ts.snap
+++ b/packages/frontity/src/cli/__tests__/__snapshots__/dev.ci.test.ts.snap
@@ -20,6 +20,7 @@ exports[`dev should get values from ENV variables 1`] = `
 Array [
   Array [
     Object {
+      "analyze": true,
       "dontOpenBrowser": true,
       "https": true,
       "port": 3001,
@@ -35,6 +36,7 @@ exports[`dev should ignore ENV variables for passed arguments 1`] = `
 Array [
   Array [
     Object {
+      "analyze": false,
       "dontOpenBrowser": false,
       "https": false,
       "port": 4000,
@@ -50,6 +52,7 @@ exports[`dev should receive default values 1`] = `
 Array [
   Array [
     Object {
+      "analyze": false,
       "dontOpenBrowser": false,
       "https": false,
       "port": 3000,

--- a/packages/frontity/src/cli/__tests__/build.ci.test.ts
+++ b/packages/frontity/src/cli/__tests__/build.ci.test.ts
@@ -29,6 +29,7 @@ describe("build", () => {
     process.env.FRONTITY_BUILD_TARGET = "es5";
     process.env.FRONTITY_BUILD_DEVELOPMENT = "true";
     process.env.FRONTITY_BUILD_PUBLIC_PATH = "/public/path";
+    process.env.FRONTITY_BUILD_ANALYZE = "true";
 
     await build({});
     expect(mockedDev.default.mock.calls).toMatchSnapshot();
@@ -38,11 +39,13 @@ describe("build", () => {
     process.env.FRONTITY_BUILD_TARGET = "es5";
     process.env.FRONTITY_BUILD_DEVELOPMENT = "true";
     process.env.FRONTITY_BUILD_PUBLIC_PATH = "/public/path";
+    process.env.FRONTITY_BUILD_ANALYZE = "true";
 
     await build({
       target: "module",
       development: false,
       publicPath: "/static",
+      analyze: false,
     });
     expect(mockedDev.default.mock.calls).toMatchSnapshot();
   });

--- a/packages/frontity/src/cli/__tests__/dev.ci.test.ts
+++ b/packages/frontity/src/cli/__tests__/dev.ci.test.ts
@@ -32,6 +32,7 @@ describe("dev", () => {
     process.env.FRONTITY_DEV_PRODUCTION = "true";
     process.env.FRONTITY_DEV_PUBLIC_PATH = "/public/path";
     process.env.FRONTITY_DEV_DONT_OPEN_BROWSER = "true";
+    process.env.FRONTITY_DEV_ANALYZE = "true";
 
     await dev({});
     expect(mockedDev.default.mock.calls).toMatchSnapshot();
@@ -44,6 +45,7 @@ describe("dev", () => {
     process.env.FRONTITY_DEV_PRODUCTION = "true";
     process.env.FRONTITY_DEV_PUBLIC_PATH = "/public/path";
     process.env.FRONTITY_DEV_DONT_OPEN_BROWSER = "true";
+    process.env.FRONTITY_DEV_ANALYZE = "true";
 
     await dev({
       target: "module",
@@ -52,6 +54,7 @@ describe("dev", () => {
       production: false,
       publicPath: "/static",
       dontOpenBrowser: false,
+      analyze: false,
     });
     expect(mockedDev.default.mock.calls).toMatchSnapshot();
   });

--- a/packages/frontity/src/cli/build.ts
+++ b/packages/frontity/src/cli/build.ts
@@ -55,6 +55,16 @@ interface BuildOptions {
    * @defaultValue "/static/"
    */
   publicPath?: string;
+
+  /**
+   * If active, it creates HTML files for bundle analyzing inside the
+   * /build/analyze/ folder.
+   *
+   * It can be also configured using the `FRONTITY_BUILD_ANALYZE` env variable.
+   *
+   * @defaultValue false
+   */
+  analyze?: boolean;
 }
 
 /**
@@ -69,6 +79,7 @@ const build = async ({
   target = process.env.FRONTITY_BUILD_TARGET || "both",
   development = !!process.env.FRONTITY_BUILD_DEVELOPMENT,
   publicPath = process.env.FRONTITY_BUILD_PUBLIC_PATH || "/static/",
+  analyze = !!process.env.FRONTITY_BUILD_ANALYZE,
 }: BuildOptions) => {
   // Check `target` parameter.
   if (target && target !== "es5" && target !== "module" && target !== "both") {
@@ -84,6 +95,7 @@ const build = async ({
     target: target as "es5" | "module" | "both",
     development,
     publicPath,
+    analyze,
   });
 };
 

--- a/packages/frontity/src/cli/dev.ts
+++ b/packages/frontity/src/cli/dev.ts
@@ -98,6 +98,16 @@ interface DevOptions {
    * @defaultValue false
    */
   dontOpenBrowser?: boolean;
+
+  /**
+   * If active, it creates HTML files for bundle analyzing inside the
+   * /build/analyze/ folder.
+   *
+   * It can be also configured using the `FRONTITY_DEV_ANALYZE` env variable.
+   *
+   * @defaultValue false
+   */
+  analyze?: boolean;
 }
 
 /**
@@ -115,6 +125,7 @@ const dev = async ({
   production = !!process.env.FRONTITY_DEV_PRODUCTION,
   publicPath = process.env.FRONTITY_DEV_PUBLIC_PATH || "/static/",
   dontOpenBrowser = !!process.env.FRONTITY_DEV_DONT_OPEN_BROWSER,
+  analyze = !!process.env.FRONTITY_DEV_ANALYZE,
 }: DevOptions) => {
   // Check `target` parameter.
   if (target && target !== "es5" && target !== "module") {
@@ -138,6 +149,7 @@ const dev = async ({
     https,
     publicPath,
     dontOpenBrowser,
+    analyze,
   });
 };
 

--- a/packages/frontity/src/cli/dev.ts
+++ b/packages/frontity/src/cli/dev.ts
@@ -95,7 +95,7 @@ interface DevOptions {
    * It can be also configured using the `FRONTITY_DEV_DONT_OPEN_BROWSER` env
    * variable.
    *
-   * @defaultValue true
+   * @defaultValue false
    */
   dontOpenBrowser?: boolean;
 }

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -55,6 +55,10 @@ program
     "--public-path <path>",
     'set the public path for static assets. Default path is "/static/".'
   )
+  .option(
+    "--analyze",
+    'Create HTML files for bundle analyzing, available at "/build/analyze/"'
+  )
   .description("Starts a server in development mode.")
   .action(dev);
 

--- a/packages/frontity/src/cli/index.ts
+++ b/packages/frontity/src/cli/index.ts
@@ -74,6 +74,10 @@ program
     "--public-path <path>",
     'set the public path for static assets. Default path is "/static/".'
   )
+  .option(
+    "--analyze",
+    'Create HTML files for bundle analyzing, available at "/build/analyze/"'
+  )
   .description("Builds the project for production.")
   .action(build);
 

--- a/packages/frontity/src/commands/__tests__/__snapshots__/build.test.ts.snap
+++ b/packages/frontity/src/commands/__tests__/__snapshots__/build.test.ts.snap
@@ -4,6 +4,7 @@ exports[`build gets the correct default values when it receives an empty object 
 Array [
   Array [
     Object {
+      "analyze": false,
       "mode": "production",
       "publicPath": "/static/",
       "target": "both",

--- a/packages/frontity/src/commands/__tests__/__snapshots__/dev.test.ts.snap
+++ b/packages/frontity/src/commands/__tests__/__snapshots__/dev.test.ts.snap
@@ -4,6 +4,7 @@ exports[`dev gets the correct default values when it receives an empty object 1`
 Array [
   Array [
     Object {
+      "analyze": false,
       "isHttps": false,
       "mode": "development",
       "openBrowser": true,

--- a/packages/frontity/src/commands/build.ts
+++ b/packages/frontity/src/commands/build.ts
@@ -1,24 +1,58 @@
 import chalk from "chalk";
 import { errorLogger } from "../utils";
 
-export default async ({
+/**
+ * Options for the {@link buildCommand} function.
+ */
+interface BuildOptions {
+  /**
+   * Builds the project for production.
+   *
+   * @defaultValue `false`
+   */
+  development?: boolean;
+
+  /**
+   * Create bundles with "es5", "module" or both.
+   *
+   * @defaultValue `"both"`
+   */
+  target?: "es5" | "module" | "both";
+
+  /**
+   * Set the public path for static assets.
+   *
+   * @defaultValue `"/static/"`
+   */
+  publicPath?: string;
+
+  /**
+   * Create HTML files for bundle analyzing.
+   *
+   * @defaultValue `false`
+   */
+  analyze?: boolean;
+}
+
+/**
+ * Build the project for production.
+ *
+ * This function is executed by the CLI when running the `npx frontity build`
+ * command.
+ *
+ * @param options - Object of type {@link BuildOptions}.
+ */
+const buildCommand = async ({
   development = false,
   target = "both",
   publicPath = "/static/",
-}: {
-  development?: boolean;
-  target?: "es5" | "module" | "both";
-  publicPath?: string;
-}) => {
-  let build: Function;
-
-  const options = {
-    mode: development ? "development" : "production",
-    target,
-    publicPath,
-  };
+  analyze = false,
+}: BuildOptions) => {
+  // Try getting the `build` function from `@frontity/core`.
+  let build: (...options: any[]) => Promise<void>;
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     build = require("@frontity/core").build;
   } catch (error) {
     const message =
@@ -31,9 +65,19 @@ export default async ({
     errorLogger(error, message);
   }
 
+  // Generate options for the core's `build` function.
+  const options = {
+    mode: development ? "development" : "production",
+    target,
+    publicPath,
+    analyze,
+  };
+
   try {
     await build(options);
   } catch (error) {
     errorLogger(error);
   }
 };
+
+export default buildCommand;

--- a/packages/frontity/src/commands/dev.ts
+++ b/packages/frontity/src/commands/dev.ts
@@ -4,33 +4,84 @@ import choosePort from "../utils/choosePort";
 
 const HOST = process.env.HOST || "0.0.0.0";
 
-export default async ({
+/**
+ * Options for the {@link devCommand} function.
+ */
+interface DevOptions {
+  /**
+   * Builds the project for production.
+   *
+   * @defaultValue `false`
+   */
+  production?: boolean;
+
+  /**
+   * Runs the server on a custom port.
+   *
+   * @defaultValue `3000`
+   */
+  port?: number;
+
+  /**
+   * Runs the server using https.
+   *
+   * @defaultValue `false`
+   */
+  https?: boolean;
+
+  /**
+   * Create bundles with "es5" or "module".
+   *
+   * @defaultValue `"module"`
+   */
+  target?: "es5" | "module";
+
+  /**
+   * Don't open a browser window with the localhost.
+   *
+   * @defaultValue `false`
+   */
+  dontOpenBrowser?: boolean;
+
+  /**
+   * Set the public path for static assets.
+   *
+   * @defaultValue `"/static/"`
+   */
+  publicPath?: string;
+
+  /**
+   * Create HTML files for bundle analyzing.
+   *
+   * @defaultValue `false`
+   */
+  analyze?: boolean;
+}
+
+/**
+ * Start a server in development mode.
+ *
+ * This function is executed by the CLI when running the `npx frontity dev`
+ * command.
+ *
+ * @param options - Object of type {@link DevOptions}.
+ *
+ * @returns Void.
+ */
+const devCommand = async ({
   production = false,
   port = 3000,
   https = false,
   target = "module",
   dontOpenBrowser = false,
   publicPath = "/static/",
-}: {
-  production?: boolean;
-  port?: number;
-  https?: boolean;
-  target?: "es5" | "module";
-  dontOpenBrowser?: boolean;
-  publicPath?: string;
-}) => {
-  let dev: Function;
-
-  const options = {
-    mode: production ? "production" : "development",
-    port,
-    isHttps: !!https,
-    target,
-    openBrowser: !dontOpenBrowser,
-    publicPath,
-  };
+  analyze = false,
+}: DevOptions) => {
+  // Try getting the `dev` function from `@frontity/core`.
+  let dev: (...options: any[]) => Promise<void>;
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     dev = require("@frontity/core").dev;
   } catch (error) {
     const message =
@@ -43,6 +94,17 @@ export default async ({
     errorLogger(error, message);
   }
 
+  // Generate options for the core's `dev` function.
+  const options = {
+    mode: production ? "production" : "development",
+    port,
+    isHttps: !!https,
+    target,
+    openBrowser: !dontOpenBrowser,
+    publicPath,
+    analyze,
+  };
+
   try {
     const port = await choosePort(HOST, options.port);
     if (port === null) {
@@ -53,3 +115,5 @@ export default async ({
     errorLogger(error);
   }
 };
+
+export default devCommand;

--- a/packages/frontity/src/commands/dev.ts
+++ b/packages/frontity/src/commands/dev.ts
@@ -65,8 +65,6 @@ interface DevOptions {
  * command.
  *
  * @param options - Object of type {@link DevOptions}.
- *
- * @returns Void.
  */
 const devCommand = async ({
   production = false,


### PR DESCRIPTION
**What**:

Add a new option to the `npx frontity dev` command to generate the HTML files for bundle analysis.

This option is `opt-in` so you would have to explicitly set `--analyze` in order to generate the HTML files.

**Why**:

This would make building times

**How**:

Adding an `--analyze` flag to the CLI's dev command and passing the value to the `dev` script of `@frontity/core`.

That value is passed down to the `plugins` function that generates the Webpack's plugin configuration. The [Bundle Analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) plugin is then added depending on the flag's value.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] TSDocs
- [x] TypeScript
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
