### PR TITLE
Fix infinite scroll link race condition

### DIFF
--- a/.changeset/sixty-scissors-shave.md
+++ b/.changeset/sixty-scissors-shave.md
@@ -1,0 +1,5 @@
+---
+"@frontity/hooks": patch
+---
+
+Prevent a possible race condition in `useInfiniteScroll`. It could happen when a link changes `state.router.link` right before the `useEffect` callback that manages the route runs.

--- a/packages/hooks/use-infinite-scroll/index.ts
+++ b/packages/hooks/use-infinite-scroll/index.ts
@@ -40,6 +40,10 @@ const useInfiniteScroll = ({
 
   const { state, actions } = useConnect<Packages>();
 
+  // Get the current router link. It will be used later to check if the link
+  // should be updated in case the route's `useInView` hook kicks in.
+  const routerLink = state.router.link;
+
   // Declare the data objects needed, all of them initialized as `null`.
   let current: Data = null;
   let next: Data = null;
@@ -107,13 +111,13 @@ const useInfiniteScroll = ({
   useEffect(() => {
     if (!isSupported) return;
 
-    if (route.inView && state.router.link !== currentLink) {
+    if (route.inView && routerLink !== currentLink) {
       actions.router.set(currentLink, {
         method: "replace",
         state: state.router.state,
       });
     }
-  }, [route.inView, currentLink]);
+  }, [route.inView, routerLink, currentLink]);
 
   return isSupported
     ? {


### PR DESCRIPTION
**What**:

Prevent a possible race condition in `useInfiniteScroll`. It could happen when a link changes `state.router.link` right before the `useEffect` callback that manages the route ([this one](https://github.com/frontity/frontity/blob/0dc2e0476f9d5efc81ce27ce91a58b9595b15806/packages/hooks/use-infinite-scroll/index.ts#L108-L120)) runs.

**Why**:

It's a very sneaky bug that appears just a few times, but when it does, it makes the e2e tests to fail. It could be affecting UX as well. 

**How**:

Getting the value of `state.router.link` outside the `useEffect` callback and passing it as a callback dependency.

**Tasks**:

- [x] Code
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional Comments**

I wasn't able to reproduce the error programmatically - that's why I didn't add any test.