### PR TITLE
Remove negative lookbehind

### DIFF
--- a/.changeset/brave-kiwis-fry.md
+++ b/.changeset/brave-kiwis-fry.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+Remove a negative lookbehind in the `verboseRegExp` function.

--- a/packages/wp-source/src/__tests__/utils.tests.ts
+++ b/packages/wp-source/src/__tests__/utils.tests.ts
@@ -1,0 +1,61 @@
+/* eslint-disable jest/expect-expect */
+import { verboseRegExp } from "../utils";
+
+describe("verboseRegExp", () => {
+  const assertRegExpEqual = (str: string, regExp) => {
+    expect(new RegExp(str).toString()).toBe(regExp.toString());
+  };
+
+  it("should work with simple regexps", () => {
+    assertRegExpEqual(verboseRegExp`hai`, /hai/);
+    // eslint-disable-next-line no-empty-character-class
+    assertRegExpEqual(verboseRegExp`[]`, /[]/);
+  });
+
+  it("should ignore whitespaces and comments", () => {
+    assertRegExpEqual(verboseRegExp`x y`, /xy/);
+    assertRegExpEqual(
+      verboseRegExp`
+  x // ignored
+  y
+`,
+      /xy/
+    );
+    assertRegExpEqual(verboseRegExp`x /* ignored */ y`, /xy/);
+
+    // Also inside character classes:
+    assertRegExpEqual(verboseRegExp`[x y]`, /[xy]/);
+    assertRegExpEqual(
+      verboseRegExp`[x//comment
+  y]`,
+      /[xy]/
+    );
+    assertRegExpEqual(verboseRegExp`[x/*z][x*/z]`, /[xz]/);
+    assertRegExpEqual(verboseRegExp`[x/*z*/y]`, /[xy]/);
+  });
+
+  it("should not ignore escaped whitespace", () => {
+    // Escaped whitespace is not ignored:
+    assertRegExpEqual(verboseRegExp`\  `, / /);
+    assertRegExpEqual(verboseRegExp`\ x `, / x/);
+    assertRegExpEqual(verboseRegExp`\       `, / /);
+    assertRegExpEqual(verboseRegExp`  \  `, / /);
+    // Also not in brackets:
+    assertRegExpEqual(verboseRegExp`[\ ]`, /[ ]/);
+  });
+
+  it("should maintain other escaped characters", () => {
+    // Other escapes are passed through
+    assertRegExpEqual(verboseRegExp`\s`, /\s/);
+    assertRegExpEqual(verboseRegExp`\n`, /\n/);
+  });
+
+  it("should allow nested brackets", () => {
+    // Nested brackets are allowed
+    assertRegExpEqual(verboseRegExp` [x [y ]] `, /[x[y]]/);
+  });
+
+  it("should allow interpolation", () => {
+    assertRegExpEqual(verboseRegExp`${"hello"}_world`, /hello_world/);
+  });
+});

--- a/packages/wp-source/src/utils.ts
+++ b/packages/wp-source/src/utils.ts
@@ -274,17 +274,17 @@ export const verboseRegExp = (
 ) => {
   // Concatenate input and arguments.
   const source = input.raw.reduce(
-    (source, input, index) =>
-      source.concat(input, String.raw`${args[index] || ""}`),
+    (output, input, index) => output.concat(input, args[index] || ""),
     ""
   );
 
-  // These expressions are removed from the input:
-  // 1. (?<!\\)\s           -> whitespace not preceded by `\`
-  // 2. [/][/].*            -> Single-line comments
-  // 3. [/][*][\s\S]*[*][/] -> Multi-line comments
-  const regexp = /(?<!\\)\s|[/][/].*|[/][*][\s\S]*[*][/]/g;
-  const result = source.replace(regexp, "");
+  const result = source
+    // These expressions are removed from the input:
+    // 1. [/][/].*            -> Single-line comments
+    // 2. [/][*][\s\S]*[*][/] -> Multi-line comments
+    .replace(/[/][/].*|[/][*][\s\S]*[*][/]/g, "")
+    // Escaped whitespaces are preserved, all others removed.
+    .replace(/(?:\\(\s))?\s*/g, "$1");
 
   return result;
 };


### PR DESCRIPTION
**What**:

Remove a negative lookbehind in the `verboseRegExp` function.

**Why**:

To make tests pass again on Firefox 70. Fixes #809

**Tasks**:

- [x] Code
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->
