### PR TITLE
Change conditional statement of GitHub workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.repo.name == github.repository
+    if: github.event.repository.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.repo.name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bs-dev.yml
+++ b/.github/workflows/e2e-bs-dev.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   e2e-browserstack:
     runs-on: ubuntu-16.04
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.repo.name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bs-dev.yml
+++ b/.github/workflows/e2e-bs-dev.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   e2e-browserstack:
     runs-on: ubuntu-16.04
-    if: github.event.repo.name == github.repository
+    if: github.event.repository.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bs-pr.yml
+++ b/.github/workflows/e2e-bs-pr.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   e2e-browserstack:
     runs-on: ubuntu-16.04
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.repo.name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-bs-pr.yml
+++ b/.github/workflows/e2e-bs-pr.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   e2e-browserstack:
     runs-on: ubuntu-16.04
-    if: github.event.repo.name == github.repository
+    if: github.event.repository.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.repo.name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.repo.name == github.repository
+    if: github.event.repository.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tasks:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.repo.name == github.repository
 
     steps:
       - uses: kentaro-m/task-completed-checker-action@v0.1.0

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tasks:
     runs-on: ubuntu-latest
-    if: github.event.repo.name == github.repository
+    if: github.event.repository.full_name == github.repository
 
     steps:
       - uses: kentaro-m/task-completed-checker-action@v0.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event.repo.name == github.repository
+    if: github.event.repository.full_name == github.repository
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.repo.name == github.repository
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
**What**:

Change the conditional statement of the GitHub workflows.

**Why**:

The workflows in the Pull Requests are working fine, but when merged into the `dev` branch, the workflow is being skipped. It seems the [Pull Request payload](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#pull_request) has a `pull_request` property and that's why `github.event.pull_request.head.repo.full_name` works, but the [Push payload](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push) doesn't have it.

**How**:

Looking into both payloads, it seems we can access `github.event.repository.full_name` directly in both cases.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- ignore-task-list-end -->
