### PR TITLE
Add `server` middlewares defined in packages to the Koa app

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -10,6 +10,7 @@ import { scriptsStats } from "./middlewares/scripts-stats";
 import { settingsAndStore } from "./middlewares/settings-and-store";
 import { serverSideRendering } from "./middlewares/server-side-rendering";
 import { errorHandling } from "./middlewares/error-handling";
+import { storeMiddlewares } from "./middlewares/store-middlewares";
 
 /**
  * Options for {@link server}.
@@ -99,6 +100,9 @@ const server = ({ packages }: ServerOptions): ReturnType<Koa["callback"]> => {
 
   // Setup the settings and store.
   app.use(settingsAndStore(packages));
+
+  // Add the server middlewares exposed by packages.
+  app.use(storeMiddlewares(app));
 
   // Sever Side Rendering with the defined
   // template and render method.

--- a/packages/core/src/server/middlewares/store-middlewares.ts
+++ b/packages/core/src/server/middlewares/store-middlewares.ts
@@ -17,7 +17,7 @@ export const storeMiddlewares =
     const store: Package = ctx.state.store;
 
     // Iterate over all the middlewares that packages expose.
-    Object.values(store.server).forEach((namespace) => {
+    Object.values(store.server || {}).forEach((namespace) => {
       Object.values(namespace).forEach((middleware) => {
         // Register the middleware.
         app.use((ctx, next) => {

--- a/packages/core/src/server/middlewares/store-middlewares.ts
+++ b/packages/core/src/server/middlewares/store-middlewares.ts
@@ -1,0 +1,33 @@
+import Koa, { Middleware, Next } from "koa";
+import { Package, Context } from "@frontity/types";
+
+/**
+ * Add package-defined middlewares to the given Koa application.
+ *
+ * @remarks The `app` argument is passed until it is accesible in `ctx`.
+ *
+ * @param app - The Koa application.
+ *
+ * @returns The middleware function.
+ */
+export const storeMiddlewares =
+  (app: Koa) =>
+  async (ctx: Context, next: Next): Promise<Middleware> => {
+    // Get the initialized store from the app context.
+    const store: Package = ctx.state.store;
+
+    // Iterate over all the middlewares that packages expose.
+    Object.values(store.server).forEach((namespace) => {
+      Object.values(namespace).forEach((middleware) => {
+        // Register the middleware.
+        app.use((ctx, next) => {
+          // Middlewares should be able to get `ctx` and `next` directly as
+          // arguments or destructure them from the first one.
+          const ctxExtended = { ...ctx, ctx, next };
+          return middleware(ctxExtended, next);
+        });
+      });
+    });
+
+    return await next();
+  };

--- a/packages/types/middleware.ts
+++ b/packages/types/middleware.ts
@@ -1,0 +1,46 @@
+import { Next } from "koa";
+import { Context } from "./action";
+
+/**
+ * Input for middlewares that destructure `ctx` and `next` from the first
+ * argument.
+ */
+export interface MiddlewareProps {
+  /**
+   * Koa context.
+   */
+  ctx: Context;
+
+  /**
+   * Next function.
+   */
+  next: Next;
+}
+
+/**
+ * Middleware that any Frontity package can export from `server`.
+ *
+ * @example
+ * ```ts
+ * // packages/my-package/src/server.js
+ * import myPackage from "./client";
+ * import serve from "koa-static"; // Node-only package.
+ * import { get } from "koa-route"; // Node-only package.
+ *
+ * export default {
+ *   ...myPackage,
+ *   server: {
+ *     myPackage: {
+ *       // Serve the ads.txt using the /public/ads.txt file.
+ *       adsTxt: get("/ads.txt", serve("./public"))),
+ *     },
+ *   },
+ * };
+ * ```
+ */
+export interface Middleware {
+  (ctx: Context, next: Next): Promise<Middleware>;
+  (props: MiddlewareProps): Promise<Middleware>;
+}
+
+export default Middleware;

--- a/packages/types/package.ts
+++ b/packages/types/package.ts
@@ -1,4 +1,5 @@
 import Fill from "./fill";
+import Middleware from "./middleware";
 
 /**
  * Types of a Frontity package.
@@ -68,6 +69,15 @@ export interface Package {
      */
     [namespace: string]: {
       [library: string]: any;
+    };
+  };
+
+  /**
+   * The server middlewares exposed by this package.
+   */
+  server?: {
+    [namespace: string]: {
+      [middleware: string]: Middleware;
     };
   };
 }


### PR DESCRIPTION
**What**:

Get middlewares exposed by Frontity packages in the `server` property and register them into the Koa server.

Co-authored-by: @cristianbote

**Why**:

To close #696 

**Tasks**:

- [ ] Code
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] Update starter themes
- [ ] Update other packages
<!-- ignore-task-list-end -->
