### PR TITLE
Fix issue where feed is matched anywhere in the permalink

### DIFF
--- a/.changeset/violet-buckets-unite.md
+++ b/.changeset/violet-buckets-unite.md
@@ -1,0 +1,5 @@
+---
+"@frontity/yoast": patch
+---
+
+Only match feed, comments or xmlrpc if they are at the beginning of the string.

--- a/packages/yoast/src/index.ts
+++ b/packages/yoast/src/index.ts
@@ -8,7 +8,7 @@ const yoastPackage: YoastPackage = {
     yoast: {
       renderTags: "both",
       transformLinks: {
-        ignore: "^(wp-(json|admin|content|includes))|feed|comments|xmlrpc",
+        ignore: "^((wp-(json|admin|content|includes))|feed|comments|xmlrpc)",
       },
     },
   },


### PR DESCRIPTION
**What**:

Update the regex for the Yoast plugin to determine when to transform links. Currently we have canonical urls pointing to the WP site that contain the word feed.

**Why**:

The regex pattern only matches wp-* links at the start of the string where as feed, comments and xmlrc anywhere in the string. 

See the regex example of how it currently works https://regex101.com/r/zcxmVX/1

**How**:

I updated the regex to match everything from the start of the string so that `feed-asd` will match but `asd-feed` won't

**Tasks**:

<!-- Have you done all of these things?  -->

<!-- To check an item, place an "x" in the box like so: "- [x] Unit tests" -->

<!-- Move any unrelated task to the Unrelated tasks section below. -->

- [x] Code
- [x] Add a changeset (with link to its [Feature Discussion](https://community.frontity.org/c/33) if it exists)

<!-- Changesets are necessary if your changes should release any packages.
Run `npx changeset` to create a changeset.
More info at https://docs.frontity.org/contributing/code-contribution-guide#what-is-a-changeset -->

**Unrelated Tasks**

<!-- ignore-task-list-start -->

- [ ] TSDocs
- [ ] TypeScript
- [ ] Unit tests
- [ ] End to end tests
- [ ] TypeScript tests
- [ ] Update starter themes
- [ ] Update other packages
- [ ] Update community discussions

<!-- ignore-task-list-end -->

**Additional Comments**

<!-- Feel free to add any additional comments. -->
