### PR TITLE
Transpile all frontity.settings/config imports

### DIFF
--- a/.changeset/modern-hounds-tell.md
+++ b/.changeset/modern-hounds-tell.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Fix transpilation of `frontity.config.js` files in external packages.

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -20,6 +20,7 @@ import * as tsNode from "ts-node";
  */
 tsNode.register({
   transpileOnly: true,
+  ignore: [],
   compilerOptions: {
     // Target latest version of ECMAScript.
     target: "es2017",

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -1,3 +1,4 @@
+import ignore from "./utils/ts-node-ignore";
 import * as tsNode from "ts-node";
 
 /**
@@ -20,7 +21,7 @@ import * as tsNode from "ts-node";
  */
 tsNode.register({
   transpileOnly: true,
-  ignore: [],
+  ignore,
   compilerOptions: {
     // Target latest version of ECMAScript.
     target: "es2017",

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -20,6 +20,7 @@ import * as tsNode from "ts-node";
  */
 tsNode.register({
   transpileOnly: true,
+  ignore: [],
   compilerOptions: {
     // Target latest version of ECMAScript.
     target: "es2017",

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -1,3 +1,4 @@
+import ignore from "./utils/ts-node-ignore";
 import * as tsNode from "ts-node";
 
 /**
@@ -20,7 +21,7 @@ import * as tsNode from "ts-node";
  */
 tsNode.register({
   transpileOnly: true,
-  ignore: [],
+  ignore,
   compilerOptions: {
     // Target latest version of ECMAScript.
     target: "es2017",

--- a/packages/core/src/scripts/utils/__tests__/ts-node-ignore.test.ts
+++ b/packages/core/src/scripts/utils/__tests__/ts-node-ignore.test.ts
@@ -1,0 +1,82 @@
+import ignore from "../ts-node-ignore";
+
+const ignoreRegExp = new RegExp(ignore[0]);
+
+describe("ts-node ignores", () => {
+  it("should ignore javascript files inside node_modules", () => {
+    expect(ignoreRegExp.test("node_modules/index.js")).toBe(true);
+    expect(ignoreRegExp.test("node_modules/some-package/index.js")).toBe(true);
+    expect(ignoreRegExp.test("node_modules/@org/some-package/index.js")).toBe(
+      true
+    );
+    expect(
+      ignoreRegExp.test("node_modules/@org/some-package/folder/index.js")
+    ).toBe(true);
+  });
+
+  it("should not ignore typescript files", () => {
+    expect(ignoreRegExp.test("index.ts")).toBe(false);
+    expect(ignoreRegExp.test("node_modules/index.ts")).toBe(false);
+    expect(ignoreRegExp.test("node_modules/some-package/index.ts")).toBe(false);
+    expect(ignoreRegExp.test("node_modules/@org/some-package/index.ts")).toBe(
+      false
+    );
+    expect(
+      ignoreRegExp.test("node_modules/@org/some-package/folder/index.ts")
+    ).toBe(false);
+  });
+
+  it("should not ignore frontity settings", () => {
+    expect(ignoreRegExp.test("frontity.settings.js")).toBe(false);
+    expect(ignoreRegExp.test("frontity.settings.ts")).toBe(false);
+  });
+
+  it("should not ignore javascript files outside node_modules", () => {
+    expect(ignoreRegExp.test("index.js")).toBe(false);
+    expect(ignoreRegExp.test("some-package/index.js")).toBe(false);
+    expect(ignoreRegExp.test("@org/some-package/index.js")).toBe(false);
+  });
+
+  it("should not ignore frontity.config files", () => {
+    expect(
+      ignoreRegExp.test("node_modules/@org/some-package/frontity.config.js")
+    ).toBe(false);
+    expect(
+      ignoreRegExp.test("node_modules/some-package/frontity.config.js")
+    ).toBe(false);
+    expect(ignoreRegExp.test("some-package/frontity.config.js")).toBe(false);
+    expect(
+      ignoreRegExp.test("node_modules/@org/some-package/frontity.config.ts")
+    ).toBe(false);
+    expect(
+      ignoreRegExp.test("node_modules/some-package/frontity.config.ts")
+    ).toBe(false);
+    expect(ignoreRegExp.test("some-package/frontity.config.ts")).toBe(false);
+  });
+
+  it("should not ignore packages from `@frontity`", () => {
+    expect(
+      ignoreRegExp.test("node_modules/@frontity/some-package/index.js")
+    ).toBe(false);
+    expect(ignoreRegExp.test("@frontity/some-package/index.js")).toBe(false);
+    expect(
+      ignoreRegExp.test("node_modules/@frontity/some-package/index.ts")
+    ).toBe(false);
+    expect(ignoreRegExp.test("@frontity/some-package/index.ts")).toBe(false);
+  });
+
+  it("should not ignore packages with `frontity` in the name", () => {
+    expect(
+      ignoreRegExp.test("node_modules/@org/some-frontity-package/index.js")
+    ).toBe(false);
+    expect(
+      ignoreRegExp.test("node_modules/some-frontity-package/index.js")
+    ).toBe(false);
+    expect(
+      ignoreRegExp.test("node_modules/@org/some-frontity-package/index.ts")
+    ).toBe(false);
+    expect(
+      ignoreRegExp.test("node_modules/some-frontity-package/index.ts")
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/scripts/utils/ts-node-ignore.ts
+++ b/packages/core/src/scripts/utils/ts-node-ignore.ts
@@ -1,0 +1,11 @@
+/**
+ * This regular expression is used for the ts-node ignores: ts-node will
+ * transpile any packages from the `@frontity` org, with `frontity` in the name
+ * (for example `some-frontity-package`), frontity.settings files,
+ * frontity.config files, and any TypeScript files that people import.
+ *
+ * This ts-node transpilation is only used outside of Webpack, so mostly for
+ * things that people import in their frontity.settings or frontity.config
+ * files.  Once Webpack runs, all the files are transpiled.
+ */
+export default ["node_modules\\/(?!.*(frontity|\\.ts$))"];


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here:
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Change the files that the `ts-node` that we run in the `dev` and `build` commands transpile.

**Why**:

<!-- Why are these changes necessary? -->

Because it was not transpiling files that were inside the `node_modules` folder, like `frontity.config.js` files in external packages.

**How**:

<!-- How were these changes implemented? -->

I created a regular expression that is passed to the `ignores` setting of `ts-node` and makes it transpile only:

- Packages from the `@frontity` org
- Packages with `frontity` in the name (for example `some-frontity-package`).
- `frontity.settings` files
- `frontity.config` files
- Any TypeScript files that people import.

By default this setting was `node_modules`.

_This `ts-node` transpilation is only used outside of Webpack, which means mostly things people import in their `frontity.settings` or `frontity.config` files. Once Webpack runs, all the files are transpiled._

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->
