### PR TITLE
Collapse empty ad slots 

### DIFF
--- a/.changeset/thirty-readers-smile.md
+++ b/.changeset/thirty-readers-smile.md
@@ -2,4 +2,5 @@
 "@frontity/google-ad-manager": patch
 ---
 
-Collapse ad slots that are not filled by Google Publisher Tag. Until now, slots would always take up space on the page as defined by its fill even if the ad call fails to fill that slot with an ad.
+The `GooglePublisherTag` component now accepts an optional `collapseEmptyDiv` prop
+which if `true` will collapse ad slots that are not filled by Google Publisher Tag.

--- a/.changeset/thirty-readers-smile.md
+++ b/.changeset/thirty-readers-smile.md
@@ -1,0 +1,5 @@
+---
+"@frontity/google-ad-manager": patch
+---
+
+Collapse ad slots that are not filled by Google Publisher Tag. Until now, slots would always take up space on the page as defined by its fill even if the ad call fails to fill that slot with an ad.

--- a/packages/google-ad-manager/src/components/google-publisher-tag.tsx
+++ b/packages/google-ad-manager/src/components/google-publisher-tag.tsx
@@ -45,6 +45,8 @@ const GooglePublisherTag: React.FC<
       Object.entries(targeting).forEach(([key, value]) =>
         slot.current.setTargeting(key, value)
       );
+      // Collapse empty ad slots
+      slot.current.setCollapseEmptyDiv(true);
 
       // Enables all GPT services.
       window.googletag.enableServices();

--- a/packages/google-ad-manager/src/components/google-publisher-tag.tsx
+++ b/packages/google-ad-manager/src/components/google-publisher-tag.tsx
@@ -14,7 +14,7 @@ import GoogleAdManager, { GooglePublisherTagProps, Size } from "../../types";
  */
 const GooglePublisherTag: React.FC<
   Connect<GoogleAdManager, GooglePublisherTagProps>
-> = ({ unit, size, id, targeting = {}, data }) => {
+> = ({ unit, size, id, targeting = {}, data, collapseEmptyDiv = false }) => {
   /**
    * Append link to the `id` if `data` is specified.
    *
@@ -45,8 +45,8 @@ const GooglePublisherTag: React.FC<
       Object.entries(targeting).forEach(([key, value]) =>
         slot.current.setTargeting(key, value)
       );
-      // Collapse empty ad slots
-      slot.current.setCollapseEmptyDiv(true);
+      // Collapse empty ad slots if
+      slot.current.setCollapseEmptyDiv(collapseEmptyDiv);
 
       // Enables all GPT services.
       window.googletag.enableServices();

--- a/packages/google-ad-manager/types.ts
+++ b/packages/google-ad-manager/types.ts
@@ -78,7 +78,7 @@ export interface GooglePublisherTagProps {
    *
    * @defaultValue false
    */
-  collapseEmptyDiv: boolean;
+  collapseEmptyDiv?: boolean;
 }
 
 /**

--- a/packages/google-ad-manager/types.ts
+++ b/packages/google-ad-manager/types.ts
@@ -68,6 +68,17 @@ export interface GooglePublisherTagProps {
    * rendered by a slot.
    */
   data?: any;
+
+  /**
+   * A value passed as the first parameter to slot.setCollapseEmptyDiv(collapseEmptyDiv).
+   *
+   * @remarks
+   * More details in:
+   * https://developers.google.com/publisher-tag/reference#googletag.Slot_setCollapseEmptyDiv
+   *
+   * @defaultValue false
+   */
+  collapseEmptyDiv: boolean;
 }
 
 /**


### PR DESCRIPTION
**What**:

To collapse empty ad slots in Frontity Google Ad manager package.

**Why**:

By default, ad slots which are not filled are left visible, which may result in blank space on page.

Reference - https://developers.google.com/publisher-tag/samples/collapse-empty-ad-slots

**How**:

We could avoid that by calling `slot.current.setCollapseEmptyDiv(true);` on each slot.  

**Tasks**:

- [x] Code
- [x] TypeScript
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->
