### PR TITLE
Skip the BrowserStack related workflows for externals contributions

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: github.repository_owner == 'frontity'
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bs-dev.yml
+++ b/.github/workflows/e2e-bs-dev.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   e2e-browserstack:
+    if: github.repository_owner == 'frontity'
     runs-on: ubuntu-16.04
 
     steps:

--- a/.github/workflows/e2e-bs-dev.yml
+++ b/.github/workflows/e2e-bs-dev.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   e2e-browserstack:
-    if: github.repository_owner == 'frontity'
     runs-on: ubuntu-16.04
+    if: github.repository_owner == 'frontity'
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bs-pr.yml
+++ b/.github/workflows/e2e-bs-pr.yml
@@ -4,8 +4,8 @@ on: [pull_request]
 
 jobs:
   e2e-browserstack:
-    if: github.repository_owner == 'frontity'
     runs-on: ubuntu-16.04
+    if: github.repository_owner == 'frontity'
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bs-pr.yml
+++ b/.github/workflows/e2e-bs-pr.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   e2e-browserstack:
+    if: github.repository_owner == 'frontity'
     runs-on: ubuntu-16.04
 
     steps:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: github.repository_owner == 'frontity'
 
     steps:
       - name: Checkout

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,8 +7,9 @@ on:
 jobs:
   tasks:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'frontity'
+
     steps:
       - uses: kentaro-m/task-completed-checker-action@v0.1.0
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'frontity'
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master


### PR DESCRIPTION
**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
In order to avoid a lot of failed workflows we should skip the ones that are coming from externals contributors. Precisely talking about the ones that need to have access to secrets.

**How**:

<!-- How were these changes implemented? -->
Add an `if` case for each BrowserStack workflow to run only for the _owners_.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->


<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] Code
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
These are not going to be skipped entirely, at merge time these will run, as the merge is done by the owners.