### PR TITLE
Fixes behaviour for the `--typescript` flag when using `frontity create`

### DIFF
--- a/.changeset/sweet-jars-matter.md
+++ b/.changeset/sweet-jars-matter.md
@@ -1,0 +1,5 @@
+---
+"frontity": patch
+---
+
+Modifies the `frontity create` command so it generates a `tsconfig.json` file and adds dev dependencies to `package.json`.

--- a/.changeset/sweet-jars-matter.md
+++ b/.changeset/sweet-jars-matter.md
@@ -2,4 +2,4 @@
 "frontity": patch
 ---
 
-Modifies the `frontity create` command so it generates a `tsconfig.json` file and adds dev dependencies to `package.json`.
+Modifies the `frontity create` command so it generates a `tsconfig.json` file and adds dev dependencies to `package.json`. Feature discussion: https://community.frontity.org/t/full-typescript-support-in-frontity-create/880

--- a/packages/frontity/src/commands/__tests__/__snapshots__/create.test.ts.snap
+++ b/packages/frontity/src/commands/__tests__/__snapshots__/create.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "name": "random-name",
   "path": "/path/to/project",
   "theme": "@frontity/mars-theme",
+  "typescript": false,
 }
 `;
 
@@ -22,6 +23,7 @@ Array [
     "random-name",
     "@frontity/mars-theme",
     "/path/to/project",
+    false,
   ],
 ]
 `;

--- a/packages/frontity/src/commands/__tests__/create.test.ts
+++ b/packages/frontity/src/commands/__tests__/create.test.ts
@@ -14,6 +14,7 @@ describe("create", () => {
     mockedSteps.ensureProjectDir.mockReset();
     mockedSteps.createPackageJson.mockReset();
     mockedSteps.createFrontitySettings.mockReset();
+    mockedSteps.createTsConfig.mockReset();
     mockedSteps.cloneStarterTheme.mockReset();
     mockedSteps.installDependencies.mockReset();
     mockedSteps.revertProgress.mockReset();
@@ -72,6 +73,7 @@ describe("create", () => {
       options.path,
       "@frontity/mars-theme"
     );
+    expect(mockedSteps.createTsConfig).toHaveBeenCalledWith(options.path);
   });
 
   test("calls removeProgress on error with dirExisted=true", async () => {

--- a/packages/frontity/src/commands/__tests__/create.test.ts
+++ b/packages/frontity/src/commands/__tests__/create.test.ts
@@ -25,6 +25,7 @@ describe("create", () => {
       name: "random-name",
       path: "/path/to/project",
       theme: "@frontity/mars-theme",
+      typescript: false,
     };
     await create(options);
     expect(mockedSteps.normalizeOptions.mock.calls[0][1]).toMatchSnapshot();
@@ -43,11 +44,18 @@ describe("create", () => {
     const options = {
       name: "random-name",
       path: "/path/to/project",
+      theme: "@frontity/mars-theme",
       typescript: false,
     };
 
     await create(options);
 
+    expect(mockedSteps.createPackageJson).toHaveBeenCalledWith(
+      options.name,
+      options.theme,
+      options.path,
+      options.typescript
+    );
     expect(mockedSteps.createFrontitySettings).toHaveBeenCalledWith(
       "js",
       options.name,
@@ -64,9 +72,18 @@ describe("create", () => {
     const options = {
       name: "random-name",
       path: "/path/to/project",
+      theme: "@frontity/mars-theme",
       typescript: true,
     };
+
     await create(options);
+
+    expect(mockedSteps.createPackageJson).toHaveBeenCalledWith(
+      options.name,
+      options.theme,
+      options.path,
+      options.typescript
+    );
     expect(mockedSteps.createFrontitySettings).toHaveBeenCalledWith(
       "ts",
       options.name,

--- a/packages/frontity/src/commands/__tests__/create.test.ts
+++ b/packages/frontity/src/commands/__tests__/create.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-try-expect, jest/no-conditional-expect */
 import create from "../create";
 import * as steps from "../../steps";
 

--- a/packages/frontity/src/commands/create.ts
+++ b/packages/frontity/src/commands/create.ts
@@ -7,6 +7,7 @@ import {
   createPackageJson,
   createReadme,
   createFrontitySettings,
+  createTsConfig,
   cloneStarterTheme,
   installDependencies,
   downloadFavicon,
@@ -42,7 +43,7 @@ export default (options?: CreateCommandOptions) =>
       let step: Promise<any>;
       let dirExisted: boolean;
 
-      // 1. Parses and validates options.
+      // Parses and validates options.
       const {
         name,
         theme,
@@ -56,22 +57,22 @@ export default (options?: CreateCommandOptions) =>
       });
 
       try {
-        // 2. Ensures that the project dir exists and is empty.
+        // Ensures that the project dir exists and is empty.
         step = ensureProjectDir(path);
         emit("message", `Ensuring ${chalk.yellow(path)} directory.`, step);
         dirExisted = await step;
 
-        // 3. Creates `README.md`
+        // Creates `README.md`
         step = createReadme(name, path);
         emit("message", `Creating ${chalk.yellow("README.md")}.`, step);
         await step;
 
-        // 3. Creates `package.json`.
+        // Creates `package.json`.
         step = createPackageJson(name, theme, path);
         emit("message", `Creating ${chalk.yellow("package.json")}.`, step);
         await step;
 
-        // 4. Creates `frontity.settings`.
+        // Creates `frontity.settings`.
         const extension = typescript ? "ts" : "js";
         step = createFrontitySettings(extension, name, path, theme);
         emit(
@@ -81,17 +82,24 @@ export default (options?: CreateCommandOptions) =>
         );
         await step;
 
-        // 5. Clones the theme inside `packages`.
+        // Creates `tsconfig.json`.
+        if (typescript) {
+          step = createTsConfig(path);
+          emit("message", `Creating ${chalk.yellow("tsconfig.json")}.`, step);
+          await step;
+        }
+
+        // Clones the theme inside `packages`.
         step = cloneStarterTheme(theme, path);
         emit("message", `Cloning ${chalk.green(theme)}.`, step);
         await step;
 
-        // 6. Installs dependencies.
+        // Installs dependencies.
         step = installDependencies(path);
         emit("message", `Installing dependencies.`, step);
         await step;
 
-        // 7. Download favicon.
+        // Download favicon.
         step = downloadFavicon(path);
         emit("message", `Downloading ${chalk.yellow("favicon.ico")}.`, step);
         await step;

--- a/packages/frontity/src/commands/create.ts
+++ b/packages/frontity/src/commands/create.ts
@@ -68,7 +68,7 @@ export default (options?: CreateCommandOptions) =>
         await step;
 
         // Creates `package.json`.
-        step = createPackageJson(name, theme, path);
+        step = createPackageJson(name, theme, path, typescript);
         emit("message", `Creating ${chalk.yellow("package.json")}.`, step);
         await step;
 

--- a/packages/frontity/src/steps/__tests__/__snapshots__/steps.test.ts.snap
+++ b/packages/frontity/src/steps/__tests__/__snapshots__/steps.test.ts.snap
@@ -365,6 +365,15 @@ Array [
 ]
 `;
 
+exports[`createTsConfig works as expected" 1`] = `
+Array [
+  Array [
+    "/path/to/project/tsconfig.json",
+    "$tsconfig$",
+  ],
+]
+`;
+
 exports[`downloadFavicon works as expected 1`] = `
 Array [
   Array [

--- a/packages/frontity/src/steps/__tests__/__snapshots__/steps.test.ts.snap
+++ b/packages/frontity/src/steps/__tests__/__snapshots__/steps.test.ts.snap
@@ -253,6 +253,72 @@ Array [
 ]
 `;
 
+exports[`createPackageJson works when "typescript" is true 1`] = `
+Array [
+  Array [
+    "frontity",
+  ],
+  Array [
+    "@frontity/core",
+  ],
+  Array [
+    "@frontity/wp-source",
+  ],
+  Array [
+    "@frontity/tiny-router",
+  ],
+  Array [
+    "@frontity/html2react",
+  ],
+  Array [
+    "@types/react",
+  ],
+  Array [
+    "@types/node-fetch",
+  ],
+]
+`;
+
+exports[`createPackageJson works when "typescript" is true 2`] = `
+Array [
+  Array [
+    "/path/to/project/package.json",
+    "{
+  \\"name\\": \\"random-name\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"private\\": true,
+  \\"description\\": \\"Frontity project\\",
+  \\"keywords\\": [
+    \\"frontity\\"
+  ],
+  \\"engines\\": {
+    \\"node\\": \\">=10.0.0\\",
+    \\"npm\\": \\">=6.0.0\\"
+  },
+  \\"scripts\\": {
+    \\"dev\\": \\"frontity dev\\",
+    \\"build\\": \\"frontity build\\",
+    \\"serve\\": \\"frontity serve\\"
+  },
+  \\"prettier\\": {},
+  \\"dependencies\\": {
+    \\"frontity\\": \\"^1.0.0\\",
+    \\"@frontity/core\\": \\"^1.0.0\\",
+    \\"@frontity/wp-source\\": \\"^1.0.0\\",
+    \\"@frontity/tiny-router\\": \\"^1.0.0\\",
+    \\"@frontity/html2react\\": \\"^1.0.0\\",
+    \\"random-theme\\": \\"./packages/random-theme\\"
+  },
+  \\"devDependencies\\": {
+    \\"@types/react\\": \\"^1.0.0\\",
+    \\"@types/node-fetch\\": \\"^1.0.0\\"
+  }
+}
+",
+  ],
+]
+`;
+
 exports[`createPackageJson works with a theme like "@frontity/mars-theme" 1`] = `
 Array [
   Array [

--- a/packages/frontity/src/steps/__tests__/steps.test.ts
+++ b/packages/frontity/src/steps/__tests__/steps.test.ts
@@ -3,6 +3,7 @@ import {
   ensureProjectDir,
   createPackageJson,
   createFrontitySettings,
+  createTsConfig,
   cloneStarterTheme,
   installDependencies,
   downloadFavicon,
@@ -190,6 +191,22 @@ describe("createFrontitySettings", () => {
     const theme = "@frontity/mars-theme";
 
     await createFrontitySettings(extension, name, path, theme);
+    expect(mockedFsExtra.readFile).toHaveBeenCalled();
+    expect(mockedFsExtra.writeFile.mock.calls).toMatchSnapshot();
+  });
+});
+
+describe("createTsConfig", () => {
+  beforeEach(() => {
+    mockedFsExtra.readFile.mockReset();
+    mockedFsExtra.readFile.mockResolvedValueOnce("$tsconfig$" as any);
+    mockedFsExtra.writeFile.mockReset();
+  });
+
+  test('works as expected"', async () => {
+    const path = "/path/to/project";
+
+    await createTsConfig(path);
     expect(mockedFsExtra.readFile).toHaveBeenCalled();
     expect(mockedFsExtra.writeFile.mock.calls).toMatchSnapshot();
   });

--- a/packages/frontity/src/steps/__tests__/steps.test.ts
+++ b/packages/frontity/src/steps/__tests__/steps.test.ts
@@ -149,8 +149,9 @@ describe("createPackageJson", () => {
     const name = "random-name";
     const theme = "@frontity/mars-theme";
     const path = "/path/to/project";
+    const typescript = false;
 
-    await createPackageJson(name, theme, path);
+    await createPackageJson(name, theme, path, typescript);
     expect(mockedUtils.fetchPackageVersion.mock.calls).toMatchSnapshot();
     expect(mockedFsExtra.writeFile.mock.calls).toMatchSnapshot();
   });
@@ -159,8 +160,20 @@ describe("createPackageJson", () => {
     const name = "random-name";
     const theme = "random-theme";
     const path = "/path/to/project";
+    const typescript = false;
 
-    await createPackageJson(name, theme, path);
+    await createPackageJson(name, theme, path, typescript);
+    expect(mockedUtils.fetchPackageVersion.mock.calls).toMatchSnapshot();
+    expect(mockedFsExtra.writeFile.mock.calls).toMatchSnapshot();
+  });
+
+  test('works when "typescript" is true', async () => {
+    const name = "random-name";
+    const theme = "random-theme";
+    const path = "/path/to/project";
+    const typescript = true;
+
+    await createPackageJson(name, theme, path, typescript);
     expect(mockedUtils.fetchPackageVersion.mock.calls).toMatchSnapshot();
     expect(mockedFsExtra.writeFile.mock.calls).toMatchSnapshot();
   });

--- a/packages/frontity/src/steps/index.ts
+++ b/packages/frontity/src/steps/index.ts
@@ -233,37 +233,14 @@ export const createFrontitySettings = async (
  * @param path - The path where the file will be created.
  */
 export const createTsConfig = async (path: string) => {
-  const tsConfig = {
-    compilerOptions: {
-      // Target latest version of ECMAScript.
-      target: "es2017",
-      // Search under node_modules for non-relative imports.
-      moduleResolution: "node",
-      // commonjs modules.
-      module: "commonjs",
-      // Allow default imports from modules with no default export.
-      allowSyntheticDefaultImports: true,
-      // Don't emit; allow Babel to transform files.
-      noEmit: true,
-      // Import non-ES modules as default imports.
-      esModuleInterop: true,
-      // Resolve JSON files.
-      resolveJsonModule: true,
-      // Support for JSX runtime.
-      jsx: "react-jsx",
-      // Support for emotion css prop with types
-      jsxImportSource: "@emotion/react",
-      // Transpile JS as well.
-      allowJs: true,
-      // Allows using the css prop in JSX components.
-      types: ["@emotion/react/types/css-prop"],
-    },
-    include: ["packages/**/*"],
-  };
-
+  const fileTemplate = await readFile(
+    resolvePath(__dirname, "../../templates/tsconfig.json"),
+    {
+      encoding: "utf8",
+    }
+  );
   const filePath = resolvePath(path, "tsconfig.json");
-  const fileData = `${JSON.stringify(tsConfig, null, 2)}${EOL}`;
-  await writeFile(filePath, fileData);
+  await writeFile(filePath, fileTemplate);
 };
 
 /**

--- a/packages/frontity/src/steps/index.ts
+++ b/packages/frontity/src/steps/index.ts
@@ -228,6 +228,45 @@ export const createFrontitySettings = async (
 };
 
 /**
+ * Create a `tsconfig.json` file.
+ *
+ * @param path - The path where the file will be created.
+ */
+export const createTsConfig = async (path: string) => {
+  const tsConfig = {
+    compilerOptions: {
+      // Target latest version of ECMAScript.
+      target: "es2017",
+      // Search under node_modules for non-relative imports.
+      moduleResolution: "node",
+      // commonjs modules.
+      module: "commonjs",
+      // Allow default imports from modules with no default export.
+      allowSyntheticDefaultImports: true,
+      // Don't emit; allow Babel to transform files.
+      noEmit: true,
+      // Import non-ES modules as default imports.
+      esModuleInterop: true,
+      // Resolve JSON files.
+      resolveJsonModule: true,
+      // Support for JSX runtime.
+      jsx: "react-jsx",
+      // Support for emotion css prop with types
+      jsxImportSource: "@emotion/react",
+      // Transpile JS as well.
+      allowJs: true,
+      // Allows using the css prop in JSX components.
+      types: ["@emotion/react/types/css-prop"],
+    },
+    include: ["packages/**/*"],
+  };
+
+  const filePath = resolvePath(path, "tsconfig.json");
+  const fileData = `${JSON.stringify(tsConfig, null, 2)}${EOL}`;
+  await writeFile(filePath, fileData);
+};
+
+/**
  * Clone the starter theme.
  *
  * @param theme - The name of the theme.

--- a/packages/frontity/src/steps/types.ts
+++ b/packages/frontity/src/steps/types.ts
@@ -98,7 +98,7 @@ export type PackageJson = {
   /**
    * The prettier configuration acording to the Frontity coding standards.
    */
-  prettier: object;
+  prettier: Record<string, unknown>;
 
   /**
    * The dependencies of the Frontity project.

--- a/packages/frontity/src/steps/types.ts
+++ b/packages/frontity/src/steps/types.ts
@@ -106,4 +106,11 @@ export type PackageJson = {
   dependencies: {
     [key: string]: string;
   };
+
+  /**
+   * The development dependencies of the Frontity project.
+   */
+  devDependencies?: {
+    [key: string]: string;
+  };
 };

--- a/packages/frontity/templates/tsconfig.json
+++ b/packages/frontity/templates/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    // Target latest version of ECMAScript.
+    "target": "es2017",
+    // Search under node_modules for non-relative imports.
+    "moduleResolution": "node",
+    // commonjs modules.
+    "module": "commonjs",
+    // Allow default imports from modules with no default export.
+    "allowSyntheticDefaultImports": true,
+    // Don't emit; allow Babel to transform files.
+    "noEmit": true,
+    // Import non-ES modules as default imports.
+    "esModuleInterop": true,
+    // Resolve JSON files.
+    "resolveJsonModule": true,
+    // Support for JSX runtime.
+    "jsx": "react-jsx",
+    // Support for emotion css prop with types
+    "jsxImportSource": "@emotion/react",
+    // Transpile JS as well.
+    "allowJs": true,
+    // Allows using the css prop in JSX components.
+    "types": ["@emotion/react/types/css-prop"]
+  },
+  "include": ["packages/**/*"]
+}


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here: 
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Adding needed behaviour on `frontity create --typescript` for a seamless init of a project.

**Why**:

<!-- Why are these changes necessary? -->
Because it is annoying to manually do these steps every time.

**How**:

<!-- How were these changes implemented? -->
Added additional steps to the create command in `frontity`.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] TSDocs
- [x] TypeScript
- [x] Unit tests
- [x] Update community discussions
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] Update starter themes
- [ ] Update other packages
- [ ] End to end tests
- [ ] TypeScript tests
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
