### PR TITLE
Add wp-source params to taxonomy and author handler

### DIFF
--- a/.changeset/sour-cars-switch.md
+++ b/.changeset/sour-cars-switch.md
@@ -1,0 +1,5 @@
+---
+"@frontity/wp-source": patch
+---
+
+Add source params to taxonomy and author api calls [#864](https://github.com/frontity/frontity/pull/864)

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/author.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/author.tests.ts.snap
@@ -317,6 +317,10 @@ Array [
       "endpoint": "users",
       "params": Object {
         "slug": "author-1",
+        "type": Array [
+          "post",
+          "cpt",
+        ],
       },
     },
   ],

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/category.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/category.tests.ts.snap
@@ -623,6 +623,10 @@ Array [
       "endpoint": "categories",
       "params": Object {
         "slug": "cat-1",
+        "type": Array [
+          "post",
+          "cpt",
+        ],
       },
     },
   ],

--- a/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/tag.tests.ts.snap
+++ b/packages/wp-source/src/libraries/handlers/__tests__/__snapshots__/tag.tests.ts.snap
@@ -378,6 +378,10 @@ Array [
       "endpoint": "tags",
       "params": Object {
         "slug": "tag-1",
+        "type": Array [
+          "post",
+          "cpt",
+        ],
       },
     },
   ],

--- a/packages/wp-source/src/libraries/handlers/author.ts
+++ b/packages/wp-source/src/libraries/handlers/author.ts
@@ -39,7 +39,13 @@ const authorHandler: Handler = async ({
   let { id }: Partial<AuthorData> = state.source.get(route);
   if (!id || force) {
     // Request author from WP
-    const response = await api.get({ endpoint: "users", params: { slug } });
+    const response = await api.get({
+      endpoint: "users",
+      params: {
+        slug,
+        ...state.source.params,
+      },
+    });
     const [entity] = await populate({ response, state, force: true });
     if (!entity)
       throw new ServerError(

--- a/packages/wp-source/src/libraries/handlers/taxonomy.ts
+++ b/packages/wp-source/src/libraries/handlers/taxonomy.ts
@@ -90,6 +90,7 @@ const taxonomyHandler = ({
       endpoint,
       params: {
         slug,
+        ...state.source.params,
       },
     });
     const [entity] = await populate({


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here: 
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Fixes issue #864

**Why**:

The `state.source.params` should added to taxonomy api calls. Like the other handlers do.

**How**:

<!-- How were these changes implemented? -->
Added wp-source params to toxonomy and author api calls.

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Unit tests
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->
- [ ] TSDocs
- [ ] TypeScript
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
<!-- ignore-task-list-end -->

**Additional Comments**
