### PR TITLE
Pass `libraries` to derived properties

### DIFF
--- a/.changeset/heavy-news-train.md
+++ b/.changeset/heavy-news-train.md
@@ -1,0 +1,6 @@
+---
+"@frontity/connect": patch
+"@frontity/types": patch
+---
+
+Modify derived props so they receive `state` and `libraries` as arguments. Also, fix the `Derived` type definition.

--- a/packages/connect/src/__tests__/create-store.tests.js
+++ b/packages/connect/src/__tests__/create-store.tests.js
@@ -14,6 +14,10 @@ beforeEach(() => {
         prop3: ({ state }) => state.prop1 + state.nested1.prop2,
         prop4: ({ state }) => (num) => state.nested1.prop3 + num,
         prop5: 0,
+        prop6: ({ state, libraries }) => {
+          const { prop3, prop4 } = state.nested1;
+          return libraries.nested1.sum(prop3, prop4(0));
+        },
       },
     },
     actions: {
@@ -63,6 +67,11 @@ beforeEach(() => {
         throw new Error("action11 error");
       },
     },
+    libraries: {
+      nested1: {
+        sum: (...args) => args.reduce((a, b) => a + b, 0),
+      },
+    },
   };
 
   store = createStore(config);
@@ -98,6 +107,10 @@ describe("createStore", () => {
     });
     expect(store1.state.prop2).toBe(2);
     expect(store2.state.prop2).toBe(4);
+  });
+
+  it("should inject `libraries` to derived properties", () => {
+    expect(store.state.nested1.prop6).toBe(6);
   });
 });
 

--- a/packages/connect/src/create-store.js
+++ b/packages/connect/src/create-store.js
@@ -102,9 +102,12 @@ export const createStore = (config) => {
         }
 
         // If it's a function, return the result of that function run with the
-        // root state.
+        // root state and libraries.
         if (!Array.isArray(target) && typeof result === "function") {
-          return result({ state: observableState });
+          return result({
+            state: observableState,
+            libraries: config.libraries,
+          });
         }
 
         return result;

--- a/packages/types/src/__tests__/derived.tests.ts
+++ b/packages/types/src/__tests__/derived.tests.ts
@@ -18,6 +18,11 @@ interface Package1 extends Package {
       };
     };
   };
+  libraries: {
+    namespace1: {
+      func1: (s: string) => string;
+    };
+  };
 }
 
 const package1: Package1 = {
@@ -25,8 +30,10 @@ const package1: Package1 = {
     namespace1: {
       prop1: "prop1",
       prop2: 2,
-      // Check that prop3 is a string (and not a function).
-      prop3: ({ state }) => state.namespace1.prop3,
+      // Check that prop3 is a string (and not a function). Also, check that
+      // derived state can access libraries.
+      prop3: ({ state, libraries }) =>
+        libraries.namespace1.func1(state.namespace1.prop3),
       // Check that prop4 returns a number (and not a function).
       prop4: ({ state }) => (str) => state.namespace1.nested1.prop5(str),
       unionDerivedProp1: ({ state }) => state.namespace1.unionDerivedProp1,
@@ -39,6 +46,11 @@ const package1: Package1 = {
           prop6: ({ state }) => state.namespace1.prop1.toLowerCase(),
         },
       },
+    },
+  },
+  libraries: {
+    namespace1: {
+      func1: (s) => s.trim(),
     },
   },
 };

--- a/packages/types/src/__tests__/merge-packages.tests.ts
+++ b/packages/types/src/__tests__/merge-packages.tests.ts
@@ -67,17 +67,12 @@ const packages: Package1 = {
   state: {
     namespace1: {
       prop1: "prop1",
-      prop2: ({ state, actions, libraries }) => {
+      prop2: ({ state, libraries }) => {
         // Test merged state.
         expectType<string>(state.namespace1.prop1);
         expectType<string>(state.namespace1.prop2);
         expectType<boolean>(state.namespace2.prop3);
         expectType<(str: string) => boolean>(state.namespace3.prop4);
-
-        // Test merged actions.
-        expectType<() => void>(actions.namespace1.action1);
-        expectType<(str: string) => void>(actions.namespace2.action2);
-        expectType<(str: string) => Promise<void>>(actions.namespace2.action3);
 
         // Test merged libraries
         expectType<() => void>(libraries.namespace1.library1);

--- a/packages/types/src/derived.ts
+++ b/packages/types/src/derived.ts
@@ -1,38 +1,34 @@
 /* eslint-disable jsdoc/require-jsdoc */
 
 import Package from "./package";
-import { ResolveState, ResolveActions } from "./utils";
+import { ResolveState } from "./utils";
 
 /**
  * Derived state is state that is calculated based on other piece of state in
  * your application.
  *
  * Derived state can have one of two types:
- * - Function which takes the application state, actions and libraries as
- *   arguments. The final state is calculated by invoking that function.
- * - A curried function, which takes takes the application state, actions and libraries as
- *   arguments and returns a function that takes any number of parameters. That
- *   function works like a "getter" for a piece of state.
+ * - Function which takes the application state and libraries as arguments. The
+ *   final state is calculated by invoking that function.
+ * - A curried function, which takes takes the application state and libraries
+ *   as arguments and returns a function that takes any number of parameters.
+ *   That function works like a "getter" for a piece of state.
  */
 export type Derived<Pkg extends Package, InputOrOutput, Output = null> = [
   Output
 ] extends [null]
   ? ({
       state,
-      actions,
       libraries,
     }: {
       state: ResolveState<Pkg["state"]>;
-      actions: ResolveActions<Pkg["actions"]>;
       libraries: Pkg["libraries"];
     }) => InputOrOutput
   : ({
       state,
-      actions,
       libraries,
     }: {
       state: ResolveState<Pkg["state"]>;
-      actions: ResolveActions<Pkg["actions"]>;
       libraries: Pkg["libraries"];
     }) => (input: InputOrOutput) => Output;
 


### PR DESCRIPTION
**What**:

Allow derived props to use libraries in their implementation.

**Why**:

To fix #716 

**How**:

Passing `libraries` when the derived props are instantiated inside `createStore`.

https://github.com/frontity/frontity/blob/61f71264db6e865c08065da067632c56384887c5/packages/connect/src/create-store.js#L107-L110

**Tasks**:

- [x] Code
- [x] TSDocs
- [x] TypeScript
- [x] Unit tests
- [x] TypeScript tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] End to end tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional comments**

`actions` are not passed down because it would break the Flux pattern (see https://github.com/frontity/frontity/issues/716#issuecomment-777340627).