### PR TITLE
Export Actions since it's a part of the api

### DIFF
--- a/packages/types/package.ts
+++ b/packages/types/package.ts
@@ -77,6 +77,6 @@ export default Package;
 /**
  * An object containing Frontity actions, or other objects containing actions.
  */
-interface Actions {
+export interface Actions {
   [key: string]: (...args: unknown[]) => unknown | Actions;
 }


### PR DESCRIPTION
<!--
Thanks for your pull request 😊. Note that not following the template might
result in your issue being closed.
-->

<!--
Please make sure you're familiar with and follow the instructions in the
contributing guidelines found here: 
https://docs.frontity.org/contributing/code-contribution-guide
-->

<!--
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
-->

<!--
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
Exporting Package which uses the type Actions leaks the Actions type but forces re-declaration.
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
Allow users/clients to not have to re-declare this type.
<!-- Why are these changes necessary? -->

**How**:

<!-- How were these changes implemented? -->

**Tasks**:

<!-- Have you done all of these things?  -->
Not sure if all this is necessary for one-word change.
<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [ ] Code
- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions
- [ ] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->
I don't think it has to release (it can just be bundled into next release whenever.
**Unrelated Tasks**

<!-- ignore-task-list-start -->

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
I can do the whole fork-test-submit workflow if deemed necessary. Since it was just adding an export, I figured it may be safe to just cut to the chase.