### PR TITLE
Fix with-preact to be defined as commonjs

### DIFF
--- a/.changeset/shaggy-laws-sniff.md
+++ b/.changeset/shaggy-laws-sniff.md
@@ -1,5 +1,5 @@
 ---
-"@frontity/with-preact": minor
+"@frontity/with-preact": patch
 ---
 
-with-preact is not usually transpiled when is part of the node_modules so the config file should be defined as commonjs
+Use `commonjs` in the `frontity.config.js` file until we add support for modules.

--- a/.changeset/shaggy-laws-sniff.md
+++ b/.changeset/shaggy-laws-sniff.md
@@ -1,0 +1,5 @@
+---
+"@frontity/with-preact": minor
+---
+
+with-preact is not usually transpiled when is part of the node_modules so the config file should be defined as commonjs

--- a/packages/with-preact/frontity.config.js
+++ b/packages/with-preact/frontity.config.js
@@ -3,7 +3,7 @@
  *
  * @param param - The passed params.
  */
-export const webpack = ({ config }) => {
+module.exports.webpack = ({ config }) => {
   config.resolve.alias["react"] = "preact/compat";
   config.resolve.alias["react-dom"] = "preact/compat";
 };


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here: 
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Change the format for `@frontity/with-preact` config file to commonjs since it's not getting transpiled if installed and use from `node_modules`.

**Why**:

<!-- Why are these changes necessary? -->
It breaks compilation otherwise.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Update other packages
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
