### PR TITLE
Use a relative path with non-external redirections

### DIFF
--- a/.changeset/sour-wolves-boil.md
+++ b/.changeset/sour-wolves-boil.md
@@ -1,0 +1,5 @@
+---
+"@frontity/tiny-router": patch
+---
+
+Make redirection URLs relative, so they redirect to `localhost` in a dev environment.

--- a/e2e/integration/wordpress-01/redirections.spec.ts
+++ b/e2e/integration/wordpress-01/redirections.spec.ts
@@ -20,6 +20,19 @@ describe("Redirections", () => {
     cy.get("#link-counter").should("contain.text", "1");
   });
 
+  it("Should redirect to the requested domain, not to `state.frontity.url`", () => {
+    cy.visit(
+      "http://localhost:3001/hello-world/?frontity_name=redirections&frontity_url=http://my.frontity.site"
+    );
+
+    cy.location("href").should(
+      "eq",
+      "http://localhost:3001/hello-world-redirected/"
+    );
+    cy.get("#post").should("exist");
+    cy.get("#link-counter").should("contain.text", "1");
+  });
+
   it("Should not redirect server side when in embedded mode", () => {
     cy.visit(
       "http://localhost:3001/hello-world/?frontity_name=redirections&frontity_embedded=true",

--- a/e2e/packages/redirections/src/index.tsx
+++ b/e2e/packages/redirections/src/index.tsx
@@ -169,6 +169,10 @@ const redirections: Redirections = {
           state.source.redirections = query.redirections;
         }
 
+        if (state.frontity.options.url) {
+          state.frontity.url = state.frontity.options.url;
+        }
+
         const handler = {
           pattern: "/urls-with-redirections/:slug",
           func: async ({ state, link }) => {

--- a/packages/tiny-router/src/__tests__/index.test.ts
+++ b/packages/tiny-router/src/__tests__/index.test.ts
@@ -431,9 +431,7 @@ describe("actions", () => {
 
       await store.actions.router.beforeSSR({ ctx: ctx as Context });
 
-      expect(ctx.redirect).toHaveBeenCalledWith(
-        "https://domain.com/final-url/?query=value#hash"
-      );
+      expect(ctx.redirect).toHaveBeenCalledWith("/final-url/?query=value#hash");
       expect(ctx.status).toBe(123);
     });
 

--- a/packages/tiny-router/src/actions.ts
+++ b/packages/tiny-router/src/actions.ts
@@ -286,12 +286,9 @@ export const beforeSSR: TinyRouter["actions"]["router"]["beforeSSR"] = ({
     // or 308.
     ctx.status = data.redirectionStatus;
 
-    // 30X redirections need the be absolute, so we add the Frontity URL.
-    const redirectionURL =
-      state.frontity.url.replace(/\/$/, "") +
-      location.pathname +
-      location.search +
-      location.hash;
+    // 30X redirections can be relative so adding the Frontity URL is not
+    // needed - see https://tools.ietf.org/html/rfc7231#page-68.
+    const redirectionURL = location.pathname + location.search + location.hash;
 
     ctx.redirect(redirectionURL);
     return;


### PR DESCRIPTION
**What**:

Turn the absolute URL included in the `location` prop of data objects into a relative URL, just for non external redirections (i.e. links pointing to the same domain).

**Why**:

To fix https://github.com/frontity/frontity/issues/728.

**How**:

Removing the line that was adding `state.frontity.url` to the generated redirection URL.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests
- [x] End to end tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
