### PR TITLE
Purge expired artifacts

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -33,7 +33,8 @@ jobs:
         env:
           CI: true
           
-      - uses: LKP-RnD/purge-expired-artifacts-action@v4
+      - name: Delete expired artifacts
+        uses: LKP-RnD/purge-expired-artifacts-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repo_to_purge: "frontity/frontity"

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           CI: true
           
-      - name: Delete expired artifacts
+      - name: Delete expired artifacts 
         uses: LKP-RnD/purge-expired-artifacts-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,6 +32,12 @@ jobs:
         run: npm ci
         env:
           CI: true
+          
+      - uses: LKP-RnD/purge-expired-artifacts-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repo_to_purge: "frontity/frontity"
+          dry_run: "false"
 
       - name: Run Eslint
         uses: bradennapier/eslint-plus-action@v3.4.2

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           CI: true
           
-      - name: Delete expired artifacts 
+      - name: Delete expired artifacts
         uses: LKP-RnD/purge-expired-artifacts-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here: 
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Purge the expired artifacts.

**Why**:

<!-- Why are these changes necessary? -->

Because the Eslint GH action is failing a lot lately and it seems like expired artifacts can be the cause, acording to this issue: https://github.com/bradennapier/eslint-plus-action/issues/45.

**How**:

<!-- How were these changes implemented? -->

By adding a previous step in the Eslint GH action that purges the expired artifacts before eslint runs.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] GH action

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)
<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
