### PR TITLE
Refactor `createSymlinks` function in `@frontity/core`

### DIFF
--- a/.changeset/wise-shrimps-explode.md
+++ b/.changeset/wise-shrimps-explode.md
@@ -1,0 +1,5 @@
+---
+"@frontity/core": patch
+---
+
+Refactor `createSymlinks` to use a custom implementation of `fs-extra`'s `readFile` function.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "deepmerge": "^4.2.2",
     "express": "^4.17.1",
     "file-loader": "^6.2.0",
-    "fs-extra": "^9.0.1",
+    "fs-extra": "^10.0.0",
     "hash-it": "^4.0.5",
     "htmlescape": "^1.1.1",
     "koa": "^2.13.0",

--- a/packages/core/src/scripts/utils/create-symlinks.ts
+++ b/packages/core/src/scripts/utils/create-symlinks.ts
@@ -1,22 +1,55 @@
 import symlinkDir from "symlink-dir";
-import { pathExists, readFile } from "fs-extra";
+import { pathExists } from "fs-extra";
 import { resolve } from "path";
+import { promises as fsPromises } from "fs";
 
-const semverRE = /^(~|\^|<|>|=)?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;
+const semverRE =
+  /^(~|\^|<|>|=)?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;
 const RE = /^(file:)?(~)?(\.{0,2}?\/([\w+\-_]+)?)+$/;
 
-const isNotSemanticVersion = (dir) => !semverRE.test(dir);
-const isValidLinkPath = (dir) => RE.test(dir);
+/**
+ * Check whether the given string isn't a semver.
+ *
+ * @param dir - Possible directory path.
+ * @returns True if not a semver.
+ */
+const isNotSemanticVersion = (dir: string) => !semverRE.test(dir);
 
-const isValidNodePackage = async (dir) =>
+/**
+ * Check whether the given string is a path pointing to a local package.
+ *
+ * @param dir - Possible link path.
+ * @returns True if it's a valid link path.
+ */
+const isValidLinkPath = (dir: string) => RE.test(dir);
+
+/**
+ * Check whether the given directory contains a Node package.
+ *
+ * @param dir - Directory path.
+ * @returns True if it's a node package.
+ */
+const isValidNodePackage = async (dir: string) =>
   await pathExists(resolve(dir, "package.json"));
+
+/**
+ * Read the file with the given path in utf8 format.
+ *
+ * @remarks This function replaces {@link fs-extra#readFile} because it doesn't
+ * work with {@link mock-fs#default}, which is used by unit tests.
+ *
+ * @param path - File path.
+ * @returns String with the file content.
+ */
+const readFileUtf8 = async (path: string) => {
+  const fileHandle = await fsPromises.open(path, "r");
+  return await fileHandle.readFile({ encoding: "utf8" });
+};
 
 export default async () => {
   // Get dependencies from CWD package.json
   const packageJsonPath = resolve(process.env.CWD, "./package.json");
-  const packageJson = JSON.parse(
-    await readFile(packageJsonPath, { encoding: "utf8" })
-  );
+  const packageJson = JSON.parse(await readFileUtf8(packageJsonPath));
   const { dependencies } = packageJson;
 
   const dependencyNames = Object.keys(dependencies).filter(


### PR DESCRIPTION
**What**:

Replace the [`fs-extra`](https://www.npmjs.com/package/fs-extra)'s `readFile` function by an in-house implementation.

**Why**:

That function seems to fail when using [`mock-fs`](https://www.npmjs.com/package/mock-fs) and Node 16.

**How**:

Use the standard `fs` library to implement a new `readFile` function that works with `mock-fs`.

**Tasks**:

- [x] Code
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**

I'm not sure if there is a problem in the `mock-fs` library, in the `fs-extra`, or it is just that they stopped to be compatible when Node 16 is used. Making some tests to isolate the problem I discovered that it was in the `readFile` function of `fs-extra`, which was throwing this error:

```
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

[Error: EINVAL: invalid argument, read] {
  errno: -22,
  code: 'EINVAL',
  syscall: 'read'
}
```

The easiest solution I've found was to replace that function by a new one, using `fs/promise`. That seems to work fine (tested in node 10 and 16).
