### PR TITLE
Fix twentytwenty headings

### DIFF
--- a/.changeset/rude-chicken-camp.md
+++ b/.changeset/rude-chicken-camp.md
@@ -1,0 +1,5 @@
+---
+"@frontity/twentytwenty-theme": patch
+---
+
+Fix some heading fonts and sizes.

--- a/packages/twentytwenty-theme/src/components/post/post-item.js
+++ b/packages/twentytwenty-theme/src/components/post/post-item.js
@@ -58,7 +58,7 @@ const PostItem = ({
 
           {/* The clickable heading for the post */}
           <PostLink link={item.link}>
-            <PostTitle
+            <PostItemTitle
               className="heading-size-1"
               dangerouslySetInnerHTML={{ __html: item.title.rendered }}
             />
@@ -138,6 +138,13 @@ export const SectionContainer = styled.div`
 
   @media (min-width: 700px) {
     width: calc(100% - 8rem);
+  }
+`;
+
+export const PostItemTitle = styled.h2`
+  margin: 0;
+  @media (min-width: 700px) {
+    font-size: 6.4rem;
   }
 `;
 

--- a/packages/twentytwenty-theme/src/components/post/post-item.js
+++ b/packages/twentytwenty-theme/src/components/post/post-item.js
@@ -143,9 +143,6 @@ export const SectionContainer = styled.div`
 
 export const PostTitle = styled.h1`
   margin: 0;
-  @media (min-width: 700px) {
-    font-size: 6.4rem !important;
-  }
 `;
 
 export const PostCaption = styled(SectionContainer)`

--- a/packages/twentytwenty-theme/src/components/post/post-item.js
+++ b/packages/twentytwenty-theme/src/components/post/post-item.js
@@ -209,4 +209,20 @@ export const EntryContent = styled.div`
     margin: 2em 0;
     max-width: 100%;
   }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  cite,
+  figcaption,
+  table,
+  address,
+  .wp-caption-text,
+  .wp-block-file {
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+      Helvetica, sans-serif;
+  }
 `;

--- a/packages/twentytwenty-theme/src/components/post/post-item.js
+++ b/packages/twentytwenty-theme/src/components/post/post-item.js
@@ -222,4 +222,27 @@ export const EntryContent = styled.div`
     font-family: "Inter", -apple-system, BlinkMacSystemFont, "Helvetica Neue",
       Helvetica, sans-serif;
   }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 3.5rem auto 2rem;
+  }
+
+  @media (min-width: 700px) {
+    h1,
+    h2,
+    h3 {
+      margin: 6rem auto 3rem;
+    }
+
+    h4,
+    h5,
+    h6 {
+      margin: 4.5rem auto 2.5rem;
+    }
+  }
 `;

--- a/packages/twentytwenty-theme/src/components/styles/global-styles.js
+++ b/packages/twentytwenty-theme/src/components/styles/global-styles.js
@@ -234,6 +234,67 @@ const elementBase = (colors) => css`
   }
 `;
 
+const elementBase700 = css`
+  @media (min-width: 700px) {
+    h1,
+    .heading-size-1,
+    h2,
+    .heading-size-2,
+    h3,
+    .heading-size-3 {
+      margin: 6rem auto 3rem;
+    }
+
+    h4,
+    .heading-size-4,
+    h5,
+    .heading-size-5,
+    h6,
+    .heading-size-6 {
+      margin: 4.5rem auto 2.5rem;
+    }
+
+    h1,
+    .heading-size-1 {
+      font-size: 6.4rem;
+    }
+
+    h2,
+    .heading-size-2 {
+      font-size: 4.8rem;
+    }
+
+    h3,
+    .heading-size-3 {
+      font-size: 4rem;
+    }
+
+    h4,
+    .heading-size-4 {
+      font-size: 3.2rem;
+    }
+
+    h5,
+    .heading-size-5 {
+      font-size: 2.4rem;
+    }
+
+    h6,
+    .heading-size-6 {
+      font-size: 1.8rem;
+    }
+  }
+`;
+
+const elementBase1220 = css`
+  @media (min-width: 1220px) {
+    h1,
+    .heading-size-1 {
+      font-size: 8.4rem;
+    }
+  }
+`;
+
 const listStyle = css`
   ul,
   ol {
@@ -461,6 +522,8 @@ const globalStyle = (colors) =>
     documentSetup(colors),
     accessibilitySettings,
     elementBase(colors),
+    elementBase700,
+    elementBase1220,
     listStyle,
     quoteStyle(colors),
     codeStyle(colors),

--- a/packages/twentytwenty-theme/src/components/styles/global-styles.js
+++ b/packages/twentytwenty-theme/src/components/styles/global-styles.js
@@ -59,6 +59,15 @@ const cssReset = css`
   }
 `;
 
+/**
+ * Styles for Document Setup.
+ *
+ * See `1. Document Setup` at
+ * https://themes.trac.wordpress.org/browser/twentytwenty/1.7/style.css.
+ *
+ * @param colors - Object with color definitions, from `state.theme.colors`.
+ * @returns Serialized style.
+ */
 const documentSetup = (colors) => css`
   html {
     font-size: 62.5%; /* 1rem = 10px */
@@ -98,6 +107,15 @@ const accessibilitySettings = css`
   }
 `;
 
+/**
+ * Styles for Element Base.
+ *
+ * See `2. Element Base` at
+ * https://themes.trac.wordpress.org/browser/twentytwenty/1.7/style.css.
+ *
+ * @param colors - Object with color definitions, from `state.theme.colors`.
+ * @returns Serialized style.
+ */
 const elementBase = (colors) => css`
   main {
     display: block;
@@ -364,6 +382,15 @@ const listStyle = css`
   }
 `;
 
+/**
+ * Styles for blockquotes.
+ *
+ * See `2. Element Base / Quotes` at
+ * https://themes.trac.wordpress.org/browser/twentytwenty/1.7/style.css.
+ *
+ * @param colors - Object with color definitions, from `state.theme.colors`.
+ * @returns Serialized style.
+ */
 const quoteStyle = (colors) => css`
   blockquote {
     border-color: ${colors.primary};
@@ -397,6 +424,15 @@ const quoteStyle = (colors) => css`
   }
 `;
 
+/**
+ * Styles for code elements.
+ *
+ * See `2. Element Base / Code` at
+ * https://themes.trac.wordpress.org/browser/twentytwenty/1.7/style.css.
+ *
+ * @param colors - Object with color definitions, from `state.theme.colors`.
+ * @returns Serialized style.
+ */
 const codeStyle = (colors) => css`
   code,
   kbd,
@@ -429,6 +465,15 @@ const codeStyle = (colors) => css`
   }
 `;
 
+/**
+ * Styles for media elements.
+ *
+ * See `2. Element Base / Media` at
+ * https://themes.trac.wordpress.org/browser/twentytwenty/1.7/style.css.
+ *
+ * @param colors - Object with color definitions, from `state.theme.colors`.
+ * @returns Serialized style.
+ */
 const mediaStyle = (colors) => css`
   figure {
     display: block;
@@ -469,6 +514,15 @@ const mediaStyle = (colors) => css`
   }
 `;
 
+/**
+ * Styles for tables.
+ *
+ * See `2. Element Base / Tables` at
+ * https://themes.trac.wordpress.org/browser/twentytwenty/1.7/style.css.
+ *
+ * @param colors - Object with color definitions, from `state.theme.colors`.
+ * @returns Serialized style.
+ */
 const tableStyles = (colors) => css`
   table {
     border: 0.1rem solid ${colors.gray.light};
@@ -516,6 +570,12 @@ const tableStyles = (colors) => css`
   }
 `;
 
+/**
+ * Global styles for the TwentyTwenty theme.
+ *
+ * @param colors - Object with color definitions, from `state.theme.colors`.
+ * @returns Serialized style.
+ */
 const globalStyle = (colors) =>
   css([
     cssReset,


### PR DESCRIPTION
**What**:

Write some CSS rules to fix the font used by headings inside the content, also some global heading sizes.

**Why**:

Fixes #278 

**How**:

Just getting those styles from the `style.css` file of the WordPress TwentyTwenty theme.

**Tasks**:

- [x] Code
- [x] TSDocs
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional comments**

Post headings have a font weight of 800, but I didn't change that as the theme only includes a font weight fo the Inter font up to 700.