### PR TITLE
Fix a race condition in the e2e CLI tests

### DIFF
--- a/packages/frontity/cli-e2e/filesystem/create.test.ts
+++ b/packages/frontity/cli-e2e/filesystem/create.test.ts
@@ -2,14 +2,15 @@ import { readdir, readFile, remove } from "fs-extra";
 import { resolve as resolvePath } from "path";
 import execa from "execa";
 
-it("should create the initial files", async () => {
-  try {
-    await execa.command(
-      `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
-      { stdio: "inherit" }
-    );
+describe("npx frontity create", () => {
+  it("should create the initial files", async () => {
+    try {
+      await execa.command(
+        `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
+        { stdio: "inherit" }
+      );
 
-    expect(await readdir("test-frontity-app")).toMatchInlineSnapshot(`
+      expect(await readdir("test-frontity-app")).toMatchInlineSnapshot(`
         Array [
           ".gitignore",
           "README.md",
@@ -20,27 +21,28 @@ it("should create the initial files", async () => {
           "package.json",
           "packages",
         ]
-      `);
-  } finally {
-    await remove("test-frontity-app");
-  }
-});
+        `);
+    } finally {
+      await remove("test-frontity-app");
+    }
+  });
 
-it("should add a .gitignore file even if inside a git repo", async () => {
-  try {
-    await execa.command(
-      `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
-      { stdio: "inherit" }
-    );
+  it("should add a .gitignore file even if inside a git repo", async () => {
+    try {
+      await execa.command(
+        `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
+        { stdio: "inherit" }
+      );
 
-    // The .gitignore should be the same as the template file.
-    const gitignore = await readFile("test-frontity-app/.gitignore", "utf8");
-    const template = await readFile(
-      resolvePath(__dirname, "../../templates/gitignore-template"),
-      { encoding: "utf8" }
-    );
-    expect(gitignore).toEqual(template);
-  } finally {
-    await remove("test-frontity-app");
-  }
+      // The .gitignore should be the same as the template file.
+      const gitignore = await readFile("test-frontity-app/.gitignore", "utf8");
+      const template = await readFile(
+        resolvePath(__dirname, "../../templates/gitignore-template"),
+        { encoding: "utf8" }
+      );
+      expect(gitignore).toEqual(template);
+    } finally {
+      await remove("test-frontity-app");
+    }
+  });
 });

--- a/packages/frontity/cli-e2e/filesystem/create.test.ts
+++ b/packages/frontity/cli-e2e/filesystem/create.test.ts
@@ -2,15 +2,14 @@ import { readdir, readFile, remove } from "fs-extra";
 import { resolve as resolvePath } from "path";
 import execa from "execa";
 
-describe("npx frontity create", () => {
-  it("should create the initial files", async () => {
-    try {
-      await execa.command(
-        `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
-        { stdio: "inherit" }
-      );
+it("should create the initial files", async () => {
+  try {
+    await execa.command(
+      `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
+      { stdio: "inherit" }
+    );
 
-      expect(await readdir("test-frontity-app")).toMatchInlineSnapshot(`
+    expect(await readdir("test-frontity-app")).toMatchInlineSnapshot(`
         Array [
           ".gitignore",
           "README.md",
@@ -22,27 +21,26 @@ describe("npx frontity create", () => {
           "packages",
         ]
       `);
-    } finally {
-      await remove("test-frontity-app");
-    }
-  });
+  } finally {
+    await remove("test-frontity-app");
+  }
+});
 
-  it("should add a .gitignore file even if inside a git repo", async () => {
-    try {
-      await execa.command(
-        `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
-        { stdio: "inherit" }
-      );
+it("should add a .gitignore file even if inside a git repo", async () => {
+  try {
+    await execa.command(
+      `ts-node src/cli/index.ts create --no-prompt --theme @frontity/mars-theme test-frontity-app`,
+      { stdio: "inherit" }
+    );
 
-      // The .gitignore should be the same as the template file.
-      const gitignore = await readFile("test-frontity-app/.gitignore", "utf8");
-      const template = await readFile(
-        resolvePath(__dirname, "../../templates/gitignore-template"),
-        { encoding: "utf8" }
-      );
-      expect(gitignore).toEqual(template);
-    } finally {
-      await remove("test-frontity-app");
-    }
-  });
+    // The .gitignore should be the same as the template file.
+    const gitignore = await readFile("test-frontity-app/.gitignore", "utf8");
+    const template = await readFile(
+      resolvePath(__dirname, "../../templates/gitignore-template"),
+      { encoding: "utf8" }
+    );
+    expect(gitignore).toEqual(template);
+  } finally {
+    await remove("test-frontity-app");
+  }
 });

--- a/packages/frontity/package.json
+++ b/packages/frontity/package.json
@@ -27,7 +27,7 @@
     "test": "jest --watch",
     "test:ci": "jest --colors --ci --coverage",
     "test:inspect": "node --inspect node_modules/bin/jest --watch --no-cache --runInBand",
-    "test:cli-e2e:filesystem": "jest --testMatch \"**/cli-e2e/filesystem/**/*.test?(s).[jt]s?(x)\" --testTimeout=180000",
+    "test:cli-e2e:filesystem": "jest --testMatch \"**/cli-e2e/filesystem/**/*.test?(s).[jt]s?(x)\" --runInBand --testTimeout=180000",
     "test:cli-e2e:docker": "jest --testMatch \"**/cli-e2e/docker/**/*.test?(s).[jt]s?(x)\" --testTimeout=180000",
     "build": "tsc --project ./tsconfig.build.json && npm run copyfiles",
     "copyfiles": "copyfiles templates/* dist",


### PR DESCRIPTION
**What**:

Fix race condition in CLI-e2e tests: https://github.com/frontity/frontity/pull/823/checks?check_run_id=2620668413#step:6:20

This problem was caused because the filesystem tests ran in parallel thus interfering with each other.

**How**:

I've added the `--runInBand` flag which will cause all of the filesystem tests to run serially. 

**Tasks**:

- [x] Code
- [x] TypeScript
- [x] Unit tests

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- ignore-task-list-end -->

