### PR TITLE
Check for all returned posts in the post type handler instead of just the first one

### DIFF
--- a/.changeset/chilly-socks-care.md
+++ b/.changeset/chilly-socks-care.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+Fix a bug where frontity could not fetch a page or child page with the same slug as the parent/child.

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/post-type.tests.ts.snap
@@ -1493,6 +1493,119 @@ Object {
 }
 `;
 
+exports[`page can have a parent with the same slug 1`] = `
+Object {
+  "api": "https://test.frontity.org/wp-json/",
+  "attachment": Object {},
+  "author": Object {
+    "1": Object {
+      "id": 1,
+      "link": "/author/author-1/",
+      "name": "Author 1",
+      "slug": "author-1",
+    },
+  },
+  "authorBase": "",
+  "category": Object {},
+  "categoryBase": "",
+  "data": Object {
+    "/author/author-1/": Object {
+      "id": 1,
+      "isFetching": false,
+      "isReady": false,
+      "link": "/author/author-1/",
+      "page": 1,
+      "query": Object {},
+      "route": "/author/author-1/",
+    },
+    "/page-1/": Object {
+      "id": 2,
+      "isFetching": false,
+      "isPage": true,
+      "isPostType": true,
+      "isReady": true,
+      "link": "/page-1/",
+      "page": 1,
+      "query": Object {},
+      "route": "/page-1/",
+      "type": "page",
+    },
+    "/parent/page-1/": Object {
+      "id": 1,
+      "isFetching": false,
+      "isPage": true,
+      "isPostType": true,
+      "isReady": true,
+      "link": "/parent/page-1/",
+      "page": 1,
+      "query": Object {},
+      "route": "/parent/page-1/",
+      "type": "page",
+    },
+  },
+  "entity": [Function],
+  "get": [Function],
+  "homepage": "",
+  "isWpCom": false,
+  "page": Object {
+    "1": Object {
+      "_embedded": Object {
+        "author": Array [
+          1,
+        ],
+        "up": Array [
+          Object {
+            "id": 2,
+            "link": "https://test.frontity.org/parent/",
+            "slug": "parent",
+          },
+        ],
+      },
+      "author": 1,
+      "featured_media": 1,
+      "id": 1,
+      "link": "/parent/page-1/",
+      "parent": 2,
+      "slug": "page-1",
+      "type": "page",
+    },
+    "2": Object {
+      "_embedded": Object {
+        "author": Array [
+          1,
+        ],
+      },
+      "author": 1,
+      "featured_media": 1,
+      "id": 2,
+      "link": "/page-1/",
+      "parent": 0,
+      "slug": "page-1",
+      "type": "page",
+    },
+  },
+  "params": Object {},
+  "post": Object {},
+  "postEndpoint": "posts",
+  "postTypes": Array [
+    Object {
+      "archive": "/cpt",
+      "endpoint": "cpts",
+      "type": "cpt",
+    },
+  ],
+  "postsPage": "",
+  "redirections": "no",
+  "subdirectory": "",
+  "tag": Object {},
+  "tagBase": "",
+  "taxonomies": Array [],
+  "taxonomy": Object {},
+  "type": Object {},
+  "url": "https://test.frontity.org",
+}
+`;
+
 exports[`page doesn't exist in source.page 1`] = `
 Object {
   "api": "https://test.frontity.org/wp-json/",

--- a/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/child-page-with-parent-same-slug.json
+++ b/packages/wp-source/src/libraries/handlers/__tests__/mocks/post-type/child-page-with-parent-same-slug.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 2,
+    "slug": "page-1",
+    "type": "page",
+    "link": "https://test.frontity.org/page-1/",
+    "author": 1,
+    "parent": 0,
+    "featured_media": 1,
+    "_embedded": {
+      "author": [
+        {
+          "id": 1,
+          "name": "Author 1",
+          "link": "https://test.frontity.org/author/author-1/",
+          "slug": "author-1"
+        }
+      ]
+    }
+  },
+  {
+    "id": 1,
+    "slug": "page-1",
+    "type": "page",
+    "link": "https://test.frontity.org/parent/page-1/",
+    "author": 1,
+    "parent": 2,
+    "featured_media": 1,
+    "_embedded": {
+      "author": [
+        {
+          "id": 1,
+          "name": "Author 1",
+          "link": "https://test.frontity.org/author/author-1/",
+          "slug": "author-1"
+        }
+      ],
+      "up": [
+        {
+          "id": 2,
+          "link": "https://test.frontity.org/parent/",
+          "slug": "parent"
+        }
+      ]
+    }
+  }
+]

--- a/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
+++ b/packages/wp-source/src/libraries/handlers/__tests__/post-type.tests.ts
@@ -8,6 +8,7 @@ import { mockResponse } from "./mocks/helpers";
 import attachment1 from "./mocks/post-type/attachment-1.json";
 import page1 from "./mocks/post-type/page-1.json";
 import page1WithParent from "./mocks/post-type/page-1-with-parent.json";
+import childPageWithParentSameSlug from "./mocks/post-type/child-page-with-parent-same-slug.json";
 import post1 from "./mocks/post-type/post-1.json";
 import post1Revision from "./mocks/post-type/post-1-revision.json";
 import post1withType from "./mocks/post-type/post-1-with-type.json";
@@ -277,6 +278,28 @@ describe("page", () => {
       .mockResolvedValueOnce(mockResponse([page1WithParent]));
     // Fetch entities
     await store.actions.source.fetch("/parent/page-1/");
+    expect(postTypeHandler).toHaveBeenCalled();
+    expect(store.state.source).toMatchSnapshot();
+  });
+
+  test("can have a parent with the same slug", async () => {
+    // Mock Api responses
+    api.get = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse(childPageWithParentSameSlug));
+
+    await store.actions.source.fetch("/parent/page-1/");
+    const childData = store.state.source.data["/parent/page-1/"];
+    expect(childData.isReady).toBe(true);
+
+    // at this point both /parent/page-1 and /page-1 should already be in state.
+    const parentData = store.state.source.data["/page-1/"];
+    expect(parentData.link).toBe("/page-1/");
+
+    // however it's not "ready" yet.
+    await store.actions.source.fetch("/page-1/");
+    expect(parentData.isReady).toBe(true);
+
     expect(postTypeHandler).toHaveBeenCalled();
     expect(store.state.source).toMatchSnapshot();
   });

--- a/packages/wp-source/src/libraries/handlers/postType.ts
+++ b/packages/wp-source/src/libraries/handlers/postType.ts
@@ -82,7 +82,7 @@ const postTypeHandler = ({
       if (populated.length > 0) {
         // We have to check if the link property in the data that we
         // populated is the same as the current route.
-        if (populated[0].link === route) {
+        if (populated.some((post) => post.link === route)) {
           isHandled = true;
           isMismatched = false;
           matchedEndpoint = endpoint;


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here: 
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Fixes #865 

**Why**:

<!-- Why are these changes necessary? -->

It's standard WP behavior

**How**:

<!-- How were these changes implemented? -->

By checking all of the returned posts instead of just the first one.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
