### PR TITLE
Fix internal redirection for `homepage` in `wp-source`.

### DIFF
--- a/.changeset/cyan-clocks-tan.md
+++ b/.changeset/cyan-clocks-tan.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+Fix an incorrect regular expression which matches the link with internal redirections when a `homepage` is defined in `state.source`.

--- a/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
+++ b/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
@@ -414,7 +414,7 @@ Array [
   Object {
     "func": [Function],
     "name": "homepage",
-    "pattern": "RegExp:^/(?!(\\\\?([^&#]+&)*s=))",
+    "pattern": "RegExp:^/(?!(\\\\?([^&#]+&)*s=[^&#]*))(\\\\?([^#]+)*)?(#.*)?$",
     "priority": 10,
   },
 ]
@@ -436,7 +436,7 @@ Array [
   Object {
     "func": [Function],
     "name": "homepage",
-    "pattern": "RegExp:^/blog/(?!(\\\\?([^&#]+&)*s=))",
+    "pattern": "RegExp:^/blog/(?!(\\\\?([^&#]+&)*s=[^&#]*))(\\\\?([^#]+)*)?(#.*)?$",
     "priority": 10,
   },
   Object {

--- a/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
+++ b/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
@@ -420,6 +420,29 @@ Array [
 ]
 `;
 
+exports[`actions.source.init should add redirect for the specified homepage and subdirectory 1`] = `
+Array [
+  Object {
+    "func": [Function],
+    "name": "homepage",
+    "pattern": "RegExp:^/subdir/(?!(\\\\?([^&#]+&)*s=[^&#]*))(\\\\?([^#]+)*)?(#.*)?$",
+    "priority": 10,
+  },
+  Object {
+    "func": [Function],
+    "name": "subdirectory",
+    "pattern": "/subdir/:subpath*/",
+    "priority": 10,
+  },
+  Object {
+    "func": [Function],
+    "name": "subdirectory (reverse)",
+    "pattern": "/(.*)",
+    "priority": 10,
+  },
+]
+`;
+
 exports[`actions.source.init should add redirect for the specified posts page 1`] = `
 Array [
   Object {

--- a/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
+++ b/packages/wp-source/src/__tests__/__snapshots__/actions.tests.ts.snap
@@ -414,7 +414,7 @@ Array [
   Object {
     "func": [Function],
     "name": "homepage",
-    "pattern": "RegExp:^/(?!(\\\\?([^&#]+&)*s=[^&#]*))(\\\\?([^#]+)*)?(#.*)?$",
+    "pattern": "RegExp:^/($|#|\\\\?(?!([^&#]+&)*s=))",
     "priority": 10,
   },
 ]
@@ -425,7 +425,7 @@ Array [
   Object {
     "func": [Function],
     "name": "homepage",
-    "pattern": "RegExp:^/subdir/(?!(\\\\?([^&#]+&)*s=[^&#]*))(\\\\?([^#]+)*)?(#.*)?$",
+    "pattern": "RegExp:^/subdir/($|#|\\\\?(?!([^&#]+&)*s=))",
     "priority": 10,
   },
   Object {
@@ -459,7 +459,7 @@ Array [
   Object {
     "func": [Function],
     "name": "homepage",
-    "pattern": "RegExp:^/blog/(?!(\\\\?([^&#]+&)*s=[^&#]*))(\\\\?([^#]+)*)?(#.*)?$",
+    "pattern": "RegExp:^/blog/($|#|\\\\?(?!([^&#]+&)*s=))",
     "priority": 10,
   },
   Object {

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -274,7 +274,7 @@ const actions: WpSource["actions"]["source"] = {
     if (homepage) {
       const pattern = `RegExp:^${concatLink(
         subdirectory
-      )}(?!(\\?([^&#]+&)*s=))`;
+      )}(?!(\\?([^&#]+&)*s=))$`;
 
       redirections.push({
         name: "homepage",

--- a/packages/wp-source/src/actions.ts
+++ b/packages/wp-source/src/actions.ts
@@ -272,9 +272,32 @@ const actions: WpSource["actions"]["source"] = {
     } = state.source;
 
     if (homepage) {
-      const pattern = `RegExp:^${concatLink(
-        subdirectory
-      )}(?!(\\?([^&#]+&)*s=))$`;
+      const regex =
+        // prettier-ignore
+        // This regex is using negative lookahead. It means that the whole regex
+        // matches if the group using the negative lookahead DOES NOT match.
+        "(?!" +         // negative lookahead       
+          "(" +           // group    
+            "\\?" +         // match "?" literally
+            "(" +           // group     
+              "[^&#]+" +      // match any character that is not `&` or `#` 1 or more times 
+              "&" +           // match `&` literally
+            ")*" +          // match the group zero or more times
+            "s=[^&#]*" +    // match a search query param (e.g. `s=something`)
+          ")" +           // end group
+        ")" +           // end negative lookahead
+        "(" +           // group 
+          "\\?" +         // match "?" literally
+          "([^#]+)*" +    // match the query string part of the URL zero or more times
+        ")?" +          // match the group zero or one times
+        "(#.*)?" +      // match the hash part of the URL 
+        "$"; // match line end
+
+      const pattern = `RegExp:^${concatLink(subdirectory)}${regex}`;
+
+      // For those who are able to read that sort of thing the full pattern is:
+      // RegExp:^/(?!(\?([^&#]+&)*s=[^&#]*))(\?([^#]+)*)?(#.*)?$
+      // (It has to be double-escaped in the string form above though)
 
       redirections.push({
         name: "homepage",

--- a/packages/wp-source/src/utils.ts
+++ b/packages/wp-source/src/utils.ts
@@ -254,3 +254,37 @@ export const shouldBailRedirecting = (
     !redirection.isExternal
   );
 };
+
+/**
+ * Write verbose RegExp strings. It supports:
+ * - Expressions in multiple lines.
+ * - Single-line and multiple-line comments.
+ * - Interpolation.
+ *
+ * @remarks Purely based on
+ * https://keleshev.com/verbose-regular-expressions-in-javascript
+ *
+ * @param input - Input.
+ * @param args - Interpolated args.
+ * @returns Regexp in string format.
+ */
+export const verboseRegExp = (
+  input: TemplateStringsArray,
+  ...args: string[]
+) => {
+  // Concatenate input and arguments.
+  const source = input.raw.reduce(
+    (source, input, index) =>
+      source.concat(input, String.raw`${args[index] || ""}`),
+    ""
+  );
+
+  // These expressions are removed from the input:
+  // 1. (?<!\\)\s           -> whitespace not preceded by `\`
+  // 2. [/][/].*            -> Single-line comments
+  // 3. [/][*][\s\S]*[*][/] -> Multi-line comments
+  const regexp = /(?<!\\)\s|[/][/].*|[/][*][\s\S]*[*][/]/g;
+  const result = source.replace(regexp, "");
+
+  return result;
+};


### PR DESCRIPTION
**What**:

Fix #805

**Why**:

The regex used to get the internal redirection if a `homepage` is defined is not correct. As described in #805, the regex would match not only for the homepage, but also for other pages.

**How**:

Update the regex used to match the redirection if a homepage is present.

**Tasks**:

- [x] Code
- [x] TSDocs
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TypeScript
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**

